### PR TITLE
chore: client-side pre-push protection + CONTRIBUTING

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# pre-push hook: reject direct pushes to the `master` branch.
+#
+# Activate by running (once per clone):
+#   git config core.hooksPath .githooks
+#
+# Bypass in a genuine emergency with --no-verify; every bypass should be
+# explained in the next commit message.
+
+set -eu
+
+protected_branch='master'
+remote_name="$1"
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+    # Normalise the remote ref name (refs/heads/master → master).
+    remote_branch="${remote_ref#refs/heads/}"
+    if [ "$remote_branch" = "$protected_branch" ]; then
+        # Deletion of master is also blocked.
+        if [ "$local_oid" = "0000000000000000000000000000000000000000" ]; then
+            echo "pre-push: refusing to delete '$protected_branch' on '$remote_name'." >&2
+            exit 1
+        fi
+        cat >&2 <<EOF
+pre-push: direct push to '$protected_branch' on '$remote_name' is blocked.
+
+Open a pull request instead:
+  git checkout -b <topic-branch>
+  git push -u origin <topic-branch>
+  gh pr create --base $protected_branch
+
+If you genuinely need to bypass this hook, rerun with --no-verify and note
+the reason in the next commit message. Server-side enforcement requires
+GitHub Pro (or making the repo public) — this hook is best-effort only.
+EOF
+        exit 1
+    fi
+done
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Development setup
+
+1. Clone the repo.
+2. Activate the repo-tracked git hooks (**one-time, per clone**):
+   ```
+   git config core.hooksPath .githooks
+   ```
+   This enables `pre-push`, which blocks direct pushes to `master`. Work on a topic branch and open a PR instead.
+
+## Branch policy
+
+- `master` is the integration branch. Every change lands via a pull request.
+- Topic branches are named by intent: `sprint-sN-scope`, `fix-...`, `ci-...`.
+- CI (`.github/workflows/ci.yml`) must be green before merging. The gating jobs are:
+  - `lint-and-test (ubuntu)` — `cargo fmt --check`, `clippy -D warnings`, full test suite, doctests.
+  - `test (windows-latest)` / `test (macos-latest)` — cross-platform determinism sanity.
+  - `release-build (ubuntu)` — `cargo build --release`.
+
+## Push protection
+
+- **Client-side** (this repo): the `pre-push` hook in `.githooks/` rejects direct pushes to `master`. Activation is opt-in via `git config core.hooksPath .githooks`. Bypass with `git push --no-verify` only in genuine emergencies, and note the reason in the next commit.
+- **Server-side** (GitHub): branch protection rules require either a public repo or a GitHub Pro subscription. This repo is currently private/free, so server-side enforcement is not in place. Making the repo public, or subscribing to Pro, would let us require the CI checks server-side — see `.github/workflows/ci.yml` for the exact job names to register as required checks.
+
+## Commit style
+
+- Conventional commit prefixes: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+- Subject under 72 characters; wrap the body at 80.
+- Explain *why* in the body; the diff already shows *what*.
+
+## Local verification before pushing
+
+```
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+cargo test --workspace --doc
+```
+
+All four are run by CI on every PR, but running them locally first saves a round trip.


### PR DESCRIPTION
## Summary

Follow-up to #2. Server-side branch protection on GitHub requires either a public repo or a GitHub Pro subscription — this one is private and free, so the REST API rejects the configuration I tried to apply:

> \`Upgrade to GitHub Pro or make this repository public to enable this feature.\`

This PR lands the best client-side fallback instead: a repo-tracked \`pre-push\` hook that rejects direct pushes to \`master\` and a \`CONTRIBUTING.md\` explaining the workflow.

## What's in the PR

- \`.githooks/pre-push\`
  - Blocks any push whose remote ref is \`refs/heads/master\`.
  - Blocks deletion of \`master\` (separately checked).
  - Exits non-zero with an actionable message pointing at \`gh pr create\`.
  - Documents the \`--no-verify\` emergency escape hatch and asks the bypasser to explain in the next commit.
  - Committed with mode 100755 so it's executable on every clone.
- Activation is opt-in per clone (one-time):
  ```
  git config core.hooksPath .githooks
  ```
  Already done on my clone — verified by trying \`git push origin master\` directly; the hook correctly rejected it.
- \`CONTRIBUTING.md\` covers:
  - hook activation
  - branch policy (topic branch → PR, no direct master pushes)
  - required CI job names, so that if the repo ever goes public or Pro, server-side rules can require them verbatim
  - recommended local-verification sequence before push
  - commit-message conventions

## What's *not* covered

- True server-side enforcement. That needs one of:
  1. Making the repo public (branch protection becomes free).
  2. GitHub Pro ($4/month).
  3. A GitHub Team plan if ownership moves to an org.
  Happy to flip the switch with \`gh api\` once either path is taken — the workflow job names in \`.github/workflows/ci.yml\` are already stable and would slot straight in as required status checks.
- The client hook is per-machine and per-clone. A contributor who never runs the activation command, or who uses \`--no-verify\`, can still push directly. This is the inherent ceiling of client-side enforcement and is flagged explicitly in \`CONTRIBUTING.md\`.

## Test plan

- [x] \`git push origin master\` rejected locally by the hook with the expected message (exit code 1).
- [x] Pushing this branch (\`push-protection\`) works normally (hook only trips on \`master\`).
- [ ] CI green on this PR (same workflow as #2; expected to pass — no code changes).