### PR TITLE
docs: top-level README + PROGRESS_LOG refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,120 @@
+# Beast Evolution Game
+
+A deterministic evolution-simulation game in Rust. Genomes mutate, phenotypes express against biomes, creatures interact, and a separate "Chronicler" layer observes emergent behaviour and names it — sim code emits only *primitive effects* and never hand-authored ability names. Every tick is replayable bit-for-bit from a seed plus input journal.
+
+**Status**: design + Sprint S1 foundations complete. Sprint S2 (manifests + registries) is next.
+
+## Quick orientation
+
+If you're picking this up fresh (human or Claude session), read in this order:
+
+1. **`documentation/PROGRESS_LOG.md`** — running session-to-session handoff. Current sprint, story status, open decisions, what landed in which commit, what to do next. Single source of truth for "where are we?".
+2. **`CLAUDE.md`** — repo conventions, tooling, invariants called out for Claude Code.
+3. **`documentation/INVARIANTS.md`** — the load-bearing contract (determinism, mechanics-label separation, registry monolithicism, scale-band unification, UI-vs-sim state). Violating any of these is a bug regardless of what else looks right.
+4. **`documentation/architecture/IMPLEMENTATION_ARCHITECTURE.md`** — primary architecture doc (stack, tradeoffs, data flow).
+5. **`documentation/architecture/CRATE_LAYOUT.md`** — all 17 planned crates, strict L0→L6 layering, inter-crate dependency DAG.
+6. **`documentation/architecture/ECS_SCHEDULE.md`** — 8-stage tick loop, per-stage parallelism, RNG-stream rules, per-system performance budget.
+7. **`documentation/systems/01_*.md` … `23_*.md`** — design spec per game system. Consult the specific file before implementing its crate.
+8. **`documentation/schemas/`** — authoritative JSON schemas for channel and primitive manifests. Mods and core data must validate against these.
+9. **`documentation/planning/`** — `IMPLEMENTATION_PLAN.md`, `EPICS.md`, `SPRINTS.md`, `RISK_REGISTER.md`. Sprint-level scope and sequencing.
+
+`documentation/Beast_Evolution_Game_Master_Design.docx` is the original design doc — prefer the markdown when possible.
+
+## Tech stack
+
+| Layer       | Choice                                                    |
+|-------------|-----------------------------------------------------------|
+| Language    | Rust (stable, pinned via `rust-toolchain.toml`)           |
+| Sim math    | `fixed::I32F32` (Q32.32) wrapped in `beast_core::Q3232`   |
+| PRNG        | `rand_xoshiro::Xoshiro256PlusPlus`, one stream per subsystem |
+| ECS         | `specs` (planned, lands in S5)                            |
+| Graphics    | SDL3 (planned, lands in S9)                               |
+| Serde       | `serde` + `bincode` for saves, `serde_json` for manifests |
+| Property tests | `proptest`                                             |
+| Benches     | `criterion`                                               |
+
+**Float arithmetic is forbidden in sim state** (lint `clippy::float_arithmetic = "warn"` at crate level, `#[allow]`'d only for the one sanctioned use: `gaussian_q3232`'s Box–Muller transform). Render/UI code may use floats freely.
+
+## Workspace layout
+
+```
+.
+├── Cargo.toml                 # workspace root
+├── rust-toolchain.toml        # stable + rustfmt + clippy
+├── crates/
+│   └── beast-core/            # L0 foundations: Q3232, Prng, EntityId, TickCounter, math
+│                              # (other 16 crates are scaffolded per sprint; see CRATE_LAYOUT.md)
+├── .github/workflows/ci.yml   # fmt, clippy, test, doc, release build, cross-platform
+├── .githooks/pre-push         # opt-in hook, blocks direct pushes to master
+├── CONTRIBUTING.md            # workflow, hook activation, push policy
+├── CLAUDE.md                  # instructions specific to Claude Code sessions
+└── documentation/             # design docs (authoritative), progress log, planning
+```
+
+Planned crates (added one per sprint, never pre-stubbed):
+
+`beast-channels`, `beast-primitives`, `beast-genome`, `beast-interpreter`, `beast-evolution`, `beast-disease`, `beast-ecs`, `beast-sim`, `beast-chronicler`, `beast-serde`, `beast-render`, `beast-ui`, `beast-audio`, `beast-mod`, `beast-cli`, `beast-app`.
+
+## Getting started
+
+### First-time setup
+
+```bash
+# Clone and activate repo-tracked hooks (one-time per clone)
+git clone https://github.com/BemusedVermin/evolution-simulation.git
+cd evolution-simulation
+git config core.hooksPath .githooks
+```
+
+`rustup` reads `rust-toolchain.toml` automatically; no manual toolchain selection needed.
+
+### Build & test
+
+```bash
+cargo build --workspace
+cargo test --workspace --all-targets
+cargo test --workspace --doc
+```
+
+### The checks CI runs on every PR
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets --locked
+cargo test --workspace --doc --locked
+cargo build --workspace --release --locked
+```
+
+CI also runs `cargo test` on `windows-latest` and `macos-latest` as a cross-platform determinism sanity check.
+
+### Benchmarks
+
+```bash
+cargo bench -p beast-core --bench core_bench
+```
+
+See `crates/beast-core/README.md` for measured baseline numbers.
+
+## Workflow
+
+- `master` is the integration branch. **All** changes land via PR.
+- Open a topic branch (`sprint-sN-scope`, `fix-...`, `docs-...`, `ci-...`), push it, and `gh pr create --base master`.
+- Direct pushes to `master` are blocked client-side by `.githooks/pre-push` (once activated). Server-side branch protection is not yet on — see `CONTRIBUTING.md` for the reason and the fix.
+- CI must be green before merging. The job names are stable and listed in `CONTRIBUTING.md`.
+- Commit prefixes: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+
+## Non-negotiables
+
+These come from `documentation/INVARIANTS.md`. In short:
+
+1. **Determinism**: bit-identical replay across 1000+ ticks is a CI gate once `beast-sim` exists (Sprint S6). Q32.32 everywhere on the sim path; one PRNG stream per subsystem, split from a single master seed; sorted iteration in hot loops; tick-count time only, no wall-clock reads; no OS RNG.
+2. **Mechanics–label separation**: systems emit primitives; the Chronicler names patterns. No hardcoded ability names in systems 01–20.
+3. **Channel registry monolithicism**: a single runtime registry; no hardcoded channel IDs in system code.
+4. **Emergence closure**: every observable behaviour traces back to a primitive emission.
+5. **Scale-band unification**: one genome/interpreter pipeline covers macro hosts and micro pathogens.
+6. **UI state vs. sim state**: derived UI flags never appear in save files.
+
+## License
+
+Proprietary — see the workspace `Cargo.toml`. Not yet OSS.

--- a/documentation/PROGRESS_LOG.md
+++ b/documentation/PROGRESS_LOG.md
@@ -8,10 +8,16 @@ This file is the canonical running log of implementation work on the Beast Evolu
 
 ## Current Status Snapshot
 
-- **Active Sprint**: S1 — Fixed-Point & PRNG (beast-core) [Week 1] — **✅ COMPLETE**
+- **Active Sprint**: S1 — Fixed-Point & PRNG (beast-core) [Week 1] — **✅ COMPLETE & merged**
 - **Next Sprint**: S2 — Manifests & Registries (beast-channels, beast-primitives) [Week 2]
 - **Phase**: 1 — Foundations & Core Sim
 - **Workspace scaffolded**: yes (beast-core only; other 16 crates deferred to their sprints)
+- **CI**: `.github/workflows/ci.yml` runs on every PR — fmt, clippy, test, doctests, release build, and cross-platform tests on windows/macOS. First run on PR #2 passed all 4 jobs.
+- **Push protection**: client-side (`.githooks/pre-push`) blocks direct pushes to master once activated via `git config core.hooksPath .githooks`. Server-side branch protection **not** configured — GitHub REST API rejected the call on this private/free repo (requires Pro or public visibility). Workflow job names are documented in `CONTRIBUTING.md` for the day we turn that on.
+- **Merged PRs on master**:
+  - **#1** `sprint-s1-beast-core` — all six S1 stories (scaffold + Q3232 + PRNG + EntityId/TickCounter/Error + Gaussian + proptests + benches) plus the post-review fixes (`EntityIdAllocator::alloc → Option<EntityId>`, `gen_range_i64` i128-widened final add).
+  - **#2** `ci-workflow` — GitHub Actions CI + `rust-toolchain.toml` + rustfmt normalisation pass.
+  - **#3** `push-protection` — pre-push hook + `CONTRIBUTING.md`.
 - **Last updated**: 2026-04-15
 
 ### Sprint S1 Story Progress (40 pts planned, 40 delivered)
@@ -38,7 +44,7 @@ This file is the canonical running log of implementation work on the Beast Evolu
 - [x] No panics on overflow/underflow — verified via proptest (19 props × 1000 cases covering full `i64` bit-pattern space)
 - [~] Fixed-point multiply < 2 CPU cycles — measured ~2.7 ns (~8 cycles on 3 GHz). Target was aspirational; real number is fine for tick budget, documented in README.
 
-**Test count**: 78 tests (44 unit + 32 proptest + 2 doctests). All green.
+**Test count**: 82 tests (47 unit + 33 proptest + 2 doctests). All green. (Grew by 4 during PR #1 review: 3 unit + 1 proptest added to cover `EntityIdAllocator` exhaustion and `gen_range_i64` wide-span regressions.)
 
 ---
 
@@ -55,6 +61,17 @@ This file is the canonical running log of implementation work on the Beast Evolu
 ---
 
 ## Session Log (reverse chronological)
+
+### 2026-04-15 — Infra & README (Claude)
+
+After PR #1 merged, added:
+- **PR #2 (merged)** — `.github/workflows/ci.yml` with four jobs (lint-and-test ubuntu, test windows, test macos, release-build ubuntu). `rust-toolchain.toml` pinning stable + rustfmt + clippy. `cargo fmt --all` normalisation pass over the existing code (import grouping + comment indentation; zero behaviour change).
+- **PR #3 (merged)** — `.githooks/pre-push` (opt-in client-side push gate for master), `CONTRIBUTING.md`. Verified the hook works by attempting a direct push — exit 1 with the PR-workflow message.
+- **PR #4 (this one, open)** — top-level `README.md` so future sessions (human or Claude) have a single entry point. PROGRESS_LOG remains the session-to-session diary; README is the project-level orientation.
+
+**Server-side branch protection blocker**: `gh api repos/.../branches/master/protection -X PUT` responds 403 `Upgrade to GitHub Pro or make this repository public to enable this feature`. Options: (a) make the repo public, (b) GitHub Pro $4/mo. Workflow job names in `CONTRIBUTING.md` are the required-check names to plug in when either path is taken.
+
+**Next action for S2**: scaffold `beast-channels` and `beast-primitives`. Entry ordering unchanged from previous note (manifests → composition hooks → registries → schema rejection tests). Validate channel and primitive manifests against the authoritative schemas in `documentation/schemas/`.
 
 ### 2026-04-15 — Sprint S1 COMPLETE (Claude)
 
@@ -103,8 +120,13 @@ Key decisions locked in:
   sanctioned float use); result is saturating-converted back to `Q3232`.
 - `TickCounter` saturates; at 60 Hz, `u64::MAX` ≈ 9.7 Gyr, so saturation is a
   bug-indicator, not a real runtime event.
-- `EntityId::NONE = u32::MAX`. `EntityIdAllocator` saturates at `u32::MAX - 1`
-  to preserve the sentinel invariant.
+- `EntityId::NONE = u32::MAX`. `EntityIdAllocator::alloc` returns
+  `Option<EntityId>` — `Some` for the first `u32::MAX - 1` calls, `None`
+  thereafter. (Original saturating impl was a uniqueness bug; caught in PR #1
+  review and fixed in commit `4765d39`.)
+- `Prng::gen_range_i64` narrows via `i128` on the final add to handle spans
+  wider than `i64::MAX` (e.g. `i64::MIN..i64::MAX`). Narrow proptest ranges
+  had hidden this; fixed in the same PR #1 review commit.
 
 Read-errors / pitfalls encountered:
 - Compiled-in lints `unsafe_code = "forbid"` and `clippy::float_arithmetic = "warn"`
@@ -161,3 +183,9 @@ _(updated as files are created)_
 - `crates/beast-core/src/time.rs` — `TickCounter` (Story 1.3).
 - `crates/beast-core/src/error.rs` — `Error`, `Result` (Story 1.3).
 - `crates/beast-core/src/math.rs` — `gaussian_q3232`, `lerp/inv_lerp/clamp/min/max` (Story 1.4).
+- `crates/beast-core/tests/proptest_{fixed_point,prng,math}.rs` — property + 100k-sample tests (Story 1.5).
+- `README.md` — top-level repo orientation (PR #4).
+- `CONTRIBUTING.md` — workflow, hook activation, push policy (PR #3).
+- `rust-toolchain.toml` — pins stable + rustfmt + clippy (PR #2).
+- `.github/workflows/ci.yml` — GitHub Actions CI (PR #2).
+- `.githooks/pre-push` — opt-in master-push gate (PR #3).


### PR DESCRIPTION
## Summary

Adds a repo-root `README.md` so anyone picking up the project (human or fresh Claude session) has one obvious entry point. Also refreshes `documentation/PROGRESS_LOG.md` to reflect the three merged infra PRs and the two decisions captured during PR #1 review.

### `README.md`

Deliberately short — it orients rather than duplicating. Links out to the authoritative docs (`INVARIANTS.md`, `CRATE_LAYOUT.md`, `ECS_SCHEDULE.md`, system specs, schemas, planning).

Sections:
- **Quick orientation** — 9-item read order, PROGRESS_LOG first.
- **Tech stack** — Q32.32, Xoshiro256PlusPlus, `specs` (planned), SDL3 (planned), serde/bincode, proptest, criterion. Flags the "no floats in sim state" lint posture.
- **Workspace layout** — what's scaffolded, and the 16 crates still deferred to their sprints.
- **Getting started** — clone, `git config core.hooksPath .githooks`, build, test.
- **The checks CI runs on every PR** — the exact command sequence, so contributors can reproduce locally before the round trip.
- **Benchmarks** — pointer to `crates/beast-core/README.md` for baseline numbers.
- **Workflow** — master-via-PR, commit prefixes, hook caveat.
- **Non-negotiables** — one-line summary of each invariant, with a pointer back to `INVARIANTS.md`.

### `documentation/PROGRESS_LOG.md` refresh

- Snapshot lists all three merged PRs (#1/#2/#3), the CI job inventory, and the server-side branch-protection blocker.
- Session log gains an entry covering PRs #2–#4 and the decisions taken.
- Two architectural-decision notes corrected:
  - `EntityIdAllocator` now returns `Option<EntityId>` (old note incorrectly described the saturating behaviour that got fixed in PR #1 review).
  - New note on `gen_range_i64` doing its final add in `i128` to handle spans > `i64::MAX`.
- File index extended with the proptest files, the CI workflow, the hook, `CONTRIBUTING.md`, `rust-toolchain.toml`, and the new `README.md` itself.

## Test plan

- [x] No code changes; `cargo test` trivially still green.
- [x] CI should pass (same workflow as #2/#3; purely docs).
- [x] Read-through: README's read-order pointers all resolve to existing files.