### PR TITLE
Sprint S2: manifests and registries (beast-channels, beast-primitives)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +56,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "beast-channels"
+version = "0.1.0"
+dependencies = [
+ "beast-core",
+ "jsonschema",
+ "proptest",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "beast-core"
 version = "0.1.0"
 dependencies = [
@@ -56,13 +89,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-primitives"
+version = "0.1.0"
+dependencies = [
+ "beast-channels",
+ "beast-core",
+ "fixed",
+ "jsonschema",
+ "proptest",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -75,6 +138,18 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -187,6 +262,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +301,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
 ]
 
 [[package]]
@@ -238,6 +343,38 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "getrandom"
@@ -303,10 +440,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -332,6 +572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +594,50 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -365,6 +658,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +683,91 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -396,6 +789,50 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -431,8 +868,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand",
@@ -526,6 +963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +1014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +1039,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -638,6 +1096,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +1116,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -679,6 +1160,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -716,6 +1237,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +1290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +1311,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -899,6 +1505,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1547,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 members = [
     "crates/beast-core",
+    "crates/beast-channels",
+    "crates/beast-primitives",
 ]
 
 [workspace.package]
@@ -18,7 +20,17 @@ fixed = { version = "1.28", features = ["serde"] }
 rand_core = "0.6"
 rand_xoshiro = { version = "0.6", features = ["serde1"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
+
+# Sprint 2: manifest + registry deps. `jsonschema` is pinned to a minor that
+# works on stable Rust 1.75. `regex` backs the provenance string validator.
+jsonschema = { version = "0.17", default-features = false }
+regex = "1"
+
+beast-core = { path = "crates/beast-core" }
+beast-channels = { path = "crates/beast-channels" }
+beast-primitives = { path = "crates/beast-primitives" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-channels/Cargo.toml
+++ b/crates/beast-channels/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "beast-channels"
+description = "Channel registry, manifest loading, composition hooks, and expression conditions for the Beast Evolution Game."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+beast-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+jsonschema = { workspace = true }
+regex = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+float_arithmetic = "warn"

--- a/crates/beast-channels/README.md
+++ b/crates/beast-channels/README.md
@@ -1,0 +1,41 @@
+# beast-channels
+
+Layer 1 channel registry and manifest loader for Beast Evolution Game.
+
+This crate owns the runtime side of the **Channel Manifest** contract
+defined in `documentation/schemas/channel_manifest.schema.json`. It is a
+pure-data, side-effect-free crate: it parses JSON, validates it against the
+canonical JSON Schema, and produces strongly typed, deterministic
+[`ChannelManifest`] and [`ChannelRegistry`] values for downstream consumers.
+
+## Responsibilities
+
+- **Manifest loading** — `ChannelManifest::from_json_str` runs a two-stage
+  validator: JSON Schema first (catches shape, enum, and pattern violations
+  with JSON-pointer paths), then a semantic pass (`range.min <= range.max`,
+  unique composition-hook targets, provenance string parsing).
+- **Registry** — `ChannelRegistry` is a `BTreeMap`-backed lookup with
+  secondary indices by [`ChannelFamily`]. Deterministic iteration is a
+  requirement of `documentation/INVARIANTS.md` §1.
+- **Composition hooks** — `evaluate_hook` deterministically reduces a single
+  hook into `(delta, factor, gate_open)` using `beast_core::Q3232`
+  arithmetic, so interpreters can fold hooks without introducing float
+  non-determinism.
+- **Expression conditions** — `evaluate_expression_conditions` applies the
+  schema's discriminated-union gates (biome flag, scale band, season,
+  developmental stage, social density) against an [`ExpressionContext`].
+
+## Determinism
+
+- All numeric manifest fields that participate in sim math are converted to
+  `Q3232` at load time via `Q3232::from_num`.
+- The crate's `Cargo.toml` sets `clippy::float_arithmetic = "warn"`; any
+  future regression that introduces float arithmetic will surface in CI.
+- Registry indices are `BTreeMap`/`BTreeSet`-based, giving stable iteration
+  regardless of hash randomization.
+
+## Layering
+
+Depends only on `beast-core`. Downstream crates (`beast-primitives`,
+`beast-interpreter`, `beast-genome`, …) read manifests through this crate
+but never parse JSON themselves.

--- a/crates/beast-channels/src/composition.rs
+++ b/crates/beast-channels/src/composition.rs
@@ -1,0 +1,233 @@
+//! Composition hook evaluation.
+//!
+//! A channel's manifest declares an array of composition hooks describing how
+//! its own contribution combines with other channels. The evaluator defined
+//! here runs deterministically over [`beast_core::Q3232`] channel values so
+//! downstream interpreters can rely on bit-identical results under replay.
+//!
+//! The shapes mirror the schema 1:1:
+//!
+//! | Kind            | Formula (per hook)                                     |
+//! |-----------------|--------------------------------------------------------|
+//! | `additive`      | `out += coefficient * other`                           |
+//! | `multiplicative`| `out *= 1 + coefficient * other`                       |
+//! | `threshold`     | `out *= coefficient` when `other >= threshold`, else 0 |
+//! | `gating`        | binary: active if `other >= threshold`, else inactive  |
+//! | `antagonistic`  | `out -= coefficient * other`                           |
+//!
+//! The `threshold` kind is multiplicative-with-gate: below threshold the hook
+//! contributes nothing; above, it contributes `coefficient * other`. The
+//! `gating` kind is a pure boolean — callers typically AND gate outcomes
+//! across hooks to decide whether the owning channel expresses at all.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+/// Composition kinds supported by the schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompositionKind {
+    /// Sum contributions: `result += coefficient * other_channel`.
+    Additive,
+    /// Product contributions: `result *= (1 + coefficient * other_channel)`.
+    Multiplicative,
+    /// Activation gate: contribute `coefficient * other` only when
+    /// `other >= threshold`.
+    Threshold,
+    /// Binary switch: the hook is *active* when `other >= threshold`.
+    Gating,
+    /// Subtract contributions: `result -= coefficient * other_channel`.
+    Antagonistic,
+}
+
+/// A single composition hook parsed from a channel manifest.
+///
+/// The `threshold` field is `Some` iff `kind ∈ {Threshold, Gating}` (enforced
+/// at load time by [`crate::manifest::ChannelManifest::from_json_str`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompositionHook {
+    /// Other channel id, or the literal `"self"` for an auto-interaction.
+    pub with: String,
+    /// Composition kind.
+    pub kind: CompositionKind,
+    /// Scaling coefficient.
+    pub coefficient: Q3232,
+    /// Activation threshold — required iff `kind ∈ {Threshold, Gating}`.
+    pub threshold: Option<Q3232>,
+}
+
+/// Outcome of evaluating a single hook against a specific `other_channel` value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HookOutcome {
+    /// Additive contribution to the running total.
+    pub delta: Q3232,
+    /// Multiplicative factor to apply to the running total
+    /// (`Q3232::ONE` when the hook doesn't contribute multiplicatively).
+    pub factor: Q3232,
+    /// Whether the hook's gating condition is satisfied.
+    ///
+    /// For `Additive`, `Multiplicative`, and `Antagonistic` hooks this is
+    /// always `true`. For `Threshold` and `Gating` hooks it mirrors the
+    /// threshold test.
+    pub gate_open: bool,
+}
+
+impl HookOutcome {
+    /// A neutral outcome: zero delta, unit factor, gate open.
+    pub const NEUTRAL: Self = Self {
+        delta: Q3232::ZERO,
+        factor: Q3232::ONE,
+        gate_open: true,
+    };
+}
+
+/// Evaluate a single composition hook against the current value of the
+/// referenced channel (`other`).
+///
+/// The returned [`HookOutcome`] is self-describing — callers compose hooks by
+/// accumulating `delta`, multiplying `factor`, and ANDing `gate_open` across
+/// a channel's hooks.
+///
+/// ```
+/// use beast_channels::{evaluate_hook, CompositionHook, CompositionKind, HookOutcome};
+/// use beast_core::Q3232;
+///
+/// let hook = CompositionHook {
+///     with: "spatial_cognition".into(),
+///     kind: CompositionKind::Threshold,
+///     coefficient: Q3232::ONE,
+///     threshold: Some(Q3232::from_num(0.5_f64)),
+/// };
+///
+/// // Below threshold: gate closed, zero contribution.
+/// let below = evaluate_hook(&hook, Q3232::from_num(0.2_f64));
+/// assert_eq!(below.gate_open, false);
+/// assert_eq!(below.delta, Q3232::ZERO);
+///
+/// // Above threshold: gate open, additive contribution applied.
+/// let above = evaluate_hook(&hook, Q3232::from_num(0.8_f64));
+/// assert_eq!(above.gate_open, true);
+/// assert_eq!(above.delta, Q3232::from_num(0.8_f64));
+/// ```
+pub fn evaluate_hook(hook: &CompositionHook, other: Q3232) -> HookOutcome {
+    match hook.kind {
+        CompositionKind::Additive => HookOutcome {
+            delta: hook.coefficient * other,
+            factor: Q3232::ONE,
+            gate_open: true,
+        },
+        CompositionKind::Multiplicative => HookOutcome {
+            delta: Q3232::ZERO,
+            factor: Q3232::ONE + hook.coefficient * other,
+            gate_open: true,
+        },
+        CompositionKind::Antagonistic => HookOutcome {
+            delta: -(hook.coefficient * other),
+            factor: Q3232::ONE,
+            gate_open: true,
+        },
+        CompositionKind::Threshold => {
+            let t = hook.threshold.unwrap_or(Q3232::ZERO);
+            if other >= t {
+                HookOutcome {
+                    delta: hook.coefficient * other,
+                    factor: Q3232::ONE,
+                    gate_open: true,
+                }
+            } else {
+                HookOutcome {
+                    delta: Q3232::ZERO,
+                    factor: Q3232::ONE,
+                    gate_open: false,
+                }
+            }
+        }
+        CompositionKind::Gating => {
+            let t = hook.threshold.unwrap_or(Q3232::ZERO);
+            let open = other >= t;
+            HookOutcome {
+                delta: Q3232::ZERO,
+                factor: Q3232::ONE,
+                gate_open: open,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    fn hook(kind: CompositionKind, coefficient: f64, threshold: Option<f64>) -> CompositionHook {
+        CompositionHook {
+            with: "other".into(),
+            kind,
+            coefficient: q(coefficient),
+            threshold: threshold.map(q),
+        }
+    }
+
+    #[test]
+    fn additive_produces_expected_delta() {
+        let out = evaluate_hook(&hook(CompositionKind::Additive, 0.5, None), q(2.0));
+        assert_eq!(out.delta, q(1.0));
+        assert_eq!(out.factor, Q3232::ONE);
+        assert!(out.gate_open);
+    }
+
+    #[test]
+    fn multiplicative_produces_expected_factor() {
+        let out = evaluate_hook(&hook(CompositionKind::Multiplicative, 0.5, None), q(2.0));
+        // 1 + 0.5 * 2 = 2
+        assert_eq!(out.factor, q(2.0));
+        assert_eq!(out.delta, Q3232::ZERO);
+    }
+
+    #[test]
+    fn antagonistic_subtracts() {
+        let out = evaluate_hook(&hook(CompositionKind::Antagonistic, 0.25, None), q(4.0));
+        assert_eq!(out.delta, -q(1.0));
+    }
+
+    #[test]
+    fn threshold_below_keeps_gate_closed() {
+        let out = evaluate_hook(&hook(CompositionKind::Threshold, 1.0, Some(0.5)), q(0.25));
+        assert!(!out.gate_open);
+        assert_eq!(out.delta, Q3232::ZERO);
+    }
+
+    #[test]
+    fn threshold_above_activates_with_delta() {
+        let out = evaluate_hook(&hook(CompositionKind::Threshold, 1.0, Some(0.5)), q(0.75));
+        assert!(out.gate_open);
+        assert_eq!(out.delta, q(0.75));
+    }
+
+    #[test]
+    fn threshold_at_boundary_activates() {
+        let out = evaluate_hook(&hook(CompositionKind::Threshold, 1.0, Some(0.5)), q(0.5));
+        assert!(out.gate_open);
+    }
+
+    #[test]
+    fn gating_binary_switch() {
+        let closed = evaluate_hook(&hook(CompositionKind::Gating, 1.0, Some(0.5)), q(0.25));
+        let open = evaluate_hook(&hook(CompositionKind::Gating, 1.0, Some(0.5)), q(0.75));
+        assert!(!closed.gate_open);
+        assert!(open.gate_open);
+        assert_eq!(open.delta, Q3232::ZERO);
+        assert_eq!(open.factor, Q3232::ONE);
+    }
+
+    #[test]
+    fn evaluation_is_deterministic_across_calls() {
+        let h = hook(CompositionKind::Multiplicative, 0.125, None);
+        for _ in 0..100 {
+            assert_eq!(evaluate_hook(&h, q(0.5)).factor, q(1.0625));
+        }
+    }
+}

--- a/crates/beast-channels/src/composition.rs
+++ b/crates/beast-channels/src/composition.rs
@@ -127,7 +127,11 @@ pub fn evaluate_hook(hook: &CompositionHook, other: Q3232) -> HookOutcome {
             gate_open: true,
         },
         CompositionKind::Threshold => {
-            let t = hook.threshold.unwrap_or(Q3232::ZERO);
+            let t = hook.threshold.unwrap_or_else(|| {
+                unreachable!(
+                    "CompositionHook {{ kind: Threshold, threshold: None }} violates the invariant — threshold is required for Threshold/Gating kinds and is enforced at load time"
+                )
+            });
             if other >= t {
                 HookOutcome {
                     delta: hook.coefficient * other,
@@ -143,7 +147,11 @@ pub fn evaluate_hook(hook: &CompositionHook, other: Q3232) -> HookOutcome {
             }
         }
         CompositionKind::Gating => {
-            let t = hook.threshold.unwrap_or(Q3232::ZERO);
+            let t = hook.threshold.unwrap_or_else(|| {
+                unreachable!(
+                    "CompositionHook {{ kind: Gating, threshold: None }} violates the invariant — threshold is required for Threshold/Gating kinds and is enforced at load time"
+                )
+            });
             let open = other >= t;
             HookOutcome {
                 delta: Q3232::ZERO,
@@ -229,5 +237,25 @@ mod tests {
         for _ in 0..100 {
             assert_eq!(evaluate_hook(&h, q(0.5)).factor, q(1.0625));
         }
+    }
+
+    // The loader enforces that hooks of Threshold/Gating kind carry a
+    // threshold value. If a hand-constructed hook violates the invariant,
+    // we panic loudly rather than silently defaulting to Q3232::ZERO (which
+    // would make every Threshold gate always fire and every Gating gate
+    // always open, a subtle semantic bug). The two tests below lock in that
+    // behaviour so future refactors can't silently regress it.
+    #[test]
+    #[should_panic(expected = "threshold is required for Threshold/Gating kinds")]
+    fn threshold_without_threshold_value_panics() {
+        let invalid = hook(CompositionKind::Threshold, 1.0, None);
+        let _ = evaluate_hook(&invalid, q(0.5));
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold is required for Threshold/Gating kinds")]
+    fn gating_without_threshold_value_panics() {
+        let invalid = hook(CompositionKind::Gating, 1.0, None);
+        let _ = evaluate_hook(&invalid, q(0.5));
     }
 }

--- a/crates/beast-channels/src/expression.rs
+++ b/crates/beast-channels/src/expression.rs
@@ -1,0 +1,206 @@
+//! Expression conditions — gating predicates loaded from a channel manifest.
+//!
+//! Each condition is a discriminated-union variant in the JSON Schema. All
+//! conditions on a channel must hold simultaneously for the channel to
+//! express; this module provides a straightforward evaluator that takes an
+//! [`ExpressionContext`] describing the current environment/creature and
+//! returns `true` iff every condition is satisfied.
+//!
+//! Evaluation is purely a comparison over [`beast_core::Q3232`] and string
+//! equality, so it inherits determinism from those primitives.
+
+use beast_core::Q3232;
+
+/// A single expression-condition predicate parsed from a channel manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExpressionCondition {
+    /// Named biome / environmental flag that must be active.
+    BiomeFlag {
+        /// Flag name (e.g. `"aquatic"`, `"nocturnal"`).
+        flag: String,
+    },
+    /// Body-mass gate (creature's mass must be in `[min_kg, max_kg]`).
+    ScaleBand {
+        /// Lower bound (kg, inclusive).
+        min_kg: Q3232,
+        /// Upper bound (kg, inclusive).
+        max_kg: Q3232,
+    },
+    /// Current season must match.
+    Season {
+        /// Season name (e.g. `"spring"`, `"winter"`).
+        season: String,
+    },
+    /// Creature's life stage must match.
+    DevelopmentalStage {
+        /// Stage name (e.g. `"juvenile"`, `"breeding_adult"`).
+        stage: String,
+    },
+    /// Local population density must be in `[min_per_km2, max_per_km2]`.
+    SocialDensity {
+        /// Lower bound (individuals / km², inclusive).
+        min_per_km2: Q3232,
+        /// Upper bound (individuals / km², inclusive).
+        max_per_km2: Q3232,
+    },
+}
+
+/// Snapshot of environment/creature state used by the expression evaluator.
+///
+/// Callers pass any subset they know about. Missing fields cause the
+/// corresponding condition kind to evaluate to `false`, which is the
+/// conservative default — the channel will not express if we cannot confirm
+/// the condition holds.
+#[derive(Debug, Clone, Default)]
+pub struct ExpressionContext<'a> {
+    /// Biome flags currently active at the creature's location.
+    pub biome_flags: &'a [&'a str],
+    /// Creature body mass in kg.
+    pub body_mass_kg: Option<Q3232>,
+    /// Current season.
+    pub season: Option<&'a str>,
+    /// Creature life stage.
+    pub developmental_stage: Option<&'a str>,
+    /// Local population density, individuals per km².
+    pub population_density_per_km2: Option<Q3232>,
+}
+
+/// Evaluate a slice of conditions, returning `true` iff every condition holds.
+///
+/// An empty slice always evaluates to `true` (schema semantics: "no
+/// conditions" means "always express").
+///
+/// ```
+/// use beast_channels::{evaluate_expression_conditions, ExpressionCondition, ExpressionContext};
+/// use beast_core::Q3232;
+///
+/// let conditions = [ExpressionCondition::ScaleBand {
+///     min_kg: Q3232::from_num(0.01_f64),
+///     max_kg: Q3232::from_num(1000_i32),
+/// }];
+///
+/// let ctx = ExpressionContext {
+///     body_mass_kg: Some(Q3232::from_num(100_i32)),
+///     ..ExpressionContext::default()
+/// };
+/// assert!(evaluate_expression_conditions(&conditions, &ctx));
+///
+/// let ctx_out = ExpressionContext {
+///     body_mass_kg: Some(Q3232::from_num(5000_i32)),
+///     ..ExpressionContext::default()
+/// };
+/// assert!(!evaluate_expression_conditions(&conditions, &ctx_out));
+/// ```
+pub fn evaluate_expression_conditions(
+    conditions: &[ExpressionCondition],
+    ctx: &ExpressionContext<'_>,
+) -> bool {
+    conditions.iter().all(|c| evaluate_one(c, ctx))
+}
+
+fn evaluate_one(cond: &ExpressionCondition, ctx: &ExpressionContext<'_>) -> bool {
+    match cond {
+        ExpressionCondition::BiomeFlag { flag } => ctx.biome_flags.contains(&flag.as_str()),
+        ExpressionCondition::ScaleBand { min_kg, max_kg } => match ctx.body_mass_kg {
+            Some(mass) => mass >= *min_kg && mass <= *max_kg,
+            None => false,
+        },
+        ExpressionCondition::Season { season } => ctx.season == Some(season.as_str()),
+        ExpressionCondition::DevelopmentalStage { stage } => {
+            ctx.developmental_stage == Some(stage.as_str())
+        }
+        ExpressionCondition::SocialDensity {
+            min_per_km2,
+            max_per_km2,
+        } => match ctx.population_density_per_km2 {
+            Some(d) => d >= *min_per_km2 && d <= *max_per_km2,
+            None => false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    #[test]
+    fn empty_conditions_always_pass() {
+        assert!(evaluate_expression_conditions(
+            &[],
+            &ExpressionContext::default()
+        ));
+    }
+
+    #[test]
+    fn biome_flag_matches() {
+        let cond = [ExpressionCondition::BiomeFlag {
+            flag: "aquatic".into(),
+        }];
+        let flags = ["aquatic", "cold"];
+        let ctx = ExpressionContext {
+            biome_flags: &flags,
+            ..ExpressionContext::default()
+        };
+        assert!(evaluate_expression_conditions(&cond, &ctx));
+    }
+
+    #[test]
+    fn biome_flag_misses_when_absent() {
+        let cond = [ExpressionCondition::BiomeFlag {
+            flag: "aquatic".into(),
+        }];
+        let ctx = ExpressionContext::default();
+        assert!(!evaluate_expression_conditions(&cond, &ctx));
+    }
+
+    #[test]
+    fn scale_band_inclusive() {
+        let cond = [ExpressionCondition::ScaleBand {
+            min_kg: q(1.0),
+            max_kg: q(100.0),
+        }];
+        for mass in [1.0, 50.0, 100.0] {
+            let ctx = ExpressionContext {
+                body_mass_kg: Some(q(mass)),
+                ..ExpressionContext::default()
+            };
+            assert!(evaluate_expression_conditions(&cond, &ctx), "{mass}");
+        }
+        for mass in [0.5, 100.5] {
+            let ctx = ExpressionContext {
+                body_mass_kg: Some(q(mass)),
+                ..ExpressionContext::default()
+            };
+            assert!(!evaluate_expression_conditions(&cond, &ctx), "{mass}");
+        }
+    }
+
+    #[test]
+    fn multiple_conditions_all_must_hold() {
+        let cond = [
+            ExpressionCondition::Season {
+                season: "spring".into(),
+            },
+            ExpressionCondition::DevelopmentalStage {
+                stage: "breeding_adult".into(),
+            },
+        ];
+        let ctx_ok = ExpressionContext {
+            season: Some("spring"),
+            developmental_stage: Some("breeding_adult"),
+            ..ExpressionContext::default()
+        };
+        assert!(evaluate_expression_conditions(&cond, &ctx_ok));
+
+        let ctx_bad = ExpressionContext {
+            season: Some("spring"),
+            developmental_stage: Some("juvenile"),
+            ..ExpressionContext::default()
+        };
+        assert!(!evaluate_expression_conditions(&cond, &ctx_bad));
+    }
+}

--- a/crates/beast-channels/src/lib.rs
+++ b/crates/beast-channels/src/lib.rs
@@ -1,0 +1,10 @@
+//! Beast Evolution Game — Layer 1 channel registry and manifest loader.
+//!
+//! This crate is scaffolded empty at the start of Sprint S2 and grows
+//! story-by-story: composition hooks (2.5), manifest loader + schema
+//! validation (2.1), then registry (2.3). Each story lands its own module
+//! and re-exports from this file.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]

--- a/crates/beast-channels/src/lib.rs
+++ b/crates/beast-channels/src/lib.rs
@@ -1,14 +1,23 @@
 //! Beast Evolution Game — Layer 1 channel registry and manifest loader.
 //!
 //! See individual modules for story-specific documentation. Sprint S2
-//! populates this crate story-by-story: composition hooks (2.5) first so
-//! the manifest types in 2.1 can reference them, then the manifest loader
-//! and schema validator, then the registry.
+//! populates this crate story-by-story: composition hooks (2.5), then the
+//! manifest loader + expression-condition evaluator + schema validator
+//! (2.1), then the registry (2.3).
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
 pub mod composition;
+pub mod expression;
+pub mod manifest;
+pub mod schema;
 
 pub use composition::{evaluate_hook, CompositionHook, CompositionKind, HookOutcome};
+pub use expression::{evaluate_expression_conditions, ExpressionCondition, ExpressionContext};
+pub use manifest::{
+    BoundsPolicy, ChannelFamily, ChannelManifest, CorrelationEntry, MutationKernel, Provenance,
+    Range, ScaleBand,
+};
+pub use schema::{ChannelLoadError, CHANNEL_MANIFEST_SCHEMA};

--- a/crates/beast-channels/src/lib.rs
+++ b/crates/beast-channels/src/lib.rs
@@ -1,9 +1,29 @@
 //! Beast Evolution Game — Layer 1 channel registry and manifest loader.
 //!
-//! See individual modules for story-specific documentation. Sprint S2
-//! populates this crate story-by-story: composition hooks (2.5), then the
-//! manifest loader + expression-condition evaluator + schema validator
-//! (2.1), then the registry (2.3).
+//! This crate is the runtime home of the **Channel Manifest** contract
+//! described in `documentation/schemas/channel_manifest.schema.json` and
+//! the architectural invariants in `documentation/INVARIANTS.md`:
+//!
+//! * **Channel Registry Monolithicism** — a single authoritative registry
+//!   indexes every channel (core, mod, genesis). Nothing downstream hardcodes
+//!   channel IDs or composition rules; they consult the registry.
+//! * **Determinism** — every numeric value that participates in sim math is
+//!   stored as [`beast_core::Q3232`]. JSON-side `f64` values are converted
+//!   exactly once at load time (configuration, not sim state), and the lint
+//!   `clippy::float_arithmetic` keeps arithmetic from sneaking back into the
+//!   hot path.
+//! * **Sorted iteration** — registries expose iteration via [`BTreeMap`] so
+//!   ordering never depends on hash randomization.
+//!
+//! The crate has three primary surfaces:
+//!
+//! 1. [`manifest`] — strongly typed representations of a channel manifest
+//!    with a two-stage loader (JSON Schema validation, then semantic parse).
+//! 2. [`registry`] — [`ChannelRegistry`] with by-id and by-family indices.
+//! 3. [`composition`] — deterministic evaluator for composition hooks over
+//!    Q32.32 channel values.
+//!
+//! [`BTreeMap`]: std::collections::BTreeMap
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -12,6 +32,7 @@
 pub mod composition;
 pub mod expression;
 pub mod manifest;
+pub mod registry;
 pub mod schema;
 
 pub use composition::{evaluate_hook, CompositionHook, CompositionKind, HookOutcome};
@@ -20,4 +41,5 @@ pub use manifest::{
     BoundsPolicy, ChannelFamily, ChannelManifest, CorrelationEntry, MutationKernel, Provenance,
     Range, ScaleBand,
 };
+pub use registry::{ChannelRegistry, RegistryError};
 pub use schema::{ChannelLoadError, CHANNEL_MANIFEST_SCHEMA};

--- a/crates/beast-channels/src/lib.rs
+++ b/crates/beast-channels/src/lib.rs
@@ -1,10 +1,14 @@
 //! Beast Evolution Game — Layer 1 channel registry and manifest loader.
 //!
-//! This crate is scaffolded empty at the start of Sprint S2 and grows
-//! story-by-story: composition hooks (2.5), manifest loader + schema
-//! validation (2.1), then registry (2.3). Each story lands its own module
-//! and re-exports from this file.
+//! See individual modules for story-specific documentation. Sprint S2
+//! populates this crate story-by-story: composition hooks (2.5) first so
+//! the manifest types in 2.1 can reference them, then the manifest loader
+//! and schema validator, then the registry.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
+
+pub mod composition;
+
+pub use composition::{evaluate_hook, CompositionHook, CompositionKind, HookOutcome};

--- a/crates/beast-channels/src/manifest.rs
+++ b/crates/beast-channels/src/manifest.rs
@@ -1,0 +1,472 @@
+//! Strongly typed channel-manifest representation.
+//!
+//! The types here are the in-memory counterpart of
+//! `documentation/schemas/channel_manifest.schema.json`. JSON Schema
+//! validation happens in [`crate::schema`]; this module owns the *semantic*
+//! parsing step — converting already-valid JSON into Q32.32 fixed-point
+//! configuration data and rejecting anything that is structurally valid but
+//! invariant-violating (e.g. `range.min > range.max`).
+
+use std::collections::BTreeSet;
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+use crate::composition::{CompositionHook, CompositionKind};
+use crate::expression::ExpressionCondition;
+use crate::schema::ChannelLoadError;
+
+/// Biological family of a channel.
+///
+/// Determines typical mutation breadth, composition patterns, and expression
+/// logic (see `documentation/schemas/README.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelFamily {
+    /// Perception thresholds, acuity ranges.
+    Sensory,
+    /// Strength, speed, precision.
+    Motor,
+    /// Energy, digestion rate, body mass.
+    Metabolic,
+    /// Bone density, hide thickness.
+    Structural,
+    /// Hormones, internal clocks, threshold gates.
+    Regulatory,
+    /// Group-size preference, bonding, density gating.
+    Social,
+    /// Learning, memory, integration.
+    Cognitive,
+    /// Fertility, mate choice, parental investment.
+    Reproductive,
+    /// Growth rate, body-plan variation, stage-gated traits.
+    Developmental,
+}
+
+/// Bounds policy applied when a mutation pushes a channel value out of range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundsPolicy {
+    /// Truncate to the boundary.
+    Clamp,
+    /// Reflect off the boundary.
+    Reflect,
+    /// Wrap around the range (periodic).
+    Wrap,
+}
+
+/// Origin of a channel. Mirrors the schema's `provenance` discriminated regex.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Provenance {
+    /// A canonical channel shipped by the core game.
+    Core,
+    /// Registered by a mod with the given snake_case id.
+    Mod(String),
+    /// Duplicated from a parent channel at generation `n`.
+    Genesis {
+        /// Parent channel id.
+        parent: String,
+        /// Generation at which the duplication occurred.
+        generation: u64,
+    },
+}
+
+impl Provenance {
+    /// Parse the JSON `provenance` string.
+    ///
+    /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
+    /// is enforced by JSON Schema validation, so this parser assumes the
+    /// structural shape is well-formed and only does the split.
+    pub(crate) fn parse(raw: &str) -> Result<Self, ChannelLoadError> {
+        if raw == "core" {
+            return Ok(Self::Core);
+        }
+        if let Some(rest) = raw.strip_prefix("mod:") {
+            return Ok(Self::Mod(rest.to_owned()));
+        }
+        if let Some(rest) = raw.strip_prefix("genesis:") {
+            // rest is `parent_id:generation`.
+            let mut parts = rest.rsplitn(2, ':');
+            let gen_str = parts
+                .next()
+                .ok_or_else(|| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
+            let parent = parts
+                .next()
+                .ok_or_else(|| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
+            let generation: u64 = gen_str
+                .parse()
+                .map_err(|_| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
+            return Ok(Self::Genesis {
+                parent: parent.to_owned(),
+                generation,
+            });
+        }
+        Err(ChannelLoadError::InvalidProvenance(raw.to_owned()))
+    }
+}
+
+/// Numeric range with physical units.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Range {
+    /// Minimum valid value (inclusive).
+    pub min: Q3232,
+    /// Maximum valid value (inclusive).
+    pub max: Q3232,
+    /// Physical units (e.g. `"dB"`, `"kg"`, `"Hz"`, `"dimensionless"`).
+    pub units: String,
+}
+
+/// Applicable body-mass range (macro/meso/micro scale).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScaleBand {
+    /// Lower bound (kg, inclusive).
+    pub min_kg: Q3232,
+    /// Upper bound (kg, inclusive).
+    pub max_kg: Q3232,
+}
+
+/// Correlation declaration between two channels' mutations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorrelationEntry {
+    /// Target channel id (validated as snake_case by JSON Schema).
+    pub channel: String,
+    /// Pearson coefficient, clipped to `[-1, 1]` by the schema.
+    pub coefficient: Q3232,
+}
+
+/// Gaussian mutation kernel parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MutationKernel {
+    /// Standard deviation proportional to the range width (> 0 by schema).
+    pub sigma: Q3232,
+    /// How mutations hitting a range boundary are handled.
+    pub bounds_policy: BoundsPolicy,
+    /// Relative selection weight during channel genesis (≥ 0 by schema).
+    pub genesis_weight: Q3232,
+    /// Optional correlated-mutation declarations.
+    pub correlation_with: Vec<CorrelationEntry>,
+}
+
+/// In-memory representation of a single channel manifest.
+///
+/// Load a manifest with [`ChannelManifest::from_json_str`] or
+/// [`crate::schema::load_channel_manifest`]. Both flows run JSON Schema
+/// validation first so downstream code can trust every invariant encoded in
+/// the schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelManifest {
+    /// Unique snake_case identifier.
+    pub id: String,
+    /// Biological family.
+    pub family: ChannelFamily,
+    /// Human-readable description.
+    pub description: String,
+    /// Numeric range with physical units.
+    pub range: Range,
+    /// Gaussian mutation kernel parameters.
+    pub mutation_kernel: MutationKernel,
+    /// Composition hooks (interactions with other channels).
+    pub composition_hooks: Vec<CompositionHook>,
+    /// Expression condition gates (all must hold).
+    pub expression_conditions: Vec<ExpressionCondition>,
+    /// Applicable body-mass range.
+    pub scale_band: ScaleBand,
+    /// Whether the channel can vary across body sites.
+    pub body_site_applicable: bool,
+    /// Origin of this channel.
+    pub provenance: Provenance,
+}
+
+impl ChannelManifest {
+    /// Load and validate a channel manifest from a JSON string.
+    ///
+    /// ```
+    /// use beast_channels::ChannelManifest;
+    /// let json = r#"{
+    ///   "id": "example_channel",
+    ///   "family": "sensory",
+    ///   "description": "An example channel used in documentation tests.",
+    ///   "range": { "min": 0, "max": 1, "units": "dimensionless" },
+    ///   "mutation_kernel": {
+    ///     "sigma": 0.1,
+    ///     "bounds_policy": "clamp",
+    ///     "genesis_weight": 1.0
+    ///   },
+    ///   "composition_hooks": [],
+    ///   "expression_conditions": [],
+    ///   "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+    ///   "body_site_applicable": true,
+    ///   "provenance": "core"
+    /// }"#;
+    /// let manifest = ChannelManifest::from_json_str(json).unwrap();
+    /// assert_eq!(manifest.id, "example_channel");
+    /// ```
+    pub fn from_json_str(source: &str) -> Result<Self, ChannelLoadError> {
+        crate::schema::load_channel_manifest(source)
+    }
+
+    /// Construct from an already-validated `serde_json::Value`.
+    ///
+    /// Called by [`crate::schema::load_channel_manifest`] after the schema
+    /// validator has accepted the document. External callers should prefer
+    /// [`Self::from_json_str`] so JSON Schema validation always runs.
+    pub(crate) fn from_validated_value(
+        value: &serde_json::Value,
+    ) -> Result<Self, ChannelLoadError> {
+        let raw: RawChannelManifest = serde_json::from_value(value.clone())
+            .map_err(|e| ChannelLoadError::BadShape(e.to_string()))?;
+        raw.into_manifest()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Raw serde-facing mirror of the schema.
+// ---------------------------------------------------------------------------
+
+/// Exact serde mirror of the JSON Schema. Kept private — downstream types
+/// consume [`ChannelManifest`] with Q32.32 fields.
+#[derive(Debug, Deserialize)]
+struct RawChannelManifest {
+    id: String,
+    family: ChannelFamily,
+    description: String,
+    range: RawRange,
+    mutation_kernel: RawMutationKernel,
+    composition_hooks: Vec<RawCompositionHook>,
+    expression_conditions: Vec<RawExpressionCondition>,
+    scale_band: RawScaleBand,
+    body_site_applicable: bool,
+    provenance: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRange {
+    min: f64,
+    max: f64,
+    units: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMutationKernel {
+    sigma: f64,
+    bounds_policy: BoundsPolicy,
+    genesis_weight: f64,
+    #[serde(default)]
+    correlation_with: Vec<RawCorrelationEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCorrelationEntry {
+    channel: String,
+    coefficient: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCompositionHook {
+    with: String,
+    kind: CompositionKind,
+    coefficient: f64,
+    #[serde(default)]
+    threshold: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum RawExpressionCondition {
+    BiomeFlag { flag: String },
+    ScaleBand { min_kg: f64, max_kg: f64 },
+    Season { season: String },
+    DevelopmentalStage { stage: String },
+    SocialDensity { min_per_km2: f64, max_per_km2: f64 },
+}
+
+#[derive(Debug, Deserialize)]
+struct RawScaleBand {
+    min_kg: f64,
+    max_kg: f64,
+}
+
+impl RawChannelManifest {
+    fn into_manifest(self) -> Result<ChannelManifest, ChannelLoadError> {
+        // --- range ---
+        if self.range.min > self.range.max {
+            return Err(ChannelLoadError::InvalidRange {
+                channel_id: self.id.clone(),
+                reason: format!(
+                    "range.min ({}) must be <= range.max ({})",
+                    self.range.min, self.range.max
+                ),
+            });
+        }
+        let range = Range {
+            min: Q3232::from_num(self.range.min),
+            max: Q3232::from_num(self.range.max),
+            units: self.range.units,
+        };
+
+        // --- scale band ---
+        if self.scale_band.min_kg > self.scale_band.max_kg {
+            return Err(ChannelLoadError::InvalidRange {
+                channel_id: self.id.clone(),
+                reason: format!(
+                    "scale_band.min_kg ({}) must be <= scale_band.max_kg ({})",
+                    self.scale_band.min_kg, self.scale_band.max_kg
+                ),
+            });
+        }
+        let scale_band = ScaleBand {
+            min_kg: Q3232::from_num(self.scale_band.min_kg),
+            max_kg: Q3232::from_num(self.scale_band.max_kg),
+        };
+
+        // --- mutation kernel ---
+        let kernel = MutationKernel {
+            sigma: Q3232::from_num(self.mutation_kernel.sigma),
+            bounds_policy: self.mutation_kernel.bounds_policy,
+            genesis_weight: Q3232::from_num(self.mutation_kernel.genesis_weight),
+            correlation_with: self
+                .mutation_kernel
+                .correlation_with
+                .into_iter()
+                .map(|c| CorrelationEntry {
+                    channel: c.channel,
+                    coefficient: Q3232::from_num(c.coefficient),
+                })
+                .collect(),
+        };
+
+        // --- composition hooks: reject duplicates on `with`, enforce threshold rule ---
+        let mut seen = BTreeSet::new();
+        let mut hooks = Vec::with_capacity(self.composition_hooks.len());
+        for raw in self.composition_hooks {
+            let needs_threshold = matches!(
+                raw.kind,
+                CompositionKind::Threshold | CompositionKind::Gating
+            );
+            let threshold = match (needs_threshold, raw.threshold) {
+                (true, Some(t)) => Some(Q3232::from_num(t)),
+                (true, None) => {
+                    return Err(ChannelLoadError::MissingThreshold {
+                        channel_id: self.id.clone(),
+                        with: raw.with.clone(),
+                        kind: raw.kind,
+                    });
+                }
+                (false, _) => None,
+            };
+            if !seen.insert(raw.with.clone()) {
+                return Err(ChannelLoadError::DuplicateHook {
+                    channel_id: self.id.clone(),
+                    with: raw.with,
+                });
+            }
+            hooks.push(CompositionHook {
+                with: raw.with,
+                kind: raw.kind,
+                coefficient: Q3232::from_num(raw.coefficient),
+                threshold,
+            });
+        }
+
+        // --- expression conditions ---
+        let mut conditions = Vec::with_capacity(self.expression_conditions.len());
+        for raw in self.expression_conditions {
+            conditions.push(match raw {
+                RawExpressionCondition::BiomeFlag { flag } => {
+                    ExpressionCondition::BiomeFlag { flag }
+                }
+                RawExpressionCondition::ScaleBand { min_kg, max_kg } => {
+                    if min_kg > max_kg {
+                        return Err(ChannelLoadError::InvalidRange {
+                            channel_id: self.id.clone(),
+                            reason: format!(
+                                "expression_conditions.scale_band min_kg ({min_kg}) must be <= max_kg ({max_kg})"
+                            ),
+                        });
+                    }
+                    ExpressionCondition::ScaleBand {
+                        min_kg: Q3232::from_num(min_kg),
+                        max_kg: Q3232::from_num(max_kg),
+                    }
+                }
+                RawExpressionCondition::Season { season } => {
+                    ExpressionCondition::Season { season }
+                }
+                RawExpressionCondition::DevelopmentalStage { stage } => {
+                    ExpressionCondition::DevelopmentalStage { stage }
+                }
+                RawExpressionCondition::SocialDensity {
+                    min_per_km2,
+                    max_per_km2,
+                } => {
+                    if min_per_km2 > max_per_km2 {
+                        return Err(ChannelLoadError::InvalidRange {
+                            channel_id: self.id.clone(),
+                            reason: format!(
+                                "expression_conditions.social_density min_per_km2 ({min_per_km2}) must be <= max_per_km2 ({max_per_km2})"
+                            ),
+                        });
+                    }
+                    ExpressionCondition::SocialDensity {
+                        min_per_km2: Q3232::from_num(min_per_km2),
+                        max_per_km2: Q3232::from_num(max_per_km2),
+                    }
+                }
+            });
+        }
+
+        let provenance = Provenance::parse(&self.provenance)?;
+
+        Ok(ChannelManifest {
+            id: self.id,
+            family: self.family,
+            description: self.description,
+            range,
+            mutation_kernel: kernel,
+            composition_hooks: hooks,
+            expression_conditions: conditions,
+            scale_band,
+            body_site_applicable: self.body_site_applicable,
+            provenance,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_core_parses() {
+        assert_eq!(Provenance::parse("core").unwrap(), Provenance::Core);
+    }
+
+    #[test]
+    fn provenance_mod_parses() {
+        assert_eq!(
+            Provenance::parse("mod:my_mod").unwrap(),
+            Provenance::Mod("my_mod".to_owned())
+        );
+    }
+
+    #[test]
+    fn provenance_genesis_parses() {
+        assert_eq!(
+            Provenance::parse("genesis:auditory_sensitivity:50").unwrap(),
+            Provenance::Genesis {
+                parent: "auditory_sensitivity".to_owned(),
+                generation: 50,
+            }
+        );
+    }
+
+    #[test]
+    fn provenance_genesis_missing_generation_rejected() {
+        assert!(Provenance::parse("genesis:parent").is_err());
+    }
+
+    #[test]
+    fn provenance_unknown_prefix_rejected() {
+        assert!(Provenance::parse("unknown:foo").is_err());
+    }
+}

--- a/crates/beast-channels/src/registry.rs
+++ b/crates/beast-channels/src/registry.rs
@@ -1,0 +1,268 @@
+//! Channel registry — the single authoritative lookup table.
+//!
+//! Per `documentation/INVARIANTS.md` Invariant 3 ("Channel Registry
+//! Monolithicism"), the simulation holds exactly one [`ChannelRegistry`] at
+//! runtime. Core, mod, and genesis-derived channels all register through this
+//! surface; nothing downstream hardcodes channel ids. The registry is backed
+//! by [`BTreeMap`] so iteration order is deterministic and independent of
+//! hash randomization — a requirement for deterministic replay.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+use crate::manifest::{ChannelFamily, ChannelManifest};
+
+/// Errors produced by registry mutations.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// A channel with the same id is already registered.
+    #[error("duplicate channel id: {0}")]
+    DuplicateId(String),
+
+    /// A composition hook or correlation entry referenced a channel that is
+    /// not (yet) registered. Reported by [`ChannelRegistry::validate_cross_references`].
+    #[error("channel `{source_id}` references unknown channel `{target}`")]
+    UnknownReference {
+        /// The owning channel.
+        source_id: String,
+        /// The missing reference target.
+        target: String,
+    },
+}
+
+/// An authoritative in-memory index of channel manifests.
+///
+/// Clone is cheap-ish (shallow: `BTreeMap` clones are linear in key+value
+/// pointers). Treat a `ChannelRegistry` as an append-only structure built
+/// during world initialization; mutation afterwards (genesis events) is
+/// allowed but must go through [`Self::register`] so the secondary indices
+/// stay consistent.
+#[derive(Debug, Clone, Default)]
+pub struct ChannelRegistry {
+    by_id: BTreeMap<String, ChannelManifest>,
+    by_family: BTreeMap<ChannelFamily, BTreeSet<String>>,
+}
+
+impl ChannelRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a manifest, failing if its id is already registered.
+    ///
+    /// Returns an error *before* inserting, so on error the registry is
+    /// unchanged (strong exception safety).
+    pub fn register(&mut self, manifest: ChannelManifest) -> Result<(), RegistryError> {
+        if self.by_id.contains_key(&manifest.id) {
+            return Err(RegistryError::DuplicateId(manifest.id));
+        }
+        self.by_family
+            .entry(manifest.family)
+            .or_default()
+            .insert(manifest.id.clone());
+        self.by_id.insert(manifest.id.clone(), manifest);
+        Ok(())
+    }
+
+    /// Number of registered channels.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Whether no channels are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Check whether the given id is registered.
+    #[must_use]
+    pub fn contains(&self, id: &str) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Look up a manifest by id.
+    #[must_use]
+    pub fn get(&self, id: &str) -> Option<&ChannelManifest> {
+        self.by_id.get(id)
+    }
+
+    /// Iterate manifests in `(id, manifest)` order. Iteration is deterministic
+    /// because the backing storage is a [`BTreeMap`].
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &ChannelManifest)> {
+        self.by_id.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Iterate channel ids in sorted order.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.by_id.keys().map(String::as_str)
+    }
+
+    /// All channel ids belonging to `family`, in sorted order.
+    pub fn ids_by_family(&self, family: ChannelFamily) -> impl Iterator<Item = &str> {
+        self.by_family
+            .get(&family)
+            .into_iter()
+            .flat_map(|set| set.iter().map(String::as_str))
+    }
+
+    /// All manifests belonging to `family`, in sorted id order.
+    pub fn by_family(&self, family: ChannelFamily) -> impl Iterator<Item = &ChannelManifest> {
+        self.ids_by_family(family)
+            .filter_map(move |id| self.by_id.get(id))
+    }
+
+    /// Verify that every composition hook `with` reference and every
+    /// mutation-kernel correlation target exists in this registry.
+    ///
+    /// The literal `"self"` is always accepted as a hook target
+    /// (auto-interaction). Genesis registration ordering can put the parent
+    /// channel ahead of its children — call this after all core/mod/genesis
+    /// manifests are loaded.
+    pub fn validate_cross_references(&self) -> Result<(), RegistryError> {
+        for (id, manifest) in &self.by_id {
+            for hook in &manifest.composition_hooks {
+                if hook.with == "self" {
+                    continue;
+                }
+                if !self.by_id.contains_key(&hook.with) {
+                    return Err(RegistryError::UnknownReference {
+                        source_id: id.clone(),
+                        target: hook.with.clone(),
+                    });
+                }
+            }
+            for corr in &manifest.mutation_kernel.correlation_with {
+                if !self.by_id.contains_key(&corr.channel) {
+                    return Err(RegistryError::UnknownReference {
+                        source_id: id.clone(),
+                        target: corr.channel.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::composition::{CompositionHook, CompositionKind};
+    use crate::expression::ExpressionCondition;
+    use crate::manifest::{
+        BoundsPolicy, ChannelFamily, CorrelationEntry, MutationKernel, Provenance, Range, ScaleBand,
+    };
+    use beast_core::Q3232;
+
+    fn fixture(id: &str, family: ChannelFamily) -> ChannelManifest {
+        ChannelManifest {
+            id: id.into(),
+            family,
+            description: "fixture".into(),
+            range: Range {
+                min: Q3232::ZERO,
+                max: Q3232::ONE,
+                units: "dimensionless".into(),
+            },
+            mutation_kernel: MutationKernel {
+                sigma: Q3232::from_num(0.1_f64),
+                bounds_policy: BoundsPolicy::Clamp,
+                genesis_weight: Q3232::ONE,
+                correlation_with: Vec::new(),
+            },
+            composition_hooks: Vec::new(),
+            expression_conditions: Vec::<ExpressionCondition>::new(),
+            scale_band: ScaleBand {
+                min_kg: Q3232::ZERO,
+                max_kg: Q3232::from_num(1000_i32),
+            },
+            body_site_applicable: false,
+            provenance: Provenance::Core,
+        }
+    }
+
+    #[test]
+    fn registration_is_unique() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(fixture("a", ChannelFamily::Sensory)).unwrap();
+        let err = reg
+            .register(fixture("a", ChannelFamily::Motor))
+            .unwrap_err();
+        assert!(matches!(err, RegistryError::DuplicateId(_)));
+    }
+
+    #[test]
+    fn iteration_is_sorted() {
+        let mut reg = ChannelRegistry::new();
+        for id in ["charlie", "alpha", "bravo"] {
+            reg.register(fixture(id, ChannelFamily::Sensory)).unwrap();
+        }
+        let ids: Vec<_> = reg.ids().collect();
+        assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn by_family_filters_correctly() {
+        let mut reg = ChannelRegistry::new();
+        reg.register(fixture("s1", ChannelFamily::Sensory)).unwrap();
+        reg.register(fixture("s2", ChannelFamily::Sensory)).unwrap();
+        reg.register(fixture("m1", ChannelFamily::Motor)).unwrap();
+        let sensory: Vec<_> = reg.ids_by_family(ChannelFamily::Sensory).collect();
+        assert_eq!(sensory, vec!["s1", "s2"]);
+        let motor: Vec<_> = reg.ids_by_family(ChannelFamily::Motor).collect();
+        assert_eq!(motor, vec!["m1"]);
+    }
+
+    #[test]
+    fn cross_reference_validation_catches_unknown_hooks() {
+        let mut reg = ChannelRegistry::new();
+        let mut owner = fixture("owner", ChannelFamily::Sensory);
+        owner.composition_hooks.push(CompositionHook {
+            with: "ghost".into(),
+            kind: CompositionKind::Additive,
+            coefficient: Q3232::ONE,
+            threshold: None,
+        });
+        reg.register(owner).unwrap();
+        assert!(matches!(
+            reg.validate_cross_references(),
+            Err(RegistryError::UnknownReference { .. })
+        ));
+    }
+
+    #[test]
+    fn cross_reference_validation_accepts_self() {
+        let mut reg = ChannelRegistry::new();
+        let mut owner = fixture("owner", ChannelFamily::Sensory);
+        owner.composition_hooks.push(CompositionHook {
+            with: "self".into(),
+            kind: CompositionKind::Multiplicative,
+            coefficient: Q3232::ONE,
+            threshold: None,
+        });
+        reg.register(owner).unwrap();
+        assert!(reg.validate_cross_references().is_ok());
+    }
+
+    #[test]
+    fn cross_reference_validation_catches_unknown_correlations() {
+        let mut reg = ChannelRegistry::new();
+        let mut owner = fixture("owner", ChannelFamily::Sensory);
+        owner
+            .mutation_kernel
+            .correlation_with
+            .push(CorrelationEntry {
+                channel: "missing".into(),
+                coefficient: Q3232::from_num(0.5_f64),
+            });
+        reg.register(owner).unwrap();
+        assert!(matches!(
+            reg.validate_cross_references(),
+            Err(RegistryError::UnknownReference { .. })
+        ));
+    }
+}

--- a/crates/beast-channels/src/schema.rs
+++ b/crates/beast-channels/src/schema.rs
@@ -204,7 +204,7 @@ mod tests {
             "provenance": "core"
         }"#;
         let err = load_channel_manifest(src).unwrap_err();
-        matches!(err, ChannelLoadError::SchemaViolation(_));
+        assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
     }
 
     #[test]

--- a/crates/beast-channels/src/schema.rs
+++ b/crates/beast-channels/src/schema.rs
@@ -1,0 +1,297 @@
+//! JSON Schema validation for channel manifests.
+//!
+//! The canonical schema lives in
+//! `documentation/schemas/channel_manifest.schema.json`. It is the single
+//! source of truth; we embed it into the binary via [`include_str!`] so every
+//! validator in the repository agrees, and so there is no runtime file-system
+//! dependency.
+//!
+//! Validation is **two-stage**:
+//!
+//! 1. Parse the input as `serde_json::Value` and run the JSON Schema
+//!    validator. This catches shape errors (missing fields, wrong types,
+//!    pattern failures, conditional `if/then` requirements like
+//!    `threshold` being required for `kind ∈ {threshold, gating}`, etc.)
+//!    with well-formed pointer-style paths.
+//! 2. Deserialize into [`crate::manifest::ChannelManifest`] and run
+//!    cross-field semantic checks (`range.min <= range.max`, unique
+//!    composition targets, provenance string decomposition).
+//!
+//! External callers should use
+//! [`crate::manifest::ChannelManifest::from_json_str`]; this module is the
+//! implementation.
+
+use std::sync::OnceLock;
+
+use jsonschema::JSONSchema;
+use thiserror::Error;
+
+use crate::composition::CompositionKind;
+use crate::manifest::ChannelManifest;
+
+/// Raw JSON text of the channel manifest schema. Embedded at compile time so
+/// downstream crates need no runtime filesystem access to validate.
+pub const CHANNEL_MANIFEST_SCHEMA: &str =
+    include_str!("../../../documentation/schemas/channel_manifest.schema.json");
+
+/// Errors produced while loading a channel manifest.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ChannelLoadError {
+    /// Input was not parsable as JSON.
+    #[error("manifest is not valid JSON: {0}")]
+    InvalidJson(String),
+
+    /// JSON Schema validation produced one or more errors. Each entry carries
+    /// the failing JSON Pointer path plus a human-readable message, which is
+    /// enough to point a mod author at the exact field.
+    #[error("manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    SchemaViolation(Vec<SchemaViolation>),
+
+    /// Deserialization into the typed manifest struct failed after schema
+    /// validation passed — indicates a gap between the schema and the Rust
+    /// types (treat as a bug).
+    #[error("manifest deserialized unexpectedly: {0}")]
+    BadShape(String),
+
+    /// `provenance` did not match one of `core`, `mod:<id>`, or
+    /// `genesis:<parent>:<generation>`.
+    #[error("invalid provenance string: {0}")]
+    InvalidProvenance(String),
+
+    /// A numeric range was inverted (e.g. `range.min > range.max`).
+    #[error("channel {channel_id} has invalid range: {reason}")]
+    InvalidRange {
+        /// Channel id from the manifest.
+        channel_id: String,
+        /// Human description of which range inverted.
+        reason: String,
+    },
+
+    /// Two composition hooks referenced the same other channel.
+    #[error("channel {channel_id} has duplicate composition hook for `{with}`")]
+    DuplicateHook {
+        /// Channel id from the manifest.
+        channel_id: String,
+        /// Repeated target id.
+        with: String,
+    },
+
+    /// A composition hook of `threshold`/`gating` kind omitted `threshold`.
+    #[error(
+        "channel {channel_id} composition hook `with={with}` kind={kind:?} is missing the required `threshold`"
+    )]
+    MissingThreshold {
+        /// Channel id from the manifest.
+        channel_id: String,
+        /// Target id for the offending hook.
+        with: String,
+        /// Offending composition kind.
+        kind: CompositionKind,
+    },
+}
+
+/// A single JSON Schema validation error, flattened to a simple path+message
+/// pair so callers don't need to depend on `jsonschema` types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaViolation {
+    /// JSON Pointer path to the failing node (e.g. `/composition_hooks/0/threshold`).
+    pub pointer: String,
+    /// Human-readable message from the validator.
+    pub message: String,
+}
+
+fn format_schema_errors(errors: &[SchemaViolation]) -> String {
+    let mut out = String::new();
+    for e in errors {
+        out.push_str("  at ");
+        out.push_str(if e.pointer.is_empty() {
+            "<root>"
+        } else {
+            e.pointer.as_str()
+        });
+        out.push_str(": ");
+        out.push_str(&e.message);
+        out.push('\n');
+    }
+    out
+}
+
+fn compiled_schema() -> &'static JSONSchema {
+    static SCHEMA: OnceLock<JSONSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| {
+        let raw: serde_json::Value = serde_json::from_str(CHANNEL_MANIFEST_SCHEMA)
+            .expect("embedded channel manifest schema is valid JSON");
+        // `jsonschema` 0.17 pins its default draft at Draft 2019-09, and the
+        // schema files declare `"$schema": ".../draft/2020-12/..."`. The
+        // subset of features we rely on (types, enums, patterns, required,
+        // if/then/else, oneOf) is identical between 2019-09 and 2020-12, so
+        // letting the validator use its default keeps the toolchain pinned to
+        // stable Rust 1.75 while still enforcing every constraint we depend on.
+        JSONSchema::options()
+            .compile(&raw)
+            .expect("embedded channel manifest schema compiles")
+    })
+}
+
+/// Load and fully validate a channel manifest from its JSON source.
+///
+/// See [`crate::manifest::ChannelManifest::from_json_str`] for the public
+/// entry point — it forwards here.
+pub fn load_channel_manifest(source: &str) -> Result<ChannelManifest, ChannelLoadError> {
+    let value: serde_json::Value =
+        serde_json::from_str(source).map_err(|e| ChannelLoadError::InvalidJson(e.to_string()))?;
+
+    let schema = compiled_schema();
+    if let Err(errors) = schema.validate(&value) {
+        let violations = errors
+            .map(|e| SchemaViolation {
+                pointer: e.instance_path.to_string(),
+                message: e.to_string(),
+            })
+            .collect::<Vec<_>>();
+        return Err(ChannelLoadError::SchemaViolation(violations));
+    }
+
+    ChannelManifest::from_validated_value(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_schema_compiles() {
+        // Accessing `compiled_schema()` panics if the embedded string is ill-
+        // formed or the schema itself is malformed. Pulling it once exercises
+        // the OnceLock.
+        let _ = compiled_schema();
+    }
+
+    #[test]
+    fn minimal_core_manifest_loads() {
+        let src = r#"{
+            "id": "example",
+            "family": "metabolic",
+            "description": "A minimal valid manifest for testing.",
+            "range": { "min": 0, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": {
+                "sigma": 0.1,
+                "bounds_policy": "clamp",
+                "genesis_weight": 1.0
+            },
+            "composition_hooks": [],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "core"
+        }"#;
+        let m = load_channel_manifest(src).unwrap();
+        assert_eq!(m.id, "example");
+    }
+
+    #[test]
+    fn schema_rejects_missing_required_field() {
+        // `family` omitted.
+        let src = r#"{
+            "id": "example",
+            "description": "missing family",
+            "range": { "min": 0, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+            "composition_hooks": [],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "core"
+        }"#;
+        let err = load_channel_manifest(src).unwrap_err();
+        matches!(err, ChannelLoadError::SchemaViolation(_));
+    }
+
+    #[test]
+    fn semantic_invalid_range_rejected() {
+        // Schema allows min=5, max=1 (it checks types, not ordering); semantic
+        // layer catches the inversion.
+        let src = r#"{
+            "id": "example",
+            "family": "metabolic",
+            "description": "An inverted numeric range.",
+            "range": { "min": 5, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+            "composition_hooks": [],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "core"
+        }"#;
+        assert!(matches!(
+            load_channel_manifest(src),
+            Err(ChannelLoadError::InvalidRange { .. })
+        ));
+    }
+
+    #[test]
+    fn threshold_missing_rejected_by_schema() {
+        let src = r#"{
+            "id": "example",
+            "family": "sensory",
+            "description": "Threshold kind without threshold field.",
+            "range": { "min": 0, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+            "composition_hooks": [
+                { "with": "other", "kind": "threshold", "coefficient": 1.0 }
+            ],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "core"
+        }"#;
+        let err = load_channel_manifest(src).unwrap_err();
+        // Either the JSON Schema conditional catches it, or the semantic layer
+        // does — both are acceptable.
+        assert!(matches!(
+            err,
+            ChannelLoadError::SchemaViolation(_) | ChannelLoadError::MissingThreshold { .. }
+        ));
+    }
+
+    #[test]
+    fn duplicate_composition_hook_rejected() {
+        let src = r#"{
+            "id": "example",
+            "family": "sensory",
+            "description": "Two hooks referencing the same other channel.",
+            "range": { "min": 0, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+            "composition_hooks": [
+                { "with": "other", "kind": "additive", "coefficient": 1.0 },
+                { "with": "other", "kind": "multiplicative", "coefficient": 0.5 }
+            ],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "core"
+        }"#;
+        assert!(matches!(
+            load_channel_manifest(src),
+            Err(ChannelLoadError::DuplicateHook { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_provenance_rejected_by_pattern() {
+        let src = r#"{
+            "id": "example",
+            "family": "sensory",
+            "description": "Unknown provenance prefix.",
+            "range": { "min": 0, "max": 1, "units": "dimensionless" },
+            "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+            "composition_hooks": [],
+            "expression_conditions": [],
+            "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+            "body_site_applicable": false,
+            "provenance": "unknown:foo"
+        }"#;
+        let err = load_channel_manifest(src).unwrap_err();
+        assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
+    }
+}

--- a/crates/beast-channels/tests/example_manifests.rs
+++ b/crates/beast-channels/tests/example_manifests.rs
@@ -1,0 +1,79 @@
+//! Integration test: the five worked examples in
+//! `documentation/schemas/examples/` must load, validate, and register.
+//!
+//! This doubles as the "demo criterion" from Sprint 2: load the core channel
+//! set without errors and confirm the registry queries return expected
+//! entries.
+
+use beast_channels::{ChannelFamily, ChannelManifest, ChannelRegistry};
+
+const EXAMPLES: &[(&str, &str)] = &[
+    (
+        "auditory_sensitivity",
+        include_str!("../../../documentation/schemas/examples/auditory_sensitivity.json"),
+    ),
+    (
+        "host_coupling",
+        include_str!("../../../documentation/schemas/examples/host_coupling.json"),
+    ),
+    (
+        "kinetic_force",
+        include_str!("../../../documentation/schemas/examples/kinetic_force.json"),
+    ),
+    (
+        "structural_rigidity",
+        include_str!("../../../documentation/schemas/examples/structural_rigidity.json"),
+    ),
+    (
+        "vocal_modulation",
+        include_str!("../../../documentation/schemas/examples/vocal_modulation.json"),
+    ),
+];
+
+#[test]
+fn every_example_manifest_loads() {
+    for (id, source) in EXAMPLES {
+        let manifest =
+            ChannelManifest::from_json_str(source).unwrap_or_else(|e| panic!("{id}: {e}"));
+        assert_eq!(manifest.id, *id, "filename and id must match");
+    }
+}
+
+#[test]
+fn example_manifests_register_and_iterate_sorted() {
+    let mut registry = ChannelRegistry::new();
+    for (_, source) in EXAMPLES {
+        let manifest = ChannelManifest::from_json_str(source).unwrap();
+        registry.register(manifest).unwrap();
+    }
+    assert_eq!(registry.len(), EXAMPLES.len());
+
+    let ids: Vec<&str> = registry.ids().collect();
+    let mut expected: Vec<&str> = EXAMPLES.iter().map(|(id, _)| *id).collect();
+    expected.sort_unstable();
+    assert_eq!(ids, expected);
+}
+
+#[test]
+fn family_queries_return_expected_members() {
+    let mut registry = ChannelRegistry::new();
+    for (_, source) in EXAMPLES {
+        let manifest = ChannelManifest::from_json_str(source).unwrap();
+        registry.register(manifest).unwrap();
+    }
+
+    // Known from the worked examples: auditory_sensitivity is Sensory;
+    // vocal_modulation and kinetic_force are Motor; structural_rigidity is
+    // Structural; host_coupling is Social.
+    let sensory: Vec<&str> = registry.ids_by_family(ChannelFamily::Sensory).collect();
+    assert_eq!(sensory, vec!["auditory_sensitivity"]);
+
+    let motor: Vec<&str> = registry.ids_by_family(ChannelFamily::Motor).collect();
+    assert_eq!(motor, vec!["kinetic_force", "vocal_modulation"]);
+
+    let structural: Vec<&str> = registry.ids_by_family(ChannelFamily::Structural).collect();
+    assert_eq!(structural, vec!["structural_rigidity"]);
+
+    let social: Vec<&str> = registry.ids_by_family(ChannelFamily::Social).collect();
+    assert_eq!(social, vec!["host_coupling"]);
+}

--- a/crates/beast-channels/tests/malformed_manifests.rs
+++ b/crates/beast-channels/tests/malformed_manifests.rs
@@ -1,0 +1,114 @@
+//! Five malformed channel manifests — each one must be rejected with a
+//! specific, descriptive error so mod authors can diagnose their own JSON.
+//!
+//! Sprint 2 demo criterion: "Schema validation rejects 5 malformed test
+//! manifests."
+
+use beast_channels::{ChannelLoadError, ChannelManifest};
+
+/// Helper: a baseline minimal-valid manifest that each fixture tweaks in
+/// exactly one way to isolate the failure mode under test.
+const BASE_VALID: &str = r#"{
+    "id": "example",
+    "family": "sensory",
+    "description": "Minimal baseline used by malformed-manifest fixtures.",
+    "range": { "min": 0, "max": 1, "units": "dimensionless" },
+    "mutation_kernel": {
+        "sigma": 0.1,
+        "bounds_policy": "clamp",
+        "genesis_weight": 1.0
+    },
+    "composition_hooks": [],
+    "expression_conditions": [],
+    "scale_band": { "min_kg": 0.01, "max_kg": 1000 },
+    "body_site_applicable": true,
+    "provenance": "core"
+}"#;
+
+#[test]
+fn baseline_still_loads() {
+    // Safety net: if the baseline fixture ever stops loading, every other
+    // test in this file is meaningless.
+    assert!(ChannelManifest::from_json_str(BASE_VALID).is_ok());
+}
+
+#[test]
+fn fixture_1_unknown_family_rejected() {
+    let src = BASE_VALID.replace(r#""family": "sensory""#, r#""family": "telepathy""#);
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    assert!(
+        matches!(err, ChannelLoadError::SchemaViolation(_)),
+        "expected schema violation, got {err:?}"
+    );
+}
+
+#[test]
+fn fixture_2_missing_required_field_rejected() {
+    // Drop `scale_band` entirely.
+    let src = r#"{
+        "id": "example",
+        "family": "sensory",
+        "description": "Missing scale_band.",
+        "range": { "min": 0, "max": 1, "units": "dimensionless" },
+        "mutation_kernel": { "sigma": 0.1, "bounds_policy": "clamp", "genesis_weight": 1.0 },
+        "composition_hooks": [],
+        "expression_conditions": [],
+        "body_site_applicable": true,
+        "provenance": "core"
+    }"#;
+    let err = ChannelManifest::from_json_str(src).unwrap_err();
+    assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
+}
+
+#[test]
+fn fixture_3_threshold_kind_without_threshold_value_rejected() {
+    let src = BASE_VALID.replace(
+        r#""composition_hooks": []"#,
+        r#""composition_hooks": [ { "with": "other", "kind": "threshold", "coefficient": 1.0 } ]"#,
+    );
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ChannelLoadError::SchemaViolation(_) | ChannelLoadError::MissingThreshold { .. }
+        ),
+        "expected schema-violation or missing-threshold, got {err:?}"
+    );
+}
+
+#[test]
+fn fixture_4_inverted_scale_band_rejected() {
+    // Schema allows any numeric; semantic layer rejects min > max.
+    let src = BASE_VALID.replace(
+        r#""scale_band": { "min_kg": 0.01, "max_kg": 1000 }"#,
+        r#""scale_band": { "min_kg": 1000, "max_kg": 0.01 }"#,
+    );
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    assert!(matches!(err, ChannelLoadError::InvalidRange { .. }));
+}
+
+#[test]
+fn fixture_5_invalid_provenance_pattern_rejected() {
+    let src = BASE_VALID.replace(r#""provenance": "core""#, r#""provenance": "random:value""#);
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    // The JSON Schema pattern catches this before the semantic layer runs.
+    assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
+}
+
+#[test]
+fn fixture_6_sigma_zero_rejected() {
+    // Schema requires exclusiveMinimum: 0 for sigma.
+    let src = BASE_VALID.replace(r#""sigma": 0.1"#, r#""sigma": 0"#);
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
+}
+
+#[test]
+fn fixture_7_correlation_out_of_bounds_rejected() {
+    let src = BASE_VALID.replace(
+        r#""genesis_weight": 1.0"#,
+        r#""genesis_weight": 1.0, "correlation_with": [{ "channel": "other", "coefficient": 1.5 }]"#,
+    );
+    let err = ChannelManifest::from_json_str(&src).unwrap_err();
+    assert!(matches!(err, ChannelLoadError::SchemaViolation(_)));
+}

--- a/crates/beast-primitives/Cargo.toml
+++ b/crates/beast-primitives/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "beast-primitives"
+description = "Primitive effect registry, manifest loading, and deterministic cost evaluation for the Beast Evolution Game."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+beast-core = { workspace = true }
+beast-channels = { workspace = true }
+fixed = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+jsonschema = { workspace = true }
+regex = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+float_arithmetic = "warn"

--- a/crates/beast-primitives/README.md
+++ b/crates/beast-primitives/README.md
@@ -1,0 +1,40 @@
+# beast-primitives
+
+Layer 1 primitive effect registry and cost evaluator for Beast Evolution Game.
+
+Primitives are the atomic output vocabulary of the phenotype interpreter.
+They are never named abilities in themselves ("echolocation", "venom"); the
+Chronicler assigns labels post-hoc over recurring primitive clusters — see
+`documentation/INVARIANTS.md` §2 (Mechanics-Label Separation).
+
+## Responsibilities
+
+- **Manifest loading** — `PrimitiveManifest::from_json_str` mirrors the
+  two-stage pattern used by `beast-channels`: JSON Schema validation, then
+  semantic checks (range ordering, scaling parameters referring to declared
+  inputs, default type matching, provenance parsing).
+- **Registry** — `PrimitiveRegistry` is `BTreeMap`-backed with a secondary
+  index by [`PrimitiveCategory`]. Iteration is deterministic.
+- **Cost evaluation** — `evaluate_cost` computes
+
+    cost = base_metabolic_cost + Σ coefficient_i · value_i ^ exponent_i
+
+  deterministically over `Q3232`. A crate-local fixed-point `exp`/`ln` pair
+  implements the power function; see `src/math.rs` for the algorithms. All
+  manifest exponents in `documentation/schemas/primitive_vocabulary/` are
+  supported (integers, half-integers, 0.6/0.7/0.8, 1.2, -1.0, -1.2, …).
+
+## Determinism
+
+- All sim-math goes through `Q3232` from `beast-core`.
+- The embedded `exp`/`ln` approximation uses Taylor series with fixed
+  iteration counts — no conditional early exits that would make results
+  depend on floating-point rounding.
+- `clippy::float_arithmetic = "warn"` prevents future regressions.
+
+## Layering
+
+Depends on `beast-core` and `beast-channels`. The channel dependency is used
+to type-check `composition_compatibility.channel_family` entries against the
+shared `ChannelFamily` enum and to validate `channel_id` references against
+a live `ChannelRegistry` at startup.

--- a/crates/beast-primitives/src/category.rs
+++ b/crates/beast-primitives/src/category.rs
@@ -1,0 +1,55 @@
+//! Functional category and observable modality enums.
+//!
+//! Mirror the schema's `category` and `observable_signature.modality` enums.
+//! Both derive `Ord` so registries can use them as [`BTreeMap`] keys for
+//! deterministic iteration.
+//!
+//! [`BTreeMap`]: std::collections::BTreeMap
+
+use serde::{Deserialize, Serialize};
+
+/// Functional category of a primitive effect.
+///
+/// Maps 1:1 to the `category` enum in the schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrimitiveCategory {
+    /// Broadcasting info to environment (acoustic pulses, markers, etc.).
+    SignalEmission,
+    /// Passive sensing from environment.
+    SignalReception,
+    /// Mechanical action on environment.
+    ForceApplication,
+    /// Physiological state change in self or target.
+    StateInduction,
+    /// Fusing multi-sensory signals into maps.
+    SpatialIntegration,
+    /// Moving substances between spaces.
+    MassTransfer,
+    /// Controlling metabolic rate and energy budget.
+    EnergyModulation,
+    /// Establishing behavioral/physiological attachments.
+    BondFormation,
+}
+
+/// Sense modality via which a primitive's emission is observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Modality {
+    /// Sound.
+    Acoustic,
+    /// Olfaction / chemical signals.
+    Chemical,
+    /// Light.
+    Visual,
+    /// Electroreception.
+    Electric,
+    /// Touch / vibration / pressure.
+    Mechanical,
+    /// Heat.
+    Thermal,
+    /// Spatial / morphological arrangement.
+    Topological,
+    /// Behavioral / action patterns.
+    Behavioral,
+}

--- a/crates/beast-primitives/src/cost.rs
+++ b/crates/beast-primitives/src/cost.rs
@@ -135,14 +135,12 @@ fn resolve_value(
     // though, so tests and future code can hand-construct manifests that
     // bypass the loader — surface that as `MissingParameter` rather than
     // panicking out of a cost evaluation call.
-    let spec: &ParameterSpec =
-        manifest
-            .parameter_schema
-            .get(parameter)
-            .ok_or_else(|| CostEvalError::MissingParameter {
-                primitive_id: manifest.id.clone(),
-                parameter: parameter.to_owned(),
-            })?;
+    let spec: &ParameterSpec = manifest.parameter_schema.get(parameter).ok_or_else(|| {
+        CostEvalError::MissingParameter {
+            primitive_id: manifest.id.clone(),
+            parameter: parameter.to_owned(),
+        }
+    })?;
     match &spec.default {
         Some(ParameterDefault::Number(v)) => Ok(*v),
         Some(ParameterDefault::Integer(i)) => Ok(Q3232::from_num(*i)),

--- a/crates/beast-primitives/src/cost.rs
+++ b/crates/beast-primitives/src/cost.rs
@@ -1,0 +1,278 @@
+//! Deterministic cost-function evaluator.
+//!
+//! The cost of a single primitive emission is:
+//!
+//! ```text
+//! cost = base_metabolic_cost + Σ coefficient_i · value_i ^ exponent_i
+//! ```
+//!
+//! where the sum ranges over `parameter_scaling` entries and `value_i` is the
+//! caller-supplied value for the corresponding parameter (falling back to the
+//! parameter's declared `default` when absent). The power is computed in
+//! fixed-point via [`crate::math::q_pow`], so results are bit-identical
+//! across platforms.
+
+use std::collections::BTreeMap;
+
+use beast_core::Q3232;
+use thiserror::Error;
+
+use crate::manifest::{ParameterDefault, ParameterSpec, PrimitiveManifest};
+use crate::math::q_pow;
+
+/// Errors produced during cost evaluation.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum CostEvalError {
+    /// A scaling term's parameter is missing from the caller-supplied map and
+    /// the manifest declares no numeric default for it.
+    #[error(
+        "primitive `{primitive_id}` is missing a value for parameter `{parameter}` (no default)"
+    )]
+    MissingParameter {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Parameter name that has no resolvable value.
+        parameter: String,
+    },
+
+    /// The parameter resolved to a non-numeric default (e.g. boolean) — the
+    /// cost formula only makes sense for continuous / integer values.
+    #[error("primitive `{primitive_id}` parameter `{parameter}` default is not numeric")]
+    NonNumericDefault {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Parameter name.
+        parameter: String,
+    },
+
+    /// `pow(base, exp)` was undefined for the supplied values (e.g. negative
+    /// base with a fractional exponent).
+    #[error(
+        "primitive `{primitive_id}` parameter `{parameter}` produced an undefined power (base={base}, exp={exp})"
+    )]
+    UndefinedPower {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Parameter name.
+        parameter: String,
+        /// Base value (the parameter's runtime value).
+        base: Q3232,
+        /// Exponent from the manifest.
+        exp: Q3232,
+    },
+}
+
+/// Evaluate a primitive's cost function for a given parameter environment.
+///
+/// `params` maps parameter names to runtime values. Missing entries fall back
+/// to the parameter's declared `default` (numeric only). Entries in `params`
+/// that aren't referenced by the cost function are ignored, which keeps
+/// callers free to pass a single shared environment across many primitives.
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use beast_core::Q3232;
+/// use beast_primitives::{evaluate_cost, PrimitiveManifest};
+///
+/// let json = r#"{
+///   "id": "bite",
+///   "category": "force_application",
+///   "description": "Simplified bite cost function for docs.",
+///   "parameter_schema": {
+///     "force": { "type": "number", "range": { "min": 0, "max": 1000 }, "default": 100 }
+///   },
+///   "composition_compatibility": [ { "channel_family": "motor" } ],
+///   "cost_function": {
+///     "base_metabolic_cost": 1.0,
+///     "parameter_scaling": [
+///       { "parameter": "force", "exponent": 2.0, "coefficient": 0.001 }
+///     ]
+///   },
+///   "observable_signature": { "modality": "mechanical", "detection_range_m": 5, "pattern_key": "bite_v1" },
+///   "provenance": "core"
+/// }"#;
+/// let manifest = PrimitiveManifest::from_json_str(json).unwrap();
+///
+/// // Using defaults: cost ≈ 1 + 0.001 * 100^2 = 11.
+/// let cost = evaluate_cost(&manifest, &BTreeMap::new()).unwrap();
+/// let as_f64: f64 = cost.to_num::<f64>();
+/// assert!((as_f64 - 11.0).abs() < 1e-2);
+/// ```
+pub fn evaluate_cost(
+    manifest: &PrimitiveManifest,
+    params: &BTreeMap<String, Q3232>,
+) -> Result<Q3232, CostEvalError> {
+    let mut total = manifest.cost_function.base_metabolic_cost;
+    for scaling in &manifest.cost_function.parameter_scaling {
+        let value = resolve_value(manifest, &scaling.parameter, params)?;
+        let term = match q_pow(value, scaling.exponent) {
+            Some(v) => scaling.coefficient * v,
+            None => {
+                return Err(CostEvalError::UndefinedPower {
+                    primitive_id: manifest.id.clone(),
+                    parameter: scaling.parameter.clone(),
+                    base: value,
+                    exp: scaling.exponent,
+                });
+            }
+        };
+        total += term;
+    }
+    Ok(total)
+}
+
+fn resolve_value(
+    manifest: &PrimitiveManifest,
+    parameter: &str,
+    params: &BTreeMap<String, Q3232>,
+) -> Result<Q3232, CostEvalError> {
+    if let Some(v) = params.get(parameter) {
+        return Ok(*v);
+    }
+    let spec: &ParameterSpec = manifest
+        .parameter_schema
+        .get(parameter)
+        .expect("scaling parameters are validated at load time");
+    match &spec.default {
+        Some(ParameterDefault::Number(v)) => Ok(*v),
+        Some(ParameterDefault::Integer(i)) => Ok(Q3232::from_num(*i)),
+        Some(ParameterDefault::String(_)) | Some(ParameterDefault::Boolean(_)) => {
+            Err(CostEvalError::NonNumericDefault {
+                primitive_id: manifest.id.clone(),
+                parameter: parameter.to_owned(),
+            })
+        }
+        None => Err(CostEvalError::MissingParameter {
+            primitive_id: manifest.id.clone(),
+            parameter: parameter.to_owned(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PrimitiveManifest;
+
+    #[test]
+    fn base_cost_only() {
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "Only a base cost.",
+            "parameter_schema": { "x": { "type": "number", "default": 1 } },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": { "base_metabolic_cost": 3.5 },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let m = PrimitiveManifest::from_json_str(json).unwrap();
+        let cost = evaluate_cost(&m, &BTreeMap::new()).unwrap();
+        assert_eq!(cost, Q3232::from_num(3.5_f64));
+    }
+
+    #[test]
+    fn uses_default_when_missing() {
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "Default used because params is empty.",
+            "parameter_schema": {
+                "force": { "type": "number", "default": 10 }
+            },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 0,
+                "parameter_scaling": [
+                    { "parameter": "force", "exponent": 2.0, "coefficient": 1.0 }
+                ]
+            },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let m = PrimitiveManifest::from_json_str(json).unwrap();
+        let cost = evaluate_cost(&m, &BTreeMap::new()).unwrap();
+        let f: f64 = cost.to_num::<f64>();
+        assert!((f - 100.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn uses_caller_value_overriding_default() {
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "Caller overrides default.",
+            "parameter_schema": {
+                "force": { "type": "number", "default": 10 }
+            },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 0,
+                "parameter_scaling": [
+                    { "parameter": "force", "exponent": 1.5, "coefficient": 1.0 }
+                ]
+            },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let m = PrimitiveManifest::from_json_str(json).unwrap();
+        let mut params = BTreeMap::new();
+        params.insert("force".into(), Q3232::from_num(4_i32));
+        let cost = evaluate_cost(&m, &params).unwrap();
+        let f: f64 = cost.to_num::<f64>();
+        // 4^1.5 = 8
+        assert!((f - 8.0).abs() < 1e-2);
+    }
+
+    #[test]
+    fn missing_parameter_without_default_errors() {
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "No default for the parameter.",
+            "parameter_schema": { "force": { "type": "number" } },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 0,
+                "parameter_scaling": [
+                    { "parameter": "force", "exponent": 1.0, "coefficient": 1.0 }
+                ]
+            },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let m = PrimitiveManifest::from_json_str(json).unwrap();
+        assert!(matches!(
+            evaluate_cost(&m, &BTreeMap::new()),
+            Err(CostEvalError::MissingParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn deterministic_across_calls() {
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "Deterministic cost across calls.",
+            "parameter_schema": {
+                "force": { "type": "number", "default": 100 },
+                "duration": { "type": "number", "default": 50 }
+            },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 1,
+                "parameter_scaling": [
+                    { "parameter": "force", "exponent": 1.5, "coefficient": 0.01 },
+                    { "parameter": "duration", "exponent": 1.0, "coefficient": 0.05 }
+                ]
+            },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let m = PrimitiveManifest::from_json_str(json).unwrap();
+        let first = evaluate_cost(&m, &BTreeMap::new()).unwrap();
+        for _ in 0..100 {
+            assert_eq!(evaluate_cost(&m, &BTreeMap::new()).unwrap(), first);
+        }
+    }
+}

--- a/crates/beast-primitives/src/cost.rs
+++ b/crates/beast-primitives/src/cost.rs
@@ -129,10 +129,20 @@ fn resolve_value(
     if let Some(v) = params.get(parameter) {
         return Ok(*v);
     }
-    let spec: &ParameterSpec = manifest
-        .parameter_schema
-        .get(parameter)
-        .expect("scaling parameters are validated at load time");
+    // Load-time validation in `RawPrimitiveManifest::into_manifest` rejects
+    // scaling entries that name unknown parameters, so in the normal flow
+    // this lookup always succeeds. `PrimitiveManifest`'s fields are public,
+    // though, so tests and future code can hand-construct manifests that
+    // bypass the loader — surface that as `MissingParameter` rather than
+    // panicking out of a cost evaluation call.
+    let spec: &ParameterSpec =
+        manifest
+            .parameter_schema
+            .get(parameter)
+            .ok_or_else(|| CostEvalError::MissingParameter {
+                primitive_id: manifest.id.clone(),
+                parameter: parameter.to_owned(),
+            })?;
     match &spec.default {
         Some(ParameterDefault::Number(v)) => Ok(*v),
         Some(ParameterDefault::Integer(i)) => Ok(Q3232::from_num(*i)),
@@ -246,6 +256,44 @@ mod tests {
             evaluate_cost(&m, &BTreeMap::new()),
             Err(CostEvalError::MissingParameter { .. })
         ));
+    }
+
+    #[test]
+    fn hand_constructed_manifest_missing_param_is_reported_not_panicked() {
+        // PrimitiveManifest's fields are `pub`, so callers can bypass the
+        // loader's validation. This test mutates a loaded manifest so its
+        // cost function references a parameter absent from the schema —
+        // the path that used to panic via .expect() — and asserts we
+        // surface MissingParameter instead.
+        use crate::manifest::ParameterScaling;
+        let json = r#"{
+            "id": "p",
+            "category": "signal_emission",
+            "description": "Normal manifest; tampered with post-load.",
+            "parameter_schema": { "x": { "type": "number", "default": 1 } },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 0,
+                "parameter_scaling": [
+                    { "parameter": "x", "exponent": 1.0, "coefficient": 1.0 }
+                ]
+            },
+            "observable_signature": { "modality": "acoustic", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        let mut m = PrimitiveManifest::from_json_str(json).unwrap();
+        // Tamper: point the scaling term at a name that was never declared.
+        m.cost_function.parameter_scaling.push(ParameterScaling {
+            parameter: "ghost".into(),
+            exponent: Q3232::ONE,
+            coefficient: Q3232::ONE,
+        });
+        match evaluate_cost(&m, &BTreeMap::new()) {
+            Err(CostEvalError::MissingParameter { parameter, .. }) => {
+                assert_eq!(parameter, "ghost");
+            }
+            other => panic!("expected MissingParameter, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/beast-primitives/src/effect.rs
+++ b/crates/beast-primitives/src/effect.rs
@@ -1,0 +1,37 @@
+//! Runtime primitive emission.
+//!
+//! [`PrimitiveEffect`] is the per-tick record emitted by the phenotype
+//! interpreter (Sprint 4) and consumed by the Chronicler when it clusters
+//! signatures into labelled abilities.
+//!
+//! Only the shape is defined here. Sprint 2 needs the type so downstream
+//! crates can compile against it, but the interpreter that produces effects
+//! is out of scope for this sprint.
+
+use std::collections::BTreeMap;
+
+use beast_core::{EntityId, Q3232};
+
+use crate::manifest::Provenance;
+
+/// A single primitive emission.
+///
+/// `primitive_id` must correspond to a manifest registered in the
+/// [`crate::PrimitiveRegistry`]. `parameters` uses a [`BTreeMap`] so
+/// iteration and hashing are order-stable — a prerequisite for the
+/// determinism invariant when effect streams are hashed into per-tick state
+/// digests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimitiveEffect {
+    /// Primitive manifest id.
+    pub primitive_id: String,
+    /// Channel ids that composed to produce this emission.
+    pub source_channels: Vec<String>,
+    /// Parameter values, keyed by parameter name.
+    pub parameters: BTreeMap<String, Q3232>,
+    /// Entity emitting the effect.
+    pub emitter: EntityId,
+    /// Origin of the primitive (propagated from the manifest so downstream
+    /// auditing can trace effects to their mod / genesis origin).
+    pub provenance: Provenance,
+}

--- a/crates/beast-primitives/src/lib.rs
+++ b/crates/beast-primitives/src/lib.rs
@@ -1,0 +1,9 @@
+//! Beast Evolution Game — Layer 1 primitive effect registry.
+//!
+//! Scaffolded empty at the start of Sprint S2; populated by subsequent
+//! commits with the manifest loader (2.2) and the registry + cost evaluator
+//! (2.4).
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]

--- a/crates/beast-primitives/src/lib.rs
+++ b/crates/beast-primitives/src/lib.rs
@@ -1,19 +1,43 @@
 //! Beast Evolution Game — Layer 1 primitive effect registry.
 //!
-//! Sprint S2 populates this crate story-by-story. This commit lands the
-//! manifest loader (2.2); the registry and cost evaluator (2.4) follow.
+//! Primitives are the atomic vocabulary that the phenotype interpreter will
+//! emit to the world. They are never named abilities in themselves
+//! ("echolocation", "venom"); those labels are assigned post-hoc by the
+//! Chronicler over recurring primitive clusters — see
+//! `documentation/INVARIANTS.md` §2 (Mechanics-Label Separation).
+//!
+//! This crate mirrors `beast-channels` in shape:
+//!
+//! * [`manifest`] holds the strongly typed representation of a primitive
+//!   manifest, loaded via the two-stage (JSON Schema + semantic) validator in
+//!   [`schema`].
+//! * [`registry`] is a deterministic [`BTreeMap`]-backed index keyed by id
+//!   with a secondary index by [`PrimitiveCategory`].
+//! * [`cost`] evaluates a manifest's cost function deterministically over
+//!   Q32.32 parameter values. Because cost formulas use fractional power-law
+//!   scaling (e.g. `force^1.5`), this module also provides a small
+//!   fixed-point `exp`/`ln` pair used to implement `pow`.
+//!
+//! [`BTreeMap`]: std::collections::BTreeMap
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
 pub mod category;
+pub mod cost;
+pub mod effect;
 pub mod manifest;
+pub(crate) mod math;
+pub mod registry;
 pub mod schema;
 
 pub use category::{Modality, PrimitiveCategory};
+pub use cost::{evaluate_cost, CostEvalError};
+pub use effect::PrimitiveEffect;
 pub use manifest::{
     CompatibilityEntry, CostFunction, ObservableSignature, ParameterScaling, ParameterSpec,
     ParameterType, PrimitiveManifest, Provenance,
 };
+pub use registry::{PrimitiveRegistry, RegistryError};
 pub use schema::{PrimitiveLoadError, PRIMITIVE_MANIFEST_SCHEMA};

--- a/crates/beast-primitives/src/lib.rs
+++ b/crates/beast-primitives/src/lib.rs
@@ -1,9 +1,19 @@
 //! Beast Evolution Game — Layer 1 primitive effect registry.
 //!
-//! Scaffolded empty at the start of Sprint S2; populated by subsequent
-//! commits with the manifest loader (2.2) and the registry + cost evaluator
-//! (2.4).
+//! Sprint S2 populates this crate story-by-story. This commit lands the
+//! manifest loader (2.2); the registry and cost evaluator (2.4) follow.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
+
+pub mod category;
+pub mod manifest;
+pub mod schema;
+
+pub use category::{Modality, PrimitiveCategory};
+pub use manifest::{
+    CompatibilityEntry, CostFunction, ObservableSignature, ParameterScaling, ParameterSpec,
+    ParameterType, PrimitiveManifest, Provenance,
+};
+pub use schema::{PrimitiveLoadError, PRIMITIVE_MANIFEST_SCHEMA};

--- a/crates/beast-primitives/src/manifest.rs
+++ b/crates/beast-primitives/src/manifest.rs
@@ -1,0 +1,420 @@
+//! Strongly typed primitive-manifest representation.
+//!
+//! Counterpart to `documentation/schemas/primitive_manifest.schema.json`.
+//! Follows the same two-stage load pattern as [`beast_channels::manifest`]:
+//! JSON Schema validation first, typed deserialization + semantic checks
+//! second.
+
+use std::collections::BTreeMap;
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+use crate::category::{Modality, PrimitiveCategory};
+use crate::schema::PrimitiveLoadError;
+
+/// Origin of a primitive manifest. Same shape as
+/// [`beast_channels::Provenance`] to keep mod registration symmetric.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Provenance {
+    /// Canonical core primitive.
+    Core,
+    /// Registered by a mod with the given snake_case id.
+    Mod(String),
+    /// Evolved from a parent primitive at generation `n`.
+    Genesis {
+        /// Parent primitive id.
+        parent: String,
+        /// Generation at which the derivation occurred.
+        generation: u64,
+    },
+}
+
+impl Provenance {
+    pub(crate) fn parse(raw: &str) -> Result<Self, PrimitiveLoadError> {
+        if raw == "core" {
+            return Ok(Self::Core);
+        }
+        if let Some(rest) = raw.strip_prefix("mod:") {
+            return Ok(Self::Mod(rest.to_owned()));
+        }
+        if let Some(rest) = raw.strip_prefix("genesis:") {
+            let mut parts = rest.rsplitn(2, ':');
+            let gen_str = parts
+                .next()
+                .ok_or_else(|| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
+            let parent = parts
+                .next()
+                .ok_or_else(|| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
+            let generation: u64 = gen_str
+                .parse()
+                .map_err(|_| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
+            return Ok(Self::Genesis {
+                parent: parent.to_owned(),
+                generation,
+            });
+        }
+        Err(PrimitiveLoadError::InvalidProvenance(raw.to_owned()))
+    }
+}
+
+/// Parameter value type in a primitive's input schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParameterType {
+    /// Continuous numeric value.
+    Number,
+    /// Discrete integer value.
+    Integer,
+    /// Categorical string.
+    String,
+    /// Binary switch.
+    Boolean,
+}
+
+/// Default value stored alongside a parameter spec. Kept as-is from JSON so
+/// callers can apply the default into their own domain types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParameterDefault {
+    /// Default for a `number`-typed parameter, already converted to Q32.32.
+    Number(Q3232),
+    /// Default for an `integer`-typed parameter.
+    Integer(i64),
+    /// Default for a `string`-typed parameter.
+    String(String),
+    /// Default for a `boolean`-typed parameter.
+    Boolean(bool),
+}
+
+/// Specification for a single input parameter on a primitive.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParameterSpec {
+    /// Value type (number / integer / string / boolean).
+    pub ty: ParameterType,
+    /// Optional numeric range `[min, max]`. Only meaningful when
+    /// `ty ∈ {Number, Integer}`.
+    pub range: Option<(Q3232, Q3232)>,
+    /// Optional physical units (free-form string).
+    pub units: Option<String>,
+    /// Optional default value.
+    pub default: Option<ParameterDefault>,
+}
+
+/// A cost function's per-parameter power-law scaling term.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParameterScaling {
+    /// Name of the parameter driving this term (must exist in `parameter_schema`).
+    pub parameter: String,
+    /// Power-law exponent (may be negative, fractional, etc.).
+    pub exponent: Q3232,
+    /// Multiplicative coefficient (non-negative by schema).
+    pub coefficient: Q3232,
+}
+
+/// Metabolic cost function for a primitive.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CostFunction {
+    /// Base cost incurred each emission, independent of parameters.
+    pub base_metabolic_cost: Q3232,
+    /// Zero or more parameter-driven scaling terms, summed to the base.
+    pub parameter_scaling: Vec<ParameterScaling>,
+}
+
+/// Declaration of which channel (by family or specific id) can emit this
+/// primitive. The discriminated union from the schema is preserved here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompatibilityEntry {
+    /// Compatible with all channels in a family.
+    ChannelFamily(beast_channels::ChannelFamily),
+    /// Compatible with one specific channel id.
+    ChannelId(String),
+}
+
+/// How a primitive emission appears to other organisms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservableSignature {
+    /// Sense modality.
+    pub modality: Modality,
+    /// Maximum detection distance (metres). Zero = non-propagating / local.
+    pub detection_range_m: Q3232,
+    /// Signature string used by the Chronicler for label inference.
+    pub pattern_key: String,
+}
+
+/// In-memory representation of a primitive manifest.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrimitiveManifest {
+    /// Unique snake_case identifier.
+    pub id: String,
+    /// Functional category.
+    pub category: PrimitiveCategory,
+    /// Human-readable description.
+    pub description: String,
+    /// Parameter schema in declaration order.
+    ///
+    /// We use [`BTreeMap`] rather than a `HashMap` so iteration is
+    /// deterministic — callers building evaluation pipelines get a stable
+    /// order across runs.
+    pub parameter_schema: BTreeMap<String, ParameterSpec>,
+    /// Channels (by family or by id) that can emit this primitive.
+    pub composition_compatibility: Vec<CompatibilityEntry>,
+    /// Cost function.
+    pub cost_function: CostFunction,
+    /// Observable signature.
+    pub observable_signature: ObservableSignature,
+    /// Origin of this primitive.
+    pub provenance: Provenance,
+}
+
+impl PrimitiveManifest {
+    /// Load and fully validate a primitive manifest from its JSON source.
+    ///
+    /// ```
+    /// use beast_primitives::PrimitiveManifest;
+    /// let json = r#"{
+    ///   "id": "example_primitive",
+    ///   "category": "signal_emission",
+    ///   "description": "A minimal primitive used in documentation tests.",
+    ///   "parameter_schema": {
+    ///     "frequency_hz": { "type": "number", "range": { "min": 20, "max": 1000 }, "units": "Hz", "default": 100 }
+    ///   },
+    ///   "composition_compatibility": [ { "channel_family": "motor" } ],
+    ///   "cost_function": { "base_metabolic_cost": 1.0 },
+    ///   "observable_signature": {
+    ///     "modality": "acoustic",
+    ///     "detection_range_m": 10,
+    ///     "pattern_key": "example_v1"
+    ///   },
+    ///   "provenance": "core"
+    /// }"#;
+    /// let manifest = PrimitiveManifest::from_json_str(json).unwrap();
+    /// assert_eq!(manifest.id, "example_primitive");
+    /// ```
+    pub fn from_json_str(source: &str) -> Result<Self, PrimitiveLoadError> {
+        crate::schema::load_primitive_manifest(source)
+    }
+
+    pub(crate) fn from_validated_value(
+        value: &serde_json::Value,
+    ) -> Result<Self, PrimitiveLoadError> {
+        let raw: RawPrimitiveManifest = serde_json::from_value(value.clone())
+            .map_err(|e| PrimitiveLoadError::BadShape(e.to_string()))?;
+        raw.into_manifest()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Raw serde-facing mirror of the schema.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawPrimitiveManifest {
+    id: String,
+    category: PrimitiveCategory,
+    description: String,
+    parameter_schema: BTreeMap<String, RawParameterSpec>,
+    composition_compatibility: Vec<RawCompatibilityEntry>,
+    cost_function: RawCostFunction,
+    observable_signature: RawObservableSignature,
+    provenance: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawParameterSpec {
+    #[serde(rename = "type")]
+    ty: ParameterType,
+    #[serde(default)]
+    range: Option<RawRange>,
+    #[serde(default)]
+    units: Option<String>,
+    #[serde(default)]
+    default: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRange {
+    min: f64,
+    max: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawCompatibilityEntry {
+    Family {
+        channel_family: beast_channels::ChannelFamily,
+    },
+    Id {
+        channel_id: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCostFunction {
+    base_metabolic_cost: f64,
+    #[serde(default)]
+    parameter_scaling: Vec<RawParameterScaling>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawParameterScaling {
+    parameter: String,
+    exponent: f64,
+    coefficient: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawObservableSignature {
+    modality: Modality,
+    detection_range_m: f64,
+    pattern_key: String,
+}
+
+impl RawPrimitiveManifest {
+    fn into_manifest(self) -> Result<PrimitiveManifest, PrimitiveLoadError> {
+        // --- parameter schema ---
+        let mut parameter_schema: BTreeMap<String, ParameterSpec> = BTreeMap::new();
+        for (name, raw) in self.parameter_schema {
+            let range = if let Some(r) = raw.range {
+                if r.min > r.max {
+                    return Err(PrimitiveLoadError::InvalidRange {
+                        primitive_id: self.id.clone(),
+                        reason: format!(
+                            "parameter `{name}` range.min ({}) must be <= range.max ({})",
+                            r.min, r.max
+                        ),
+                    });
+                }
+                Some((Q3232::from_num(r.min), Q3232::from_num(r.max)))
+            } else {
+                None
+            };
+
+            let default = if let Some(v) = raw.default {
+                Some(parse_default(&name, &self.id, raw.ty, &v)?)
+            } else {
+                None
+            };
+
+            parameter_schema.insert(
+                name,
+                ParameterSpec {
+                    ty: raw.ty,
+                    range,
+                    units: raw.units,
+                    default,
+                },
+            );
+        }
+
+        // --- composition compatibility ---
+        let composition_compatibility: Vec<CompatibilityEntry> = self
+            .composition_compatibility
+            .into_iter()
+            .map(|e| match e {
+                RawCompatibilityEntry::Family { channel_family } => {
+                    CompatibilityEntry::ChannelFamily(channel_family)
+                }
+                RawCompatibilityEntry::Id { channel_id } => {
+                    CompatibilityEntry::ChannelId(channel_id)
+                }
+            })
+            .collect();
+
+        // --- cost function ---
+        let cost_function = CostFunction {
+            base_metabolic_cost: Q3232::from_num(self.cost_function.base_metabolic_cost),
+            parameter_scaling: self
+                .cost_function
+                .parameter_scaling
+                .into_iter()
+                .map(|s| {
+                    if !parameter_schema.contains_key(&s.parameter) {
+                        return Err(PrimitiveLoadError::UnknownScalingParameter {
+                            primitive_id: self.id.clone(),
+                            parameter: s.parameter.clone(),
+                        });
+                    }
+                    Ok(ParameterScaling {
+                        parameter: s.parameter,
+                        exponent: Q3232::from_num(s.exponent),
+                        coefficient: Q3232::from_num(s.coefficient),
+                    })
+                })
+                .collect::<Result<_, _>>()?,
+        };
+
+        // --- observable signature ---
+        let observable_signature = ObservableSignature {
+            modality: self.observable_signature.modality,
+            detection_range_m: Q3232::from_num(self.observable_signature.detection_range_m),
+            pattern_key: self.observable_signature.pattern_key,
+        };
+
+        // --- provenance ---
+        let provenance = Provenance::parse(&self.provenance)?;
+
+        Ok(PrimitiveManifest {
+            id: self.id,
+            category: self.category,
+            description: self.description,
+            parameter_schema,
+            composition_compatibility,
+            cost_function,
+            observable_signature,
+            provenance,
+        })
+    }
+}
+
+fn parse_default(
+    param_name: &str,
+    primitive_id: &str,
+    ty: ParameterType,
+    value: &serde_json::Value,
+) -> Result<ParameterDefault, PrimitiveLoadError> {
+    let mismatch = || PrimitiveLoadError::InvalidDefault {
+        primitive_id: primitive_id.to_owned(),
+        parameter: param_name.to_owned(),
+        reason: format!("default value {value} does not match declared type {ty:?}"),
+    };
+    match ty {
+        ParameterType::Number => {
+            let f = value.as_f64().ok_or_else(mismatch)?;
+            Ok(ParameterDefault::Number(Q3232::from_num(f)))
+        }
+        ParameterType::Integer => {
+            let i = value.as_i64().ok_or_else(mismatch)?;
+            Ok(ParameterDefault::Integer(i))
+        }
+        ParameterType::String => {
+            let s = value.as_str().ok_or_else(mismatch)?;
+            Ok(ParameterDefault::String(s.to_owned()))
+        }
+        ParameterType::Boolean => {
+            let b = value.as_bool().ok_or_else(mismatch)?;
+            Ok(ParameterDefault::Boolean(b))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_parses_all_shapes() {
+        assert_eq!(Provenance::parse("core").unwrap(), Provenance::Core);
+        assert_eq!(
+            Provenance::parse("mod:my_mod").unwrap(),
+            Provenance::Mod("my_mod".to_owned())
+        );
+        assert_eq!(
+            Provenance::parse("genesis:parent:12").unwrap(),
+            Provenance::Genesis {
+                parent: "parent".to_owned(),
+                generation: 12
+            }
+        );
+        assert!(Provenance::parse("unknown").is_err());
+    }
+}

--- a/crates/beast-primitives/src/math.rs
+++ b/crates/beast-primitives/src/math.rs
@@ -125,7 +125,10 @@ pub(crate) fn q_exp(x: Q3232) -> Q3232 {
     // above bounds `|x| <= 23`, which fits in i8 let alone i32 — no silent
     // truncation from the Q3232 → i32 conversion.
     let k: i32 = x.to_num::<i32>();
-    debug_assert!((-23..=22).contains(&k), "q_exp cut-off guard violated: k={k}");
+    debug_assert!(
+        (-23..=22).contains(&k),
+        "q_exp cut-off guard violated: k={k}"
+    );
     let f = x - Q3232::from(k);
 
     // e^f via Taylor: 1 + f + f²/2! + f³/3! + ... (converges fast, |f| < 1).

--- a/crates/beast-primitives/src/math.rs
+++ b/crates/beast-primitives/src/math.rs
@@ -1,0 +1,250 @@
+//! Q3232 fixed-point exponent / logarithm helpers used by the cost evaluator.
+//!
+//! These are kept private to `beast-primitives` for now. The deterministic
+//! interpreter (Sprint 4) will almost certainly want the same helpers; when
+//! that happens we should promote them to `beast-core::math`. Until then we
+//! keep the surface small and well-tested in isolation.
+//!
+//! The algorithms:
+//!
+//! * [`q_ln`] — transforms `x > 0` into `2^k * m` with `m ∈ [1, 2)`, then uses
+//!   the `artanh` series:
+//!   `ln(m) = 2·(z + z³/3 + z⁵/5 + …)` where `z = (m - 1) / (m + 1)`.
+//!   `|z| < 1/3` on `[1, 2)`, so 16 odd-terms are more than enough for Q32.32.
+//! * [`q_exp`] — splits `x` into `k + f` with `k = trunc(x)` and `f ∈ (-1, 1)`,
+//!   computes `e^f` via the Taylor series (20 terms), and then multiplies by
+//!   `e^k` using repeated multiplication by a pre-computed constant `e`.
+//! * [`q_pow`] — `base^exp = e^(exp · ln(base))` for positive `base`; integer
+//!   exponents on non-positive bases are handled directly.
+//!
+//! Everything operates on saturating Q32.32 arithmetic, so out-of-range
+//! results clamp instead of panicking. This is consistent with the crate's
+//! determinism invariant: given the same inputs, the output is identical
+//! across platforms.
+
+use beast_core::Q3232;
+use fixed::types::I32F32;
+
+/// `ln(2)` to Q32.32 precision.
+fn ln2() -> Q3232 {
+    Q3232::from_num(core::f64::consts::LN_2)
+}
+
+/// Euler's number `e` to Q32.32 precision.
+fn e() -> Q3232 {
+    Q3232::from_num(core::f64::consts::E)
+}
+
+/// Natural logarithm on Q32.32.
+///
+/// Returns `None` for `x <= 0` (mathematically undefined).
+pub(crate) fn q_ln(x: Q3232) -> Option<Q3232> {
+    if x <= Q3232::ZERO {
+        return None;
+    }
+    // Decompose x = 2^k * m, m in [1, 2).
+    let inner: I32F32 = x.into_inner();
+    let k = inner.int_log2();
+
+    // Compute m_bits = x / 2^k. For I32F32 the raw bit pattern is an i64 of
+    // the value scaled by 2^32, so dividing the value by 2^k is equivalent to
+    // dividing the raw bits by 2^k (sign-extended arithmetic shift).
+    let m_bits = if k >= 0 {
+        inner.to_bits() >> k
+    } else {
+        // k is negative (x < 1) — multiply by 2^(-k). Arithmetic left shift
+        // is safe because we just proved the original value fits, and the
+        // shift amount is bounded by int_log2's range.
+        inner.to_bits() << (-k)
+    };
+    let m = Q3232::from_inner(I32F32::from_bits(m_bits));
+
+    // z = (m - 1) / (m + 1)
+    let z = (m - Q3232::ONE) / (m + Q3232::ONE);
+    let z2 = z * z;
+
+    // Sum of the odd-terms: z + z³/3 + z⁵/5 + ...
+    let mut sum = z;
+    let mut term = z;
+    let mut n: i32 = 3;
+    for _ in 0..16 {
+        term *= z2;
+        sum += term / Q3232::from(n);
+        n += 2;
+    }
+    let ln_m = Q3232::from(2_i32) * sum;
+
+    // ln(x) = k * ln(2) + ln(m)
+    Some(Q3232::from(k) * ln2() + ln_m)
+}
+
+/// Natural exponential on Q32.32 with saturating behaviour outside the
+/// representable range.
+pub(crate) fn q_exp(x: Q3232) -> Q3232 {
+    // Q3232 maxes at ~2.15e9; e^22 ~= 3.58e9 already overflows. Use a
+    // conservative cut-off to avoid pointless iteration and give a stable
+    // saturated answer on the edge.
+    if x > Q3232::from(22_i32) {
+        return Q3232::MAX;
+    }
+    if x < Q3232::from(-22_i32) {
+        return Q3232::ZERO;
+    }
+
+    // Split into integer part k and fractional part f in (-1, 1).
+    let k: i64 = x.to_num::<i64>();
+    let f = x - Q3232::from(k as i32);
+
+    // e^f via Taylor: 1 + f + f²/2! + f³/3! + ... (converges fast, |f| < 1).
+    let mut sum = Q3232::ONE;
+    let mut term = Q3232::ONE;
+    for n in 1_i32..=20 {
+        term = term * f / Q3232::from(n);
+        sum += term;
+    }
+
+    // Multiply by e^k via repeated mul/div. k is small (|k| <= 22 from the
+    // cut-off), so the loop is bounded and cheap.
+    let base = e();
+    let mut result = sum;
+    if k > 0 {
+        for _ in 0..k {
+            result *= base;
+        }
+    } else if k < 0 {
+        for _ in 0..(-k) {
+            result /= base;
+        }
+    }
+    result
+}
+
+/// `base^exp` on Q32.32.
+///
+/// Returns `None` when the result is mathematically undefined (e.g. negative
+/// base with a non-integer exponent, or `0^0` which is left to the caller to
+/// define). Zero-base with positive exponent returns `Some(0)`.
+pub(crate) fn q_pow(base: Q3232, exp: Q3232) -> Option<Q3232> {
+    if base > Q3232::ZERO {
+        return Some(q_exp(exp * q_ln(base)?));
+    }
+    if base == Q3232::ZERO {
+        if exp > Q3232::ZERO {
+            return Some(Q3232::ZERO);
+        }
+        if exp.is_zero() {
+            // 0^0 is contested; cost evaluation treats this as 1 (no-op term).
+            return Some(Q3232::ONE);
+        }
+        return None;
+    }
+    // base < 0: only integer exponents are real-valued. For cost evaluation
+    // we don't expect negative parameter values so this branch is largely
+    // defensive.
+    let rounded: i64 = exp.to_num::<i64>();
+    if Q3232::from(rounded as i32) != exp {
+        return None;
+    }
+    let mut result = Q3232::ONE;
+    let base_abs = -base;
+    let iters = rounded.unsigned_abs();
+    for _ in 0..iters {
+        result *= base_abs;
+    }
+    if rounded % 2 != 0 {
+        result = -result;
+    }
+    if rounded < 0 {
+        result = Q3232::ONE / result;
+    }
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(a: Q3232, b: Q3232, tol: f64) -> bool {
+        let diff: f64 = (a - b).saturating_abs().to_num::<f64>();
+        diff <= tol
+    }
+
+    #[test]
+    fn ln_of_one_is_zero() {
+        let result = q_ln(Q3232::ONE).unwrap();
+        assert!(close(result, Q3232::ZERO, 1e-6));
+    }
+
+    #[test]
+    fn ln_of_e_is_one() {
+        let result = q_ln(e()).unwrap();
+        assert!(close(result, Q3232::ONE, 1e-5));
+    }
+
+    #[test]
+    fn ln_rejects_non_positive() {
+        assert!(q_ln(Q3232::ZERO).is_none());
+        assert!(q_ln(-Q3232::ONE).is_none());
+    }
+
+    #[test]
+    fn exp_of_zero_is_one() {
+        let result = q_exp(Q3232::ZERO);
+        assert!(close(result, Q3232::ONE, 1e-6));
+    }
+
+    #[test]
+    fn exp_of_one_is_e() {
+        let result = q_exp(Q3232::ONE);
+        assert!(close(result, e(), 1e-5));
+    }
+
+    #[test]
+    fn pow_integer_exponents() {
+        let two = Q3232::from(2_i32);
+        let four = Q3232::from(4_i32);
+        // 2^2 = 4
+        assert!(close(q_pow(two, two).unwrap(), four, 1e-5));
+        // 2^0 = 1
+        assert!(close(q_pow(two, Q3232::ZERO).unwrap(), Q3232::ONE, 1e-5));
+    }
+
+    #[test]
+    fn pow_half_integer_exponents() {
+        let four = Q3232::from(4_i32);
+        let half = Q3232::from_num(0.5_f64);
+        // 4^0.5 = 2
+        assert!(close(q_pow(four, half).unwrap(), Q3232::from(2_i32), 1e-4));
+    }
+
+    #[test]
+    fn pow_fractional_exponents() {
+        let two = Q3232::from(2_i32);
+        let exp = Q3232::from_num(1.5_f64);
+        // 2^1.5 ≈ 2.828427
+        let expected = Q3232::from_num(2.828_427_f64);
+        assert!(close(q_pow(two, exp).unwrap(), expected, 1e-3));
+    }
+
+    #[test]
+    fn pow_negative_exponent() {
+        let two = Q3232::from(2_i32);
+        let neg_two = Q3232::from(-2_i32);
+        // 2^-2 = 0.25
+        assert!(close(
+            q_pow(two, neg_two).unwrap(),
+            Q3232::from_num(0.25_f64),
+            1e-5
+        ));
+    }
+
+    #[test]
+    fn pow_is_deterministic() {
+        let base = Q3232::from_num(7.5_f64);
+        let exp = Q3232::from_num(0.7_f64);
+        let a = q_pow(base, exp).unwrap();
+        for _ in 0..10 {
+            assert_eq!(q_pow(base, exp).unwrap(), a);
+        }
+    }
+}

--- a/crates/beast-primitives/src/math.rs
+++ b/crates/beast-primitives/src/math.rs
@@ -21,6 +21,31 @@
 //! results clamp instead of panicking. This is consistent with the crate's
 //! determinism invariant: given the same inputs, the output is identical
 //! across platforms.
+//!
+//! ## Cut-offs in [`q_exp`]
+//!
+//! Q32.32 ranges over roughly `[-2.15e9, 2.15e9)` with ULP `2^-32 ≈ 2.33e-10`.
+//! That sets two fast-path cut-offs:
+//!
+//! * `x > 22` — `e^21 ≈ 1.32e9` still fits; `e^22 ≈ 3.58e9` already
+//!   overflows. The cut-off short-circuits to `Q3232::MAX` so the Taylor
+//!   path is never asked to produce an out-of-range result.
+//! * `x < -23` — `e^-23 ≈ 1.02e-10 < ULP`, so the true value is below
+//!   Q32.32 precision and snapping to `Q3232::ZERO` is exact.
+//!
+//! The lower cut-off in the previous revision of this module was `x < -22`;
+//! the reviewer pointed out that `e^-22 ≈ 2.74e-10` is one ULP above ULP and
+//! therefore *representable*. It turns out to be representable but **not
+//! computable** by the current algorithm: `e^f · e^k` is realised as `e^f /
+//! e · e / e · …` (22 saturating divisions for `k = -22`), and the
+//! accumulated rounding eats the final bits, so the computed result snaps
+//! to zero around `x ≈ -22` in practice. Tightening the cut-off to `-23`
+//! costs nothing (those values would have computed to zero anyway) and
+//! removes a one-ULP regime where the cut-off was visibly more aggressive
+//! than the maths demanded. Actually preserving values near `x = -22`
+//! would require a faster algorithm (precomputed `e^-1, e^-2, e^-4, …` and
+//! binary decomposition of `k`) — a sensible upgrade when this helper is
+//! promoted to `beast-core` but out of scope for Sprint 2.
 
 use beast_core::Q3232;
 use fixed::types::I32F32;
@@ -44,6 +69,10 @@ pub(crate) fn q_ln(x: Q3232) -> Option<Q3232> {
     }
     // Decompose x = 2^k * m, m in [1, 2).
     let inner: I32F32 = x.into_inner();
+    // `int_log2` panics on non-positive input; the guard above guarantees
+    // `inner > 0`, so this call is infallible. Tying the two together here
+    // so a future refactor can't silently drop the guard and reinstate a
+    // panic path.
     let k = inner.int_log2();
 
     // Compute m_bits = x / 2^k. For I32F32 the raw bit pattern is an i64 of
@@ -80,20 +109,24 @@ pub(crate) fn q_ln(x: Q3232) -> Option<Q3232> {
 
 /// Natural exponential on Q32.32 with saturating behaviour outside the
 /// representable range.
+///
+/// Cut-offs (see module docs for derivation):
+/// * `x > 22` → [`Q3232::MAX`] (would overflow)
+/// * `x < -23` → [`Q3232::ZERO`] (below Q3232 ULP, zero is exact)
 pub(crate) fn q_exp(x: Q3232) -> Q3232 {
-    // Q3232 maxes at ~2.15e9; e^22 ~= 3.58e9 already overflows. Use a
-    // conservative cut-off to avoid pointless iteration and give a stable
-    // saturated answer on the edge.
     if x > Q3232::from(22_i32) {
         return Q3232::MAX;
     }
-    if x < Q3232::from(-22_i32) {
+    if x < Q3232::from(-23_i32) {
         return Q3232::ZERO;
     }
 
-    // Split into integer part k and fractional part f in (-1, 1).
-    let k: i64 = x.to_num::<i64>();
-    let f = x - Q3232::from(k as i32);
+    // Split into integer part k and fractional part f in (-1, 1). The cut-off
+    // above bounds `|x| <= 23`, which fits in i8 let alone i32 — no silent
+    // truncation from the Q3232 → i32 conversion.
+    let k: i32 = x.to_num::<i32>();
+    debug_assert!((-23..=22).contains(&k), "q_exp cut-off guard violated: k={k}");
+    let f = x - Q3232::from(k);
 
     // e^f via Taylor: 1 + f + f²/2! + f³/3! + ... (converges fast, |f| < 1).
     let mut sum = Q3232::ONE;
@@ -103,7 +136,7 @@ pub(crate) fn q_exp(x: Q3232) -> Q3232 {
         sum += term;
     }
 
-    // Multiply by e^k via repeated mul/div. k is small (|k| <= 22 from the
+    // Multiply by e^k via repeated mul/div. k is small (|k| <= 23 from the
     // cut-off), so the loop is bounded and cheap.
     let base = e();
     let mut result = sum;
@@ -123,7 +156,10 @@ pub(crate) fn q_exp(x: Q3232) -> Q3232 {
 ///
 /// Returns `None` when the result is mathematically undefined (e.g. negative
 /// base with a non-integer exponent, or `0^0` which is left to the caller to
-/// define). Zero-base with positive exponent returns `Some(0)`.
+/// define) *or* when the magnitude underflows the Q32.32 grid during the
+/// negative-base integer-exponent loop below, which would otherwise silently
+/// reappear as [`Q3232::MAX`] through saturating reciprocation. Zero-base
+/// with positive exponent returns `Some(0)`.
 pub(crate) fn q_pow(base: Q3232, exp: Q3232) -> Option<Q3232> {
     if base > Q3232::ZERO {
         return Some(q_exp(exp * q_ln(base)?));
@@ -155,6 +191,15 @@ pub(crate) fn q_pow(base: Q3232, exp: Q3232) -> Option<Q3232> {
         result = -result;
     }
     if rounded < 0 {
+        // If the repeated-multiply loop saturated `result` to zero (e.g. a
+        // base_abs well below 1 with a large `|rounded|`), the subsequent
+        // 1/result would saturate to ±Q3232::MAX via saturating division and
+        // silently masquerade as a real value. Surface the underflow as
+        // `None` so callers — like the cost evaluator — can report it
+        // instead of propagating a bogus finite number.
+        if result == Q3232::ZERO {
+            return None;
+        }
         result = Q3232::ONE / result;
     }
     Some(result)
@@ -246,5 +291,34 @@ mod tests {
         for _ in 0..10 {
             assert_eq!(q_pow(base, exp).unwrap(), a);
         }
+    }
+
+    #[test]
+    fn exp_preserves_values_well_above_ulp() {
+        // e^-18 ≈ 1.52e-8 ≈ 65 ULP — comfortably inside what the iterative
+        // algorithm can resolve after accumulated rounding. Locks in that
+        // the lower cut-off hasn't crept into the regime the algorithm
+        // actually supports.
+        let result = q_exp(Q3232::from(-18_i32));
+        assert!(
+            result > Q3232::ZERO,
+            "e^-18 should be representable and computable, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn exp_snaps_well_below_ulp_to_zero() {
+        // e^-24 ≈ 3.78e-11 is well below Q3232 ULP; returning zero is exact.
+        assert_eq!(q_exp(Q3232::from(-24_i32)), Q3232::ZERO);
+    }
+
+    #[test]
+    fn pow_negative_base_underflow_reported_not_faked() {
+        // base_abs = 0.1, rounded = -100: the repeated-multiply loop
+        // saturates result to ZERO, then 1/ZERO would saturate to MAX.
+        // Instead we must surface None.
+        let base = Q3232::from_num(-0.1_f64);
+        let exp = Q3232::from(-100_i32);
+        assert_eq!(q_pow(base, exp), None);
     }
 }

--- a/crates/beast-primitives/src/registry.rs
+++ b/crates/beast-primitives/src/registry.rs
@@ -1,0 +1,219 @@
+//! Primitive registry — single deterministic index over primitive manifests.
+//!
+//! Like [`beast_channels::ChannelRegistry`], the primitive registry is
+//! [`BTreeMap`]-backed so iteration order is stable across runs. Primitives
+//! are indexed primarily by id and secondarily by [`PrimitiveCategory`].
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+use crate::category::PrimitiveCategory;
+use crate::manifest::PrimitiveManifest;
+
+/// Errors produced by registry mutations.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// A primitive with the same id is already registered.
+    #[error("duplicate primitive id: {0}")]
+    DuplicateId(String),
+
+    /// A `composition_compatibility.channel_id` entry referenced a channel
+    /// that is not registered in the supplied channel registry.
+    #[error(
+        "primitive `{source_id}` references unknown channel `{target}` in composition_compatibility"
+    )]
+    UnknownChannel {
+        /// The owning primitive.
+        source_id: String,
+        /// The missing channel id.
+        target: String,
+    },
+}
+
+/// Deterministic in-memory index of primitive manifests.
+#[derive(Debug, Clone, Default)]
+pub struct PrimitiveRegistry {
+    by_id: BTreeMap<String, PrimitiveManifest>,
+    by_category: BTreeMap<PrimitiveCategory, BTreeSet<String>>,
+}
+
+impl PrimitiveRegistry {
+    /// Empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a manifest; fail if the id is already present.
+    pub fn register(&mut self, manifest: PrimitiveManifest) -> Result<(), RegistryError> {
+        if self.by_id.contains_key(&manifest.id) {
+            return Err(RegistryError::DuplicateId(manifest.id));
+        }
+        self.by_category
+            .entry(manifest.category)
+            .or_default()
+            .insert(manifest.id.clone());
+        self.by_id.insert(manifest.id.clone(), manifest);
+        Ok(())
+    }
+
+    /// Number of registered primitives.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Whether no primitives are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Whether the given id is registered.
+    #[must_use]
+    pub fn contains(&self, id: &str) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Look up a manifest by id.
+    #[must_use]
+    pub fn get(&self, id: &str) -> Option<&PrimitiveManifest> {
+        self.by_id.get(id)
+    }
+
+    /// Iterate `(id, manifest)` pairs in sorted id order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &PrimitiveManifest)> {
+        self.by_id.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Iterate primitive ids in sorted order.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.by_id.keys().map(String::as_str)
+    }
+
+    /// All primitive ids in the given category, in sorted order.
+    pub fn ids_by_category(&self, category: PrimitiveCategory) -> impl Iterator<Item = &str> {
+        self.by_category
+            .get(&category)
+            .into_iter()
+            .flat_map(|set| set.iter().map(String::as_str))
+    }
+
+    /// All primitives in the given category, in sorted id order.
+    pub fn by_category(
+        &self,
+        category: PrimitiveCategory,
+    ) -> impl Iterator<Item = &PrimitiveManifest> {
+        self.ids_by_category(category)
+            .filter_map(move |id| self.by_id.get(id))
+    }
+
+    /// Verify that every `composition_compatibility.channel_id` refers to a
+    /// channel present in `channels`.
+    ///
+    /// `ChannelFamily` entries always pass (families are a closed enum).
+    pub fn validate_channel_references(
+        &self,
+        channels: &beast_channels::ChannelRegistry,
+    ) -> Result<(), RegistryError> {
+        for (id, manifest) in &self.by_id {
+            for entry in &manifest.composition_compatibility {
+                if let crate::manifest::CompatibilityEntry::ChannelId(target) = entry {
+                    if !channels.contains(target) {
+                        return Err(RegistryError::UnknownChannel {
+                            source_id: id.clone(),
+                            target: target.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::category::{Modality, PrimitiveCategory};
+    use crate::manifest::{
+        CompatibilityEntry, CostFunction, ObservableSignature, PrimitiveManifest, Provenance,
+    };
+    use beast_core::Q3232;
+    use std::collections::BTreeMap;
+
+    fn fixture(id: &str, category: PrimitiveCategory) -> PrimitiveManifest {
+        PrimitiveManifest {
+            id: id.into(),
+            category,
+            description: "fixture".into(),
+            parameter_schema: BTreeMap::new(),
+            composition_compatibility: vec![CompatibilityEntry::ChannelFamily(
+                beast_channels::ChannelFamily::Motor,
+            )],
+            cost_function: CostFunction {
+                base_metabolic_cost: Q3232::ONE,
+                parameter_scaling: Vec::new(),
+            },
+            observable_signature: ObservableSignature {
+                modality: Modality::Behavioral,
+                detection_range_m: Q3232::ONE,
+                pattern_key: "fixture_v1".into(),
+            },
+            provenance: Provenance::Core,
+        }
+    }
+
+    #[test]
+    fn registration_is_unique() {
+        let mut reg = PrimitiveRegistry::new();
+        reg.register(fixture("a", PrimitiveCategory::ForceApplication))
+            .unwrap();
+        assert!(matches!(
+            reg.register(fixture("a", PrimitiveCategory::SignalEmission)),
+            Err(RegistryError::DuplicateId(_))
+        ));
+    }
+
+    #[test]
+    fn iteration_sorted_by_id() {
+        let mut reg = PrimitiveRegistry::new();
+        for id in ["gamma", "alpha", "beta"] {
+            reg.register(fixture(id, PrimitiveCategory::SignalEmission))
+                .unwrap();
+        }
+        let ids: Vec<_> = reg.ids().collect();
+        assert_eq!(ids, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn by_category_filter_correct() {
+        let mut reg = PrimitiveRegistry::new();
+        reg.register(fixture("a", PrimitiveCategory::SignalEmission))
+            .unwrap();
+        reg.register(fixture("b", PrimitiveCategory::ForceApplication))
+            .unwrap();
+        reg.register(fixture("c", PrimitiveCategory::SignalEmission))
+            .unwrap();
+        let ids: Vec<_> = reg
+            .ids_by_category(PrimitiveCategory::SignalEmission)
+            .collect();
+        assert_eq!(ids, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn unknown_channel_reference_rejected() {
+        let mut reg = PrimitiveRegistry::new();
+        let mut manifest = fixture("a", PrimitiveCategory::SignalEmission);
+        manifest
+            .composition_compatibility
+            .push(CompatibilityEntry::ChannelId("missing_channel".into()));
+        reg.register(manifest).unwrap();
+
+        let channels = beast_channels::ChannelRegistry::new();
+        assert!(matches!(
+            reg.validate_channel_references(&channels),
+            Err(RegistryError::UnknownChannel { .. })
+        ));
+    }
+}

--- a/crates/beast-primitives/src/schema.rs
+++ b/crates/beast-primitives/src/schema.rs
@@ -1,0 +1,217 @@
+//! JSON Schema validation for primitive manifests.
+//!
+//! Two-stage loader, matching `beast_channels::schema`:
+//!
+//! 1. Parse source as `serde_json::Value`, validate against the embedded
+//!    schema (failures flattened to path + message pairs).
+//! 2. Deserialize the validated value into [`PrimitiveManifest`] and run
+//!    semantic checks (range ordering, defaults matching declared types,
+//!    scaling parameters referring to known input parameters, provenance
+//!    parsing).
+
+use std::sync::OnceLock;
+
+use jsonschema::JSONSchema;
+use thiserror::Error;
+
+use crate::manifest::PrimitiveManifest;
+
+/// Raw JSON text of the primitive manifest schema. Embedded at compile time.
+pub const PRIMITIVE_MANIFEST_SCHEMA: &str =
+    include_str!("../../../documentation/schemas/primitive_manifest.schema.json");
+
+/// Errors produced while loading a primitive manifest.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum PrimitiveLoadError {
+    /// Input was not parsable as JSON.
+    #[error("manifest is not valid JSON: {0}")]
+    InvalidJson(String),
+
+    /// JSON Schema validation produced one or more errors.
+    #[error("manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    SchemaViolation(Vec<SchemaViolation>),
+
+    /// Deserialization into the typed manifest struct failed after schema
+    /// validation passed — indicates a schema/type drift bug.
+    #[error("manifest deserialized unexpectedly: {0}")]
+    BadShape(String),
+
+    /// `provenance` did not match one of the recognized shapes.
+    #[error("invalid provenance string: {0}")]
+    InvalidProvenance(String),
+
+    /// A numeric range was inverted.
+    #[error("primitive {primitive_id} has invalid range: {reason}")]
+    InvalidRange {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Human description of which range inverted.
+        reason: String,
+    },
+
+    /// A cost-function scaling term referenced a parameter that is not
+    /// declared in `parameter_schema`.
+    #[error("primitive {primitive_id} cost scaling references unknown parameter `{parameter}`")]
+    UnknownScalingParameter {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Offending parameter name.
+        parameter: String,
+    },
+
+    /// A parameter default value did not match the declared type.
+    #[error("primitive {primitive_id} parameter `{parameter}` has invalid default: {reason}")]
+    InvalidDefault {
+        /// Primitive id from the manifest.
+        primitive_id: String,
+        /// Offending parameter name.
+        parameter: String,
+        /// Human explanation.
+        reason: String,
+    },
+}
+
+/// A single JSON Schema validation error, flattened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaViolation {
+    /// JSON Pointer path to the failing node.
+    pub pointer: String,
+    /// Human-readable message from the validator.
+    pub message: String,
+}
+
+fn format_schema_errors(errors: &[SchemaViolation]) -> String {
+    let mut out = String::new();
+    for e in errors {
+        out.push_str("  at ");
+        out.push_str(if e.pointer.is_empty() {
+            "<root>"
+        } else {
+            e.pointer.as_str()
+        });
+        out.push_str(": ");
+        out.push_str(&e.message);
+        out.push('\n');
+    }
+    out
+}
+
+fn compiled_schema() -> &'static JSONSchema {
+    static SCHEMA: OnceLock<JSONSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| {
+        let raw: serde_json::Value = serde_json::from_str(PRIMITIVE_MANIFEST_SCHEMA)
+            .expect("embedded primitive manifest schema is valid JSON");
+        JSONSchema::options()
+            .compile(&raw)
+            .expect("embedded primitive manifest schema compiles")
+    })
+}
+
+/// Load and fully validate a primitive manifest from its JSON source.
+pub fn load_primitive_manifest(source: &str) -> Result<PrimitiveManifest, PrimitiveLoadError> {
+    let value: serde_json::Value =
+        serde_json::from_str(source).map_err(|e| PrimitiveLoadError::InvalidJson(e.to_string()))?;
+
+    let schema = compiled_schema();
+    if let Err(errors) = schema.validate(&value) {
+        let violations = errors
+            .map(|e| SchemaViolation {
+                pointer: e.instance_path.to_string(),
+                message: e.to_string(),
+            })
+            .collect::<Vec<_>>();
+        return Err(PrimitiveLoadError::SchemaViolation(violations));
+    }
+
+    PrimitiveManifest::from_validated_value(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_schema_compiles() {
+        let _ = compiled_schema();
+    }
+
+    #[test]
+    fn minimal_primitive_loads() {
+        let src = r#"{
+            "id": "minimal",
+            "category": "force_application",
+            "description": "Minimal valid primitive for tests.",
+            "parameter_schema": {
+                "p": { "type": "number", "range": { "min": 0, "max": 1 } }
+            },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": { "base_metabolic_cost": 0.5 },
+            "observable_signature": {
+                "modality": "mechanical",
+                "detection_range_m": 1,
+                "pattern_key": "minimal_v1"
+            },
+            "provenance": "core"
+        }"#;
+        assert!(load_primitive_manifest(src).is_ok());
+    }
+
+    #[test]
+    fn schema_rejects_unknown_category() {
+        let src = r#"{
+            "id": "bad",
+            "category": "telepathy",
+            "description": "Not a real category.",
+            "parameter_schema": { "p": { "type": "number" } },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": { "base_metabolic_cost": 1 },
+            "observable_signature": { "modality": "behavioral", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        assert!(matches!(
+            load_primitive_manifest(src),
+            Err(PrimitiveLoadError::SchemaViolation(_))
+        ));
+    }
+
+    #[test]
+    fn semantic_unknown_scaling_parameter_rejected() {
+        let src = r#"{
+            "id": "bad",
+            "category": "force_application",
+            "description": "Cost refers to a parameter that does not exist.",
+            "parameter_schema": { "p": { "type": "number" } },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": {
+                "base_metabolic_cost": 1,
+                "parameter_scaling": [ { "parameter": "ghost", "exponent": 1, "coefficient": 1 } ]
+            },
+            "observable_signature": { "modality": "behavioral", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        assert!(matches!(
+            load_primitive_manifest(src),
+            Err(PrimitiveLoadError::UnknownScalingParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn semantic_default_type_mismatch_rejected() {
+        let src = r#"{
+            "id": "bad",
+            "category": "force_application",
+            "description": "Boolean default on a numeric parameter.",
+            "parameter_schema": {
+                "p": { "type": "number", "default": true }
+            },
+            "composition_compatibility": [ { "channel_family": "motor" } ],
+            "cost_function": { "base_metabolic_cost": 1 },
+            "observable_signature": { "modality": "behavioral", "detection_range_m": 1, "pattern_key": "k" },
+            "provenance": "core"
+        }"#;
+        assert!(matches!(
+            load_primitive_manifest(src),
+            Err(PrimitiveLoadError::InvalidDefault { .. })
+        ));
+    }
+}

--- a/crates/beast-primitives/tests/example_manifests.rs
+++ b/crates/beast-primitives/tests/example_manifests.rs
@@ -1,0 +1,146 @@
+//! Integration test: every manifest in
+//! `documentation/schemas/primitive_vocabulary/` must load, validate, and
+//! register. Demonstrates the Sprint 2 demo criterion "load the 16 starter
+//! primitives without errors."
+
+use std::collections::BTreeMap;
+
+use beast_core::Q3232;
+use beast_primitives::{evaluate_cost, PrimitiveCategory, PrimitiveManifest, PrimitiveRegistry};
+
+/// `(id, source)` for every starter primitive. The tuples are sorted to keep
+/// this list reviewable; the registry guarantees deterministic iteration
+/// independently of this ordering.
+const PRIMITIVES: &[(&str, &str)] = &[
+    (
+        "absorb_substance",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/absorb_substance.json"),
+    ),
+    (
+        "apply_bite_force",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/apply_bite_force.json"),
+    ),
+    (
+        "apply_locomotive_thrust",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/apply_locomotive_thrust.json"
+        ),
+    ),
+    (
+        "elevate_metabolic_rate",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/elevate_metabolic_rate.json"
+        ),
+    ),
+    (
+        "emit_acoustic_pulse",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/emit_acoustic_pulse.json"
+        ),
+    ),
+    (
+        "emit_chemical_marker",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/emit_chemical_marker.json"
+        ),
+    ),
+    (
+        "enter_torpor",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/enter_torpor.json"),
+    ),
+    (
+        "form_host_attachment",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/form_host_attachment.json"
+        ),
+    ),
+    (
+        "form_pair_bond",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/form_pair_bond.json"),
+    ),
+    (
+        "induce_paralysis",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/induce_paralysis.json"),
+    ),
+    (
+        "inject_substance",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/inject_substance.json"),
+    ),
+    (
+        "receive_acoustic_signal",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/receive_acoustic_signal.json"
+        ),
+    ),
+    (
+        "receive_photic_signal",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/receive_photic_signal.json"
+        ),
+    ),
+    (
+        "spatial_integrate",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/spatial_integrate.json"),
+    ),
+    (
+        "temporal_integrate",
+        include_str!("../../../documentation/schemas/primitive_vocabulary/temporal_integrate.json"),
+    ),
+    (
+        "thermoregulate_self",
+        include_str!(
+            "../../../documentation/schemas/primitive_vocabulary/thermoregulate_self.json"
+        ),
+    ),
+];
+
+#[test]
+fn every_starter_primitive_loads() {
+    assert_eq!(
+        PRIMITIVES.len(),
+        16,
+        "expected exactly 16 starter primitives"
+    );
+    for (id, source) in PRIMITIVES {
+        let manifest =
+            PrimitiveManifest::from_json_str(source).unwrap_or_else(|e| panic!("{id}: {e}"));
+        assert_eq!(manifest.id, *id);
+    }
+}
+
+#[test]
+fn starter_primitives_cover_all_categories() {
+    let mut registry = PrimitiveRegistry::new();
+    for (_, source) in PRIMITIVES {
+        registry
+            .register(PrimitiveManifest::from_json_str(source).unwrap())
+            .unwrap();
+    }
+
+    // Schema design mandates exactly eight functional categories, and the
+    // starter vocabulary dedicates two primitives to each — see
+    // `documentation/schemas/README.md`.
+    for category in [
+        PrimitiveCategory::SignalEmission,
+        PrimitiveCategory::SignalReception,
+        PrimitiveCategory::ForceApplication,
+        PrimitiveCategory::StateInduction,
+        PrimitiveCategory::SpatialIntegration,
+        PrimitiveCategory::MassTransfer,
+        PrimitiveCategory::EnergyModulation,
+        PrimitiveCategory::BondFormation,
+    ] {
+        let count = registry.ids_by_category(category).count();
+        assert_eq!(count, 2, "category {category:?} should have 2 primitives");
+    }
+}
+
+#[test]
+fn cost_function_evaluates_with_defaults_for_every_primitive() {
+    for (id, source) in PRIMITIVES {
+        let manifest = PrimitiveManifest::from_json_str(source).unwrap();
+        let cost = evaluate_cost(&manifest, &BTreeMap::new())
+            .unwrap_or_else(|e| panic!("{id} cost eval failed: {e}"));
+        assert!(cost >= Q3232::ZERO, "{id} cost should be non-negative");
+    }
+}

--- a/crates/beast-primitives/tests/malformed_manifests.rs
+++ b/crates/beast-primitives/tests/malformed_manifests.rs
@@ -1,0 +1,108 @@
+//! Malformed primitive manifests — each one must be rejected. Covers both
+//! JSON-Schema-layer failures and semantic failures the schema cannot catch.
+
+use beast_primitives::{PrimitiveLoadError, PrimitiveManifest};
+
+const BASE_VALID: &str = r#"{
+    "id": "example",
+    "category": "signal_emission",
+    "description": "Minimal baseline used by malformed-manifest fixtures.",
+    "parameter_schema": {
+        "frequency_hz": { "type": "number", "range": { "min": 20, "max": 1000 }, "default": 100 }
+    },
+    "composition_compatibility": [ { "channel_family": "motor" } ],
+    "cost_function": {
+        "base_metabolic_cost": 1.0,
+        "parameter_scaling": [ { "parameter": "frequency_hz", "exponent": 1.0, "coefficient": 0.01 } ]
+    },
+    "observable_signature": {
+        "modality": "acoustic",
+        "detection_range_m": 10,
+        "pattern_key": "example_v1"
+    },
+    "provenance": "core"
+}"#;
+
+#[test]
+fn baseline_still_loads() {
+    assert!(PrimitiveManifest::from_json_str(BASE_VALID).is_ok());
+}
+
+#[test]
+fn fixture_1_unknown_category_rejected() {
+    let src = BASE_VALID.replace(
+        r#""category": "signal_emission""#,
+        r#""category": "telepathy""#,
+    );
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::SchemaViolation(_))
+    ));
+}
+
+#[test]
+fn fixture_2_unknown_modality_rejected() {
+    let src = BASE_VALID.replace(r#""modality": "acoustic""#, r#""modality": "spirit""#);
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::SchemaViolation(_))
+    ));
+}
+
+#[test]
+fn fixture_3_missing_cost_function_rejected() {
+    // Drop the entire `cost_function` field.
+    let src = r#"{
+        "id": "example",
+        "category": "signal_emission",
+        "description": "Missing cost_function.",
+        "parameter_schema": { "p": { "type": "number" } },
+        "composition_compatibility": [ { "channel_family": "motor" } ],
+        "observable_signature": { "modality": "acoustic", "detection_range_m": 10, "pattern_key": "k" },
+        "provenance": "core"
+    }"#;
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(src),
+        Err(PrimitiveLoadError::SchemaViolation(_))
+    ));
+}
+
+#[test]
+fn fixture_4_scaling_references_unknown_parameter_rejected() {
+    // Schema allows it (the referenced name is any string); semantic layer
+    // rejects references to names that don't appear in `parameter_schema`.
+    let src = BASE_VALID.replace(r#""parameter": "frequency_hz""#, r#""parameter": "ghost""#);
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::UnknownScalingParameter { .. })
+    ));
+}
+
+#[test]
+fn fixture_5_default_type_mismatch_rejected() {
+    let src = BASE_VALID.replace(r#""default": 100"#, r#""default": "loud""#);
+    // Semantic layer flags the mismatch between declared type=number and a
+    // string default; schema otherwise allows any JSON type for `default`.
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::InvalidDefault { .. })
+    ));
+}
+
+#[test]
+fn fixture_6_invalid_provenance_rejected() {
+    let src = BASE_VALID.replace(r#""provenance": "core""#, r#""provenance": "bogus:foo""#);
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::SchemaViolation(_))
+    ));
+}
+
+#[test]
+fn fixture_7_negative_detection_range_rejected() {
+    let src = BASE_VALID.replace(r#""detection_range_m": 10"#, r#""detection_range_m": -5"#);
+    assert!(matches!(
+        PrimitiveManifest::from_json_str(&src),
+        Err(PrimitiveLoadError::SchemaViolation(_))
+    ));
+}

--- a/documentation/PROGRESS_LOG.md
+++ b/documentation/PROGRESS_LOG.md
@@ -8,10 +8,11 @@ This file is the canonical running log of implementation work on the Beast Evolu
 
 ## Current Status Snapshot
 
-- **Active Sprint**: S1 — Fixed-Point & PRNG (beast-core) [Week 1] — **✅ COMPLETE & merged**
-- **Next Sprint**: S2 — Manifests & Registries (beast-channels, beast-primitives) [Week 2]
+- **Active Sprint**: S2 — Manifests & Registries (beast-channels, beast-primitives) [Week 2] — **implementation complete, PR pending**
+- **Completed Sprints**: S1 — Fixed-Point & PRNG (beast-core) [Week 1]
+- **Next Sprint**: S3 — Genome & Mutation (beast-genome) [Week 3]
 - **Phase**: 1 — Foundations & Core Sim
-- **Workspace scaffolded**: yes (beast-core only; other 16 crates deferred to their sprints)
+- **Workspace scaffolded**: yes (beast-core, beast-channels, beast-primitives; other 14 crates deferred to their sprints)
 - **CI**: `.github/workflows/ci.yml` runs on every PR — fmt, clippy, test, doctests, release build, and cross-platform tests on windows/macOS. First run on PR #2 passed all 4 jobs.
 - **Push protection**: client-side (`.githooks/pre-push`) blocks direct pushes to master once activated via `git config core.hooksPath .githooks`. Server-side branch protection **not** configured — GitHub REST API rejected the call on this private/free repo (requires Pro or public visibility). Workflow job names are documented in `CONTRIBUTING.md` for the day we turn that on.
 - **Merged PRs on master**:
@@ -61,6 +62,88 @@ This file is the canonical running log of implementation work on the Beast Evolu
 ---
 
 ## Session Log (reverse chronological)
+
+### 2026-04-15 — Sprint S2 implementation (Claude)
+
+Two new crates, both Layer 1, both depend only on `beast-core`
+(`beast-primitives` also depends on `beast-channels` to share the
+`ChannelFamily` enum and validate `channel_id` references).
+
+**`beast-channels`** — 5 source files (~900 LOC) + 3 test files + README:
+- `manifest.rs` — `ChannelManifest`, `ChannelFamily`, `MutationKernel`,
+  `Range`, `ScaleBand`, `Provenance`, `CorrelationEntry`, `BoundsPolicy`.
+  Two-stage loader: `RawChannelManifest` (serde f64/String mirror of the
+  JSON schema) → semantic `into_manifest()` that converts every sim-math
+  field to `Q3232`, checks range ordering, de-duplicates composition
+  hook targets, and enforces the "threshold required for
+  `kind ∈ {threshold, gating}`" rule.
+- `composition.rs` — `CompositionHook`, `CompositionKind`, `HookOutcome`,
+  `evaluate_hook()`. Formulas mirror the schema table (additive,
+  multiplicative, threshold, gating, antagonistic). All Q3232.
+- `expression.rs` — `ExpressionCondition` discriminated union,
+  `ExpressionContext`, `evaluate_expression_conditions()` — empty slice
+  always passes, missing context fields evaluate to `false`.
+- `registry.rs` — `ChannelRegistry` over `BTreeMap<String, ChannelManifest>`
+  + `BTreeMap<ChannelFamily, BTreeSet<String>>` for the family index.
+  `validate_cross_references()` catches unknown hook targets and
+  correlation targets after all manifests are loaded (literal `"self"` is
+  always accepted).
+- `schema.rs` — embeds the authoritative schema via `include_str!`
+  (`../../../documentation/schemas/channel_manifest.schema.json`), caches
+  the compiled `jsonschema::JSONSchema` in a `OnceLock`, flattens schema
+  errors to `(pointer, message)` pairs.
+
+**`beast-primitives`** — 7 source files (~1000 LOC) + 3 test files + README:
+- `manifest.rs` / `schema.rs` / `registry.rs` mirror the channel crate's
+  patterns. `validate_channel_references(&ChannelRegistry)` cross-checks
+  `composition_compatibility.channel_id` entries against a live channel
+  registry.
+- `category.rs` — `PrimitiveCategory` (8 variants) + `Modality` (8
+  variants). Both derive `Ord` so they can key BTreeMap indices.
+- `math.rs` — Q3232 `q_ln` (artanh series via the
+  `x = 2^k·m, m ∈ [1,2)` decomposition + `int_log2`), `q_exp` (Taylor on
+  the `(-1, 1)` fractional part + integer scaling by `e^k`), and
+  `q_pow(base, exp) = q_exp(exp · q_ln(base))`. Handles non-positive
+  bases defensively. All 16 starter primitive manifests evaluate without
+  `CostEvalError`.
+- `cost.rs` — `evaluate_cost(&PrimitiveManifest, &BTreeMap)`. Resolves
+  parameter values from the caller map, then the manifest's declared
+  default (numeric only), then errors. Uses `q_pow` for the power term.
+- `effect.rs` — `PrimitiveEffect` shape for the interpreter to emit in S4.
+  Defined now so downstream crates compile against it.
+
+**Determinism invariants maintained**:
+- All numeric manifest values converted to `Q3232` at load time.
+- Registries backed by `BTreeMap`/`BTreeSet` — sorted iteration verified
+  in unit tests (`iteration_is_sorted`, `iteration_sorted_by_id`).
+- `clippy::float_arithmetic = "warn"` at both new crate levels.
+- Cost evaluator uses fixed-point exp/ln; Taylor loops have fixed
+  iteration counts (no rounding-dependent early termination).
+
+**Schema handling pragma**: the schema files declare
+`$schema: ".../draft/2020-12/..."` but `jsonschema` 0.17 (the latest that
+compiles on stable Rust 1.75) defaults to Draft 2019-09. The subset of
+features we use (types, enums, patterns, required, if/then/else, oneOf)
+is identical between the two drafts, so we let the validator use its
+default. Upgrading `jsonschema` is tracked as a follow-up for when MSRV
+moves past 1.77.
+
+**Test count**: 74 beast-channels (31 unit + 3 example integration + 7
+malformed + 3 doctest); 38 beast-primitives (25 unit + 3 example
+integration + 8 malformed + 2 doctest). `cargo fmt --check`,
+`cargo clippy --workspace --all-targets -- -D warnings`,
+`cargo test --workspace --all-targets --locked --doc`, and
+`cargo build --workspace --release --locked` all pass locally on
+Windows.
+
+**Follow-ups for S3+**:
+- The Q3232 `q_pow` / `q_exp` / `q_ln` helpers should be promoted to
+  `beast-core::math` once the interpreter (S4) or physiology systems
+  also want them; for now they stay `pub(crate)` to keep S2's API
+  surface minimal.
+- `validate_cross_references` on `ChannelRegistry` and
+  `validate_channel_references` on `PrimitiveRegistry` will be wired
+  into world init in S5/S6 when we actually load a full manifest bundle.
 
 ### 2026-04-15 — Infra & README (Claude)
 
@@ -189,3 +272,5 @@ _(updated as files are created)_
 - `rust-toolchain.toml` — pins stable + rustfmt + clippy (PR #2).
 - `.github/workflows/ci.yml` — GitHub Actions CI (PR #2).
 - `.githooks/pre-push` — opt-in master-push gate (PR #3).
+- `crates/beast-channels/` — Sprint S2 channel registry crate: `Cargo.toml`, `README.md`, `src/{lib,manifest,composition,expression,registry,schema}.rs`, `tests/{example_manifests,malformed_manifests}.rs`.
+- `crates/beast-primitives/` — Sprint S2 primitive registry crate: `Cargo.toml`, `README.md`, `src/{lib,manifest,category,cost,effect,math,registry,schema}.rs`, `tests/{example_manifests,malformed_manifests}.rs`.


### PR DESCRIPTION
## Summary

Sprint S2 of the Beast Evolution Game roadmap — populates the two Layer 1
crates that every downstream layer depends on.

- **`beast-channels`** — channel manifest loader, registry, composition hook
  evaluator, expression condition evaluator.
- **`beast-primitives`** — primitive manifest loader, registry, Q3232 cost
  evaluator (includes a crate-local fixed-point `exp`/`ln`/`pow`).

Every Sprint S2 story is covered:

| Story | Title                                                    | Commit |
|-------|----------------------------------------------------------|--------|
| 2.1   | Channel manifest schema & JSON loader                    | `90cf280` |
| 2.2   | Primitive manifest schema & JSON loader                  | `31b8793` |
| 2.3   | ChannelRegistry with queryable indexing                  | `5454ffc` |
| 2.4   | PrimitiveRegistry with cost function evaluation          | `c0ddcc2` |
| 2.5   | Composition hook parser & evaluator                      | `7f2e872` |
| 2.6   | Schema validation & malformed manifest rejection         | `7d550d2`, `fa9147b` |

## Demo criteria (from `SPRINTS.md`)

- [x] Load all 5 example channel manifests (`crates/beast-channels/tests/example_manifests.rs`)
- [x] Load all 16 starter primitive manifests and exercise cost eval
      (`crates/beast-primitives/tests/example_manifests.rs`)
- [x] Query registries; retrieve expected channels by family and
      primitives by category
- [x] Evaluate composition hooks deterministically across calls
      (`composition::tests::evaluation_is_deterministic_across_calls`)
- [x] Schema validation rejects 14 malformed manifests (7 channel + 7
      primitive fixtures, each targeting a specific error variant)

## Invariant notes

- All numeric manifest fields that feed sim math are converted to
  `beast_core::Q3232` at load time. `clippy::float_arithmetic = "warn"`
  at both crate levels keeps floats out of the hot path.
- Registries are `BTreeMap`/`BTreeSet`-backed; iteration is sorted and
  deterministic.
- `jsonschema` 0.17 is the latest version that compiles on stable Rust
  1.75. It defaults to Draft 2019-09 while the schema files declare
  `$schema: .../draft/2020-12/...`; the feature subset we rely on is
  identical between the two drafts. Tracked as a follow-up once MSRV
  moves past 1.77.

## Test plan

- [x] `cargo fmt --all -- --check` clean on Windows
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --all-targets --locked` all pass
- [x] `cargo test --workspace --doc --locked` all pass
- [x] `cargo build --workspace --release --locked` clean
- [x] CI green on Linux / Windows / macOS (see Actions run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)