### PR TITLE
infra: cargo-deny, Dependabot, coverage, schema-drift guards, issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Something is broken, misbehaving, or doesn't match the spec.
+title: "[bug] "
+labels: ["type:bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Stop.** If this bug is a **security vulnerability** (it allows an
+        attacker to panic the runtime, execute code, leak data, etc.), do
+        **not** file it here. Use private disclosure — see `SECURITY.md`.
+
+        If this bug is a **determinism regression** (replay hashes diverge,
+        same seed produces different output, etc.), use the dedicated
+        **Determinism Regression** template instead — it asks for the
+        specific fields a determinism triage needs.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: One-paragraph description.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened?
+      description: What behaviour does the spec / docs / your reading of the code suggest?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps. Prefer a failing test case inline when possible.
+      placeholder: |
+        1. Run `cargo test -p beast-channels composition::tests::…`
+        2. Observe panic in …
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Output / logs
+      description: Copy the full error output, stack trace, or panic message.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: "`git rev-parse HEAD` on the branch you hit this on."
+      placeholder: "e.g. 080b2d4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      multiple: true
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust toolchain
+      description: "`rustc --version`"
+      placeholder: "rustc 1.83.0 (90b35a623 2024-11-26)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Your best guess — triage will confirm.
+      options:
+        - "Low — cosmetic, doesn't affect correctness"
+        - "Medium — wrong behaviour, has a workaround"
+        - "High — wrong behaviour, no workaround, blocks sprint work"
+        - "Critical — data loss, panic on common input, or crash"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Hide the "blank issue" option so every new issue lands in a template
+# with the fields triage actually needs. If none of the templates fit,
+# users can start a Discussion (once enabled) or link to CONTRIBUTING.md
+# for the workflow.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/BemusedVermin/evolution-simulation/blob/master/CONTRIBUTING.md
+    about: Read before filing — sprint workflow, PR expectations, determinism contract.
+  - name: Security vulnerability (sensitive)
+    url: https://github.com/BemusedVermin/evolution-simulation/security/advisories/new
+    about: Report exploitable vulnerabilities privately. Do NOT use public issues.
+  - name: Project planning docs
+    url: https://github.com/BemusedVermin/evolution-simulation/tree/master/documentation/planning
+    about: Sprints, epics, risk register — check these before proposing a feature.

--- a/.github/ISSUE_TEMPLATE/determinism_regression.yml
+++ b/.github/ISSUE_TEMPLATE/determinism_regression.yml
@@ -1,0 +1,102 @@
+name: Determinism Regression
+description: Replay hashes diverge, same seed produces different output, or cross-platform results don't match.
+title: "[determinism] "
+labels: ["type:determinism", "priority:high", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Determinism is the load-bearing invariant for this project
+        (`documentation/INVARIANTS.md` §1). A regression here is higher
+        priority than a typical bug — it silently corrupts save/load,
+        replay, and multiplayer guarantees.
+
+        **Triage protocol** (from `INVARIANTS.md`): first suspect the
+        numerical precision / PRNG seeding / iteration order, in that
+        order. Please capture as much of the reproducer below as you can.
+
+  - type: dropdown
+    id: divergence-class
+    attributes:
+      label: Divergence class
+      description: What kind of determinism break did you observe?
+      options:
+        - "Same seed, same platform, same commit → different output across runs"
+        - "Same seed, different platform (linux/windows/macOS) → different output"
+        - "Save → load → replay does not match original (state-hash mismatch)"
+        - "Tick-by-tick hash diverges partway through a run"
+        - "Other (explain)"
+    validations:
+      required: true
+
+  - type: input
+    id: seed
+    attributes:
+      label: PRNG seed
+      description: The master seed that reproduces the divergence.
+      placeholder: "0xDEADBEEFCAFEBABE"
+    validations:
+      required: true
+
+  - type: input
+    id: diverge-tick
+    attributes:
+      label: First divergent tick
+      description: Earliest tick at which the hash differs from the reference.
+      placeholder: "e.g. 437"
+    validations:
+      required: false
+
+  - type: textarea
+    id: platforms
+    attributes:
+      label: Platforms affected
+      description: List the platforms where you reproduced or failed to reproduce.
+      placeholder: |
+        - Reproduces on: Windows 11 + rustc 1.83.0
+        - Does not reproduce on: Ubuntu 22.04 + rustc 1.83.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: suspected-cause
+    attributes:
+      label: Suspected cause
+      description: Your best guess. Triage ordering from INVARIANTS.md is precision → seeding → iteration order.
+      options:
+        - "Numerical precision (float leak into sim state, saturation bug)"
+        - "PRNG seeding (stream split, cross-subsystem contamination)"
+        - "Iteration order (HashMap/HashSet leaking into state)"
+        - "Wall-clock / OS-entropy read (forbidden)"
+        - "Unknown"
+    validations:
+      required: true
+
+  - type: textarea
+    id: diff
+    attributes:
+      label: Binary diff of the first diverging tick
+      description: |
+        If the determinism test produced one (per `INVARIANTS.md` §1
+        "failure protocol"), paste it here. Include the entity / component
+        that diverged and the observed vs expected bytes.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: ci-run
+    attributes:
+      label: CI run (if applicable)
+      description: Link to the failing GitHub Actions run.
+      placeholder: "https://github.com/BemusedVermin/evolution-simulation/actions/runs/…"
+    validations:
+      required: false
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: "`git rev-parse HEAD` on the reproducer."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature Request
+description: Propose a new capability, system, or enhancement.
+title: "[feat] "
+labels: ["type:feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: skim `documentation/planning/SPRINTS.md` and
+        `EPICS.md`. If this feature fits an existing epic, say so below —
+        we may just need to slot it into a sprint rather than scope a new
+        one.
+
+        For **larger features** that will need multiple implementation
+        tasks (an "epic-sized" feature), use the **Feature Task** template
+        for the individual pieces and link them back to this request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What pain point does this solve? Who benefits?
+      placeholder: "Today, when X happens, Y is painful because…"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What do you want to see? Sketch the API, UI, or behaviour.
+      placeholder: "Add a `…` that does `…`."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you rule out, and why?
+      placeholder: "Option A was rejected because…"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: invariant-impact
+    attributes:
+      label: Invariant impact
+      description: |
+        Does this proposal touch any of the load-bearing invariants in
+        `documentation/INVARIANTS.md` (determinism, mechanics-label
+        separation, channel registry monolithicism, emergence closure,
+        scale-band unification, UI-vs-sim state)?
+      options:
+        - "No — purely additive, no invariant interaction"
+        - "Yes — affects determinism (needs fixed-point, sorted iteration, etc.)"
+        - "Yes — affects mechanics-label separation (adds named-ability logic)"
+        - "Yes — affects another invariant (explain below)"
+        - "Unsure — please advise"
+    validations:
+      required: true
+
+  - type: input
+    id: sprint
+    attributes:
+      label: Target sprint (optional)
+      description: If this maps to a planned sprint, say which (e.g. `S5`, `S11`).
+      placeholder: "e.g. S7"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What observable behaviour tells us this is done?
+      placeholder: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -1,0 +1,82 @@
+name: Feature Task
+description: Implementation task under a larger feature or sprint story.
+title: "[task] "
+labels: ["type:task", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for the *individual pieces* of a larger
+        feature — one task per story point group, typically mapping 1:1
+        to a commit or small PR. File the parent as a **Feature Request**
+        first and link it below.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue / epic
+      description: Link to the parent Feature Request, epic doc, or sprint story.
+      placeholder: "#12 / EPICS.md#E4 / SPRINTS.md#S5"
+    validations:
+      required: true
+
+  - type: input
+    id: sprint
+    attributes:
+      label: Sprint
+      description: Sprint this task belongs to.
+      placeholder: "S5"
+    validations:
+      required: true
+
+  - type: input
+    id: points
+    attributes:
+      label: Story points
+      description: Fibonacci-ish estimate (1, 2, 3, 5, 8). Keep tasks to ≤ 8.
+      placeholder: "3"
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What this task does, concretely. Files, modules, or systems touched.
+      placeholder: "Add `ChannelRegistry::by_family(…)` and wire it into the interpreter."
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Explicitly out of scope
+      description: What this task is *not* doing. Prevents scope creep at review time.
+      placeholder: "- Cost function evaluation — that's task #14"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, testable.
+      value: |
+        - [ ] Tests cover the new behaviour (unit + integration where relevant)
+        - [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+        - [ ] `cargo fmt --check` clean
+        - [ ] Relevant README / PROGRESS_LOG entry updated
+    validations:
+      required: true
+
+  - type: dropdown
+    id: invariant-impact
+    attributes:
+      label: Invariant impact
+      description: See `documentation/INVARIANTS.md`.
+      options:
+        - "No"
+        - "Yes — determinism"
+        - "Yes — other (explain in scope)"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,57 @@
+name: Security (non-sensitive)
+description: Hardening suggestion, defense-in-depth idea, or general security discussion.
+title: "[security] "
+labels: ["type:security", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ### ⚠️ Is this an exploitable vulnerability?
+        >
+        > **If yes, close this template and report privately.** See
+        > [`SECURITY.md`](../blob/master/SECURITY.md) for the private
+        > disclosure process.
+        >
+        > This template is for **non-sensitive** security work:
+        > hardening suggestions, questions about how a subsystem handles
+        > malformed input, `cargo-deny` / `cargo-audit` adjustments,
+        > defense-in-depth proposals. Anything you'd be comfortable
+        > discussing in public without giving an attacker a roadmap.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - "Hardening suggestion (reduce attack surface)"
+        - "Defense-in-depth (add a check that isn't strictly required)"
+        - "Dependency concern (cargo-deny / cargo-audit adjustment)"
+        - "Input validation question"
+        - "Documentation (SECURITY.md, disclosure process)"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: concern
+    attributes:
+      label: Concern
+      description: What's the issue or suggestion? Which component is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix (optional)
+      description: If you have one in mind, sketch it here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have confirmed this is NOT an exploitable vulnerability. Exploitable vulnerabilities go through private disclosure per `SECURITY.md`.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,61 @@
+<!--
+Bug-fix PR template. Use this for fixes that address a filed bug or an
+unreported defect noticed in review.
+
+Activate via: ?template=bug_fix.md on the PR creation URL.
+-->
+
+## Summary
+
+<!-- One sentence: what was broken, how is it fixed? -->
+
+## Linked issue
+
+<!-- Fixes #<bug-id>. If there's no issue yet, describe the bug here with repro. -->
+
+## Root cause
+
+<!--
+Walk through the actual failure mode. Not "X was wrong" — "X was wrong
+because we assumed Y and Z never happens, but it does when …".
+Reviewers should be able to reason about whether the fix addresses the
+real cause or only a symptom.
+-->
+
+## Fix
+
+<!-- What changed and why that change addresses the root cause above. -->
+
+## Regression coverage
+
+<!--
+A bug fix without a failing-before / passing-after test is a recipe
+for the same bug reappearing. Link or inline the new test.
+-->
+
+- [ ] Added a regression test that fails on `master` and passes on this branch.
+- [ ] Test is deterministic (no timing, no random without explicit seed).
+- [ ] If this is a determinism-related fix, verify the test runs on all three CI OSes.
+
+## Invariant impact
+
+<!--
+- [ ] No invariant touched (behaviour was already inside the contract).
+- [ ] Tightened an invariant (what was silently relaxed, what now enforces it).
+- [ ] Touches determinism — describe what changes in state/output, if anything.
+-->
+
+## Risk assessment
+
+<!--
+How confident are you that this doesn't introduce a new bug?
+- What else called the buggy code path?
+- Any behaviour change for callers that weren't hitting the bug?
+-->
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace --all-targets --locked`
+- [ ] Regression test from above — demonstrably fails on `master`.

--- a/.github/PULL_REQUEST_TEMPLATE/determinism.md
+++ b/.github/PULL_REQUEST_TEMPLATE/determinism.md
@@ -1,0 +1,80 @@
+<!--
+Determinism PR template. Use this for fixes to replay-hash divergences,
+PRNG seeding bugs, float leaks into sim state, and iteration-order bugs.
+
+Activate via: ?template=determinism.md on the PR creation URL.
+
+See documentation/INVARIANTS.md §1 for the full determinism contract.
+-->
+
+## Summary
+
+<!-- What divergence did we have? What's the fix in one sentence? -->
+
+## Linked issue
+
+<!-- Fixes #<determinism-regression-issue>. -->
+
+## Divergence class
+
+<!--
+Tick the observed class:
+
+- [ ] Same seed, same commit, same platform → different output across runs.
+- [ ] Same seed, different platform (linux/windows/macOS) → different output.
+- [ ] Save → load → replay doesn't match original (state-hash mismatch).
+- [ ] Tick-by-tick hash diverges partway through a run.
+-->
+
+## Root cause
+
+<!--
+Determinism bugs fall into three buckets (in the order INVARIANTS.md
+says to suspect them):
+
+1. Numerical precision — float leaking into sim state, Q3232 saturation,
+   rounding asymmetry.
+2. PRNG seeding — cross-subsystem stream contamination, re-seeding from
+   derived state, missing `long_jump()` on split.
+3. Iteration order — HashMap/HashSet leaking into state, non-sorted
+   iteration of entity keys.
+
+Describe which bucket this fits (or whether it's a new class) and the
+exact mechanism that made the output diverge.
+-->
+
+## Fix
+
+<!-- What changed. Reference the specific invariant clause if applicable. -->
+
+## Regression coverage
+
+<!--
+Determinism regressions *must* come with a hash-comparison test that:
+- Runs a deterministic scenario for a fixed tick count.
+- Compares the state hash against a committed golden, or runs twice
+  and compares, whichever is appropriate.
+- Runs on all three CI OSes.
+-->
+
+- [ ] Added hash-comparison regression test.
+- [ ] Test fails on `master`, passes on this branch.
+- [ ] Test runs under the cross-platform matrix (windows + macos + ubuntu).
+- [ ] Test is free of wall-clock reads and OS RNG.
+
+## Invariant confirmation
+
+<!-- Tick everything you verified: -->
+
+- [ ] All sim-state math uses `Q3232` (no `f32`/`f64` in the changed code path).
+- [ ] PRNG usage goes through a subsystem stream (no `rand::thread_rng`, no `std::random`).
+- [ ] Hot-path iteration uses `BTreeMap` / `BTreeSet` / explicitly-sorted collections.
+- [ ] No wall-clock reads (`SystemTime`, `Instant`) on the sim path.
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace --all-targets --locked`
+- [ ] Cross-platform CI (windows + macos) green.
+- [ ] When the formal determinism test lands in S6, this regression is included in its corpus.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,60 @@
+<!--
+Feature PR template. Use this for new capabilities (matches the
+Feature Request / Feature Task issue templates).
+
+Activate via: ?template=feature.md on the PR creation URL.
+-->
+
+## Summary
+
+<!-- What new capability does this land? One paragraph, reader-facing. -->
+
+## Linked issues
+
+<!--
+- Closes #<feature-request>
+- Implements #<feature-task-1>, #<feature-task-2>, …
+- Sprint: SPRINTS.md#S?
+-->
+
+## Design notes
+
+<!--
+Anything a reviewer should know about the shape of the change that
+isn't obvious from the diff. API decisions, data-structure choices,
+invariants added / relaxed, future-proofing deliberately deferred.
+-->
+
+## Invariant impact
+
+<!--
+See documentation/INVARIANTS.md. Tick one:
+
+- [ ] No invariant touched.
+- [ ] Determinism — describe what keeps bit-identical replay intact.
+- [ ] Mechanics-label separation — confirm no named-ability logic in sim code.
+- [ ] Channel registry monolithicism — all channel lookups go through the registry.
+- [ ] Other invariant (explain).
+-->
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace --all-targets --locked`
+- [ ] `cargo test --workspace --doc --locked`
+- [ ] Feature-specific tests listed here:
+  -
+- [ ] `cargo deny check` (if deps changed)
+
+## Docs
+
+- [ ] `documentation/PROGRESS_LOG.md` session entry added.
+- [ ] Crate `README.md` updated (if public surface changed).
+- [ ] Inline rustdoc on new public items.
+
+## Out of scope (deliberate)
+
+<!-- What this PR is NOT doing. Tracked follow-ups with issue links. -->
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE/security.md
+++ b/.github/PULL_REQUEST_TEMPLATE/security.md
@@ -1,0 +1,80 @@
+<!--
+Security PR template. Use this for fixes to security issues, hardening
+changes, and dependency advisories.
+
+> If this PR fixes an UNDISCLOSED vulnerability, DO NOT open it as a
+> normal PR against master. Use a GitHub Security Advisory
+> (Security tab → Report a vulnerability → proposed fix), which creates
+> a private fork + temporary private branch for coordinated disclosure.
+> Public PRs for unfixed CVEs turn the diff into an exploit manual.
+
+Activate via: ?template=security.md on the PR creation URL.
+-->
+
+## Summary
+
+<!-- One-paragraph description of the security change. -->
+
+## Vulnerability class
+
+<!--
+Pick all that apply:
+- Panic / DoS on attacker-controlled input
+- Memory safety (only possible via `unsafe`, which is forbidden — flag if you're relaxing the forbid)
+- Input validation gap
+- Cryptographic misuse
+- Secret / credential leakage
+- Dependency advisory (RUSTSEC-…)
+- Hardening / defense-in-depth (no known exploit, reducing attack surface)
+- Other
+-->
+
+## Linked issue / advisory
+
+<!--
+- Fixes GHSA-… (private advisory)
+- Fixes #<security-issue-number> (non-sensitive)
+- Addresses RUSTSEC-…
+-->
+
+## Affected versions
+
+<!-- Commit range / tag range / "all published versions". -->
+
+## Fix summary
+
+<!--
+What changed. For non-sensitive PRs, include detail. For PRs coordinated
+with a GitHub Security Advisory, keep this high-level until disclosure.
+-->
+
+## Regression coverage
+
+<!--
+For non-sensitive security PRs: include the failing-before / passing-after
+test inline.
+
+For PRs coordinated with a private advisory: describe the test that
+will land with disclosure, or link it in the advisory draft.
+-->
+
+- [ ] Regression test covers the vulnerable path.
+- [ ] Test is deterministic.
+- [ ] `cargo deny check` clean (advisory fixed or acknowledged in `deny.toml`).
+
+## Disclosure timeline
+
+<!--
+- Reported: <date>
+- Triaged: <date>
+- Fix ready: <date>
+- Public disclosure target: <date or "with release">
+-->
+
+## Test plan
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace --all-targets --locked`
+- [ ] `cargo deny check`
+- [ ] Manual reproduction of the vulnerability pre-fix confirms failure; post-fix confirms success.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot config for the Beast Evolution Game workspace.
+#
+# Two ecosystems: Rust crates (via Cargo.lock) and GitHub Actions pins in
+# `.github/workflows/`. Both run weekly on Monday mornings so PRs arrive
+# together and can be reviewed in one sitting.
+#
+# Strategy:
+# * Group patch + minor bumps into a single PR per ecosystem so we don't
+#   drown in individual Dependabot PRs for trivial bumps.
+# * Keep major bumps as individual PRs — they're rarely drop-in and merit
+#   per-dep review (jsonschema, fixed, rand_xoshiro all have tight
+#   invariants around determinism).
+# * Ignore any advisory-specific bumps; `cargo-deny` already catches those
+#   in CI, and a Dependabot PR for a yanked version is noise.
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      cargo-patch-minor:
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions-patch-minor:
+        update-types:
+          - patch
+          - minor

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Default PR template. GitHub picks one of the specialised templates under
+.github/PULL_REQUEST_TEMPLATE/ when you pass `?template=<name>.md` on
+the PR creation URL — e.g.
+https://github.com/BemusedVermin/evolution-simulation/compare/master...my-branch?template=bug_fix.md
+
+If your PR is a clean fit for Feature, Bug Fix, Security, or
+Determinism, prefer the specialised template. Use this one for
+anything else (infra, docs, CI tweaks, refactors).
+-->
+
+## Summary
+
+<!-- One or two sentences. What changes, and why? -->
+
+## Changes
+
+<!-- Bullet list of the meaningful edits. File paths welcome. -->
+
+-
+-
+
+## Linked issues
+
+<!-- Closes #N / Part of #N / See #N. Or "none" if this is drive-by infra. -->
+
+## Invariant impact
+
+<!--
+See documentation/INVARIANTS.md. Tick one.
+
+- [ ] No invariant touched.
+- [ ] Touches determinism (fixed-point, sorted iteration, PRNG streams).
+- [ ] Touches mechanics-label separation.
+- [ ] Touches channel registry monolithicism.
+- [ ] Touches another invariant (explain below).
+-->
+
+## Test plan
+
+<!--
+Concrete commands a reviewer can run. Check each off as you verify.
+
+- [ ] cargo fmt --all -- --check
+- [ ] cargo clippy --workspace --all-targets -- -D warnings
+- [ ] cargo test --workspace --all-targets --locked
+- [ ] cargo test --workspace --doc --locked
+- [ ] cargo deny check (if deps changed)
+- [ ] Any manual verification steps the reviewer can't infer from tests
+-->
+
+## Notes for reviewer
+
+<!-- Anything non-obvious: trade-offs taken, follow-ups deferred, surprising diffs. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,25 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --all-targets --locked
 
+  # Dependency audit: advisories, licenses, unknown registries / git sources.
+  # Configuration lives in `deny.toml` at the repo root. Failing here means a
+  # new dep has a known CVE, uses an unvetted license, or was pulled from a
+  # source we haven't approved.
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: cargo deny check
+        run: cargo deny check --hide-inclusion-graph
+
   # Release build ensures nothing regressed under opt-level=3 + LTO.
   release-build:
     name: release-build (ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,46 @@ jobs:
       - name: cargo deny check
         run: cargo deny check --hide-inclusion-graph
 
+  # Coverage reporting. Report-only today — testing.md targets 80% line
+  # coverage; once we have baseline numbers from a few CI runs we can flip
+  # the `--fail-under-lines` flag on to enforce the threshold. Runs with
+  # `--no-fail-fast` so a single flaky test doesn't mask the coverage report.
+  coverage:
+    name: coverage (ubuntu)
+    needs: lint-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-coverage
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: cargo llvm-cov (summary)
+        run: cargo llvm-cov --workspace --all-targets --locked --summary-only --no-fail-fast
+
+      - name: cargo llvm-cov (LCOV for upload)
+        run: cargo llvm-cov --workspace --all-targets --locked --lcov --output-path lcov.info --no-fail-fast
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          retention-days: 14
+
   # Release build ensures nothing regressed under opt-level=3 + LTO.
   release-build:
     name: release-build (ubuntu)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+Public issues are indexed by search engines and cached before they can be
+triaged, so even a short-lived issue can leak exploit details to the world.
+
+### How to report
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab][security-tab] on this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form with repro steps, affected component, and any
+   suggested remediation.
+
+[security-tab]: https://github.com/BemusedVermin/evolution-simulation/security
+
+If the Security tab is not available to you, email **liammcg44@gmail.com**
+with `[SECURITY] beast-evolution-game` in the subject line. Encrypt the
+message if you have access to my public key; otherwise plain email is
+acceptable for an initial heads-up and we can move to an encrypted channel
+once a report is acknowledged.
+
+### What to include
+
+- Affected commit / tag / branch.
+- Affected component (crate name, module path, or manifest file).
+- Reproduction steps that are **minimal and deterministic**. Because this
+  project's correctness contract is deterministic replay, an issue that
+  reproduces from a specific seed + tick count is much easier to triage
+  than one that requires manual reproduction.
+- Expected versus observed behaviour.
+- Your assessment of severity (optional).
+
+### What to expect
+
+- Acknowledgement within **72 hours** of the initial report.
+- A plain-language triage response within **7 days** describing whether
+  the issue is in scope, the rough severity, and the expected fix
+  timeline.
+- A fix, mitigation, or explicit won't-fix decision within **30 days**
+  for confirmed vulnerabilities. If circumstances require longer, you
+  will be told why.
+- Public disclosure (GitHub Security Advisory + release notes) coordinated
+  with you, typically once a fix has been released.
+
+## In scope
+
+- All code under this repository (every `beast-*` crate, CI workflows,
+  and any tooling scripts).
+- The JSON manifest schemas under `documentation/schemas/` when a
+  malformed input can trigger a panic, infinite loop, or resource
+  exhaustion in the runtime loaders.
+- Determinism invariants documented in `documentation/INVARIANTS.md`
+  when a realistic input can cause bit-divergent replay (this is a
+  correctness bug with save/load implications, treated like a security
+  issue for disclosure purposes).
+
+## Out of scope
+
+- Vulnerabilities in third-party crates — please report those upstream.
+  We track them via `cargo-deny` on every PR and respond to RUSTSEC
+  advisories as they surface.
+- Social engineering of the maintainers.
+- Denial-of-service via unbounded input sizes you control (e.g. feeding
+  an infinitely large JSON manifest). These are interesting but not
+  treated as vulnerabilities at this stage of the project.
+
+## Non-sensitive security concerns
+
+For hardening suggestions, defense-in-depth ideas, or questions about
+how a given subsystem handles malformed input, open a regular
+**Security** issue from the template. Those are fine to discuss in
+public.

--- a/crates/beast-channels/tests/schema_drift.rs
+++ b/crates/beast-channels/tests/schema_drift.rs
@@ -1,0 +1,78 @@
+//! Schema-drift guard: walks `documentation/schemas/examples/` at test time
+//! and parses every `.json` file through the runtime loader.
+//!
+//! The companion test in `example_manifests.rs` pins five specific examples
+//! via `include_str!`. That hardcoded list only protects the files we
+//! remembered to add to it — a sixth example landing without a corresponding
+//! entry would slip through unchecked. This test iterates the directory at
+//! runtime, so *any* new JSON fixture must parse or the build goes red.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use beast_channels::ChannelManifest;
+
+/// Path to `documentation/schemas/examples/` relative to the workspace root,
+/// resolved via `CARGO_MANIFEST_DIR` so the test works from any cwd.
+fn examples_dir() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .join("..")
+        .join("..")
+        .join("documentation")
+        .join("schemas")
+        .join("examples")
+}
+
+#[test]
+fn every_example_manifest_parses() {
+    let dir = examples_dir();
+    let entries =
+        fs::read_dir(&dir).unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+
+    let mut checked = 0usize;
+    for entry in entries {
+        let entry = entry.expect("valid DirEntry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        ChannelManifest::from_json_str(&source).unwrap_or_else(|e| {
+            panic!(
+                "{} failed to parse as ChannelManifest:\n{e}",
+                path.display()
+            )
+        });
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "no .json fixtures found under {} — did the docs directory move?",
+        dir.display()
+    );
+}
+
+/// Parallel guard: if the canonical JSON Schema file on disk ever diverges
+/// from the one embedded into the crate via `include_str!`, this test will
+/// fail. Catches the pathological case where someone copies the schema into
+/// the crate directory and edits one copy without touching the other.
+#[test]
+fn embedded_schema_matches_canonical_file() {
+    let canonical = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("documentation")
+        .join("schemas")
+        .join("channel_manifest.schema.json");
+    let on_disk = fs::read_to_string(&canonical)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", canonical.display()));
+    assert_eq!(
+        on_disk,
+        beast_channels::CHANNEL_MANIFEST_SCHEMA,
+        "embedded schema has drifted from {}",
+        canonical.display(),
+    );
+}

--- a/crates/beast-primitives/tests/schema_drift.rs
+++ b/crates/beast-primitives/tests/schema_drift.rs
@@ -1,0 +1,72 @@
+//! Schema-drift guard: mirrors `beast-channels::tests::schema_drift` for the
+//! primitive vocabulary. Walks `documentation/schemas/primitive_vocabulary/`
+//! at test time and parses every `.json` through
+//! `PrimitiveManifest::from_json_str`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use beast_primitives::PrimitiveManifest;
+
+fn vocabulary_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("documentation")
+        .join("schemas")
+        .join("primitive_vocabulary")
+}
+
+#[test]
+fn every_vocabulary_manifest_parses() {
+    let dir = vocabulary_dir();
+    let entries =
+        fs::read_dir(&dir).unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+
+    let mut checked = 0usize;
+    for entry in entries {
+        let entry = entry.expect("valid DirEntry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        PrimitiveManifest::from_json_str(&source).unwrap_or_else(|e| {
+            panic!(
+                "{} failed to parse as PrimitiveManifest:\n{e}",
+                path.display()
+            )
+        });
+        checked += 1;
+    }
+
+    // The starter vocabulary is exactly 16 primitives (see
+    // `documentation/schemas/README.md`). If that count ever changes, update
+    // this assertion in the same PR that moves the catalogue — drifting the
+    // number silently would be a reviewer footgun.
+    assert_eq!(
+        checked,
+        16,
+        "expected 16 starter primitives under {}, found {checked}",
+        dir.display(),
+    );
+}
+
+#[test]
+fn embedded_schema_matches_canonical_file() {
+    let canonical = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("documentation")
+        .join("schemas")
+        .join("primitive_manifest.schema.json");
+    let on_disk = fs::read_to_string(&canonical)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", canonical.display()));
+    assert_eq!(
+        on_disk,
+        beast_primitives::PRIMITIVE_MANIFEST_SCHEMA,
+        "embedded schema has drifted from {}",
+        canonical.display(),
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,67 @@
+# cargo-deny configuration for the Beast Evolution Game workspace.
+#
+# Run locally with `cargo deny check`. CI runs the same command against every
+# PR (see `.github/workflows/ci.yml`, job `cargo-deny`). Four sections:
+#
+# * [advisories] — RUSTSEC vulnerabilities; block on any.
+# * [licenses]   — allow a small, recognisable set; reject everything else so
+#                  GPL / unclear / unlicensed crates can't slip in unnoticed.
+# * [bans]       — block wildcard external deps; permit the workspace's own
+#                  path-based `{ workspace = true }` references.
+# * [sources]    — only crates.io and workspace paths (no arbitrary git).
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "warn"
+# Treat every unreviewed advisory as a hard failure. If we ever need to
+# acknowledge-and-ship through one, add its RUSTSEC id to `ignore` with a
+# dated justification.
+ignore = []
+
+[licenses]
+version = 2
+# Covers every permissive license used by the crates in our current graph
+# plus the handful most people reach for. If a new dep introduces an
+# unrecognised license, the CI run will fail loudly — the right response is
+# to audit the crate and either add the license here with a comment or swap
+# the crate out.
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "CC0-1.0",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+# Our own workspace crates declare `license = "Proprietary"` in Cargo.toml —
+# this is not a valid SPDX expression, but these crates also set
+# `publish = false`, so treating them as private and skipping the license
+# check is correct. cargo-deny exempts a crate iff it is publish = false AND
+# its name is registered (or `ignore = true` is set here).
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# `{ workspace = true }` resolves to a wildcard version in cargo-deny's view
+# but is actually a tightly-pinned path dep inside the workspace. This flag
+# carves out that legitimate case without weakening the wildcard ban on
+# external crates.
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/documentation/PROGRESS_LOG.md
+++ b/documentation/PROGRESS_LOG.md
@@ -63,6 +63,45 @@ This file is the canonical running log of implementation work on the Beast Evolu
 
 ## Session Log (reverse chronological)
 
+### 2026-04-15 — Post-S2 infra: cargo-deny, Dependabot, schema drift, coverage (Claude)
+
+Five small commits on `infra/cargo-deny-and-coverage`, landing the
+non-tracking items from the post-merge recommendations (item #2, the
+GitHub Project board + per-sprint issues, deferred to a separate
+session).
+
+- **`cargo-deny`** (`8e3c170`) — `deny.toml` covers advisories (block
+  on any RUSTSEC), licenses (allow-list of ~12 permissive SPDX
+  expressions + `[licenses.private] ignore = true` so our own
+  `publish = false` "Proprietary" crates are skipped), bans
+  (`multiple-versions = "warn"` for the benign `getrandom` 0.2/0.3
+  duplicate, `wildcards = "deny"` with `allow-wildcard-paths = true`
+  so `{ workspace = true }` is permitted), sources (crates.io only).
+  CI job installs via `taiki-e/install-action` to avoid the 2-minute
+  compile-from-source cost.
+- **Dependabot** (`ca0b5c9`) — weekly Monday 09:00 UTC for cargo +
+  github-actions. Patch+minor bumps grouped into one PR per ecosystem;
+  majors come through individually because the determinism-critical
+  crates (jsonschema, fixed, rand_xoshiro) warrant per-bump review.
+- **Schema-drift guards** (`ac9bece` for channels, `0025505` for
+  primitives) — integration tests that walk
+  `documentation/schemas/examples/` and `primitive_vocabulary/` at
+  test time via `std::fs` from `CARGO_MANIFEST_DIR`. Every `.json`
+  file must parse via the runtime loader. Second test in each crate
+  pins the embedded `include_str!` schema byte-for-byte against the
+  canonical file on disk. The primitive-side test also asserts the
+  starter-vocabulary count is exactly 16 so adding/removing a
+  primitive is a reviewer-visible change.
+- **Coverage reporting** (`37ffa31`) — new `coverage` job runs
+  `cargo-llvm-cov` with `--summary-only` (per-crate numbers in log)
+  and `--lcov --output-path lcov.info` (uploaded as `coverage-lcov`
+  artifact with 14-day retention). Report-only to start; enabling
+  `--fail-under-lines 80` is a one-line follow-up once we have a
+  baseline.
+
+Deferred to its own session: GitHub Project v2 board with per-sprint
+issues and issue templates (Story / Bug / Determinism-regression).
+
 ### 2026-04-15 — Sprint S2 implementation (Claude)
 
 Two new crates, both Layer 1, both depend only on `beast-core`

--- a/documentation/PROGRESS_LOG.md
+++ b/documentation/PROGRESS_LOG.md
@@ -99,8 +99,18 @@ session).
   `--fail-under-lines 80` is a one-line follow-up once we have a
   baseline.
 
+- **Issue + PR templates** (`2c42b04`, issue templates commit,
+  PR templates commit) — five issue YAML forms (feature_request,
+  feature_task, bug_report, security, determinism_regression) with
+  `config.yml` disabling blank issues and linking to CONTRIBUTING.md
+  and the private-advisory form. Default `pull_request_template.md`
+  for generic PRs plus four specialised templates (feature.md,
+  bug_fix.md, security.md, determinism.md) activated via
+  `?template=<name>.md`. `SECURITY.md` at the repo root establishes
+  private-disclosure process with explicit SLAs.
+
 Deferred to its own session: GitHub Project v2 board with per-sprint
-issues and issue templates (Story / Bug / Determinism-regression).
+issues.
 
 ### 2026-04-15 — Sprint S2 implementation (Claude)
 


### PR DESCRIPTION
## Summary

Post-S2 infrastructure bundle. Three buckets:

- **Dependency & security gates** — `cargo-deny` gate in CI, Dependabot weekly, `SECURITY.md` private-disclosure policy.
- **Schema-drift guards** — walk `documentation/schemas/examples/` and `primitive_vocabulary/` at test time; pin embedded `include_str!` schemas byte-for-byte against the canonical files.
- **Coverage + contribution templates** — `cargo-llvm-cov` CI job (report-only), five issue templates + `config.yml`, default + four specialised PR templates.

## Commits (10, each scoped to one concern)

| # | Scope | Commit |
|---|-------|--------|
| 1 | cargo-deny config + CI job | `8e3c170` |
| 2 | Dependabot (cargo + github-actions, weekly) | `ca0b5c9` |
| 3 | beast-channels schema-drift test | `ac9bece` |
| 4 | beast-primitives schema-drift test | `0025505` |
| 5 | cargo-llvm-cov coverage CI job | `37ffa31` |
| 6 | PROGRESS_LOG session entry | `a539524` |
| 7 | SECURITY.md private disclosure policy | `2c42b04` |
| 8 | Issue templates (5 + config) | `3fe4907` |
| 9 | PR templates (default + 4) | `de29190` |
| 10 | PROGRESS_LOG extended with templates | `7187f6b` |

## What's in scope

### cargo-deny (`deny.toml` + CI job)

- **Advisories**: any active RUSTSEC fails CI.
- **Licenses**: ~12 permissive SPDX allowlist + `[licenses.private] ignore = true` so our own `publish = false` workspace crates' `license = "Proprietary"` is skipped.
- **Bans**: `multiple-versions = "warn"` (benign `getrandom` 0.2/0.3 duplicate), `wildcards = "deny"` for external crates, `allow-wildcard-paths = true` for `{ workspace = true }` refs.
- **Sources**: crates.io only.
- Verified locally: `advisories ok, bans ok, licenses ok, sources ok`.

### Dependabot

Weekly Monday 09:00 UTC for cargo + github-actions. Patch + minor bumps grouped per-ecosystem. Majors land individually so determinism-critical crates (jsonschema, fixed, rand_xoshiro) get per-bump review.

### Schema-drift guards

Two integration tests per manifest crate:

1. `every_{example,vocabulary}_manifest_parses` — walks the docs directory at test time via `std::fs` from `CARGO_MANIFEST_DIR` and parses every `.json` through the runtime loader. Catches new fixtures that forgot to wire into `example_manifests.rs`'s hardcoded `include_str!` list, and catches existing fixtures edited into a state the current schema/loader rejects.
2. `embedded_schema_matches_canonical_file` — pins the embedded `CHANNEL_MANIFEST_SCHEMA` / `PRIMITIVE_MANIFEST_SCHEMA` byte-for-byte against the canonical file on disk. Prevents the pathological case of someone copying the schema into the crate directory and editing one copy.

The primitives-side test also asserts the starter-vocabulary count is exactly 16.

### Coverage reporting

New `coverage` job runs after `lint-and-test` on ubuntu, produces a per-crate `--summary-only` summary in the CI log plus an LCOV artifact (`coverage-lcov`, 14-day retention). Report-only today; once we have a baseline we can flip on `--fail-under-lines 80` to enforce the threshold from `rules/common/testing.md`.

### SECURITY.md

Private disclosure via GitHub Security Advisories (with email fallback). Explicit SLAs: 72h ack, 7d triage, 30d fix-or-won't-fix. Determinism-invariant violations are treated under the security track because they silently corrupt save/load/replay.

### Issue templates

YAML forms (structured fields, auto-labels):

- `feature_request.yml` — problem, proposal, alternatives, invariant impact, sprint, acceptance.
- `feature_task.yml` — parent, sprint, points, scope / out-of-scope, acceptance DoD checklist, invariant impact.
- `bug_report.yml` — what/expected/repro/output/commit/OS/rustc/severity. Gates on "is this security? is this determinism?" and redirects.
- `security.yml` — non-sensitive only; confirmation checkbox re-states that exploitable vulns go through `SECURITY.md`.
- `determinism_regression.yml` — project-critical. Seed, first divergent tick, platforms, suspected cause ordered per INVARIANTS.md triage (precision → seeding → iteration order), binary diff when the determinism test emits one.
- `config.yml` — disables blank issues, links to CONTRIBUTING.md, private advisory form, planning docs.

### PR templates

Default `pull_request_template.md` for generic PRs (infra, docs, refactors). Four specialised templates under `.github/PULL_REQUEST_TEMPLATE/` activated via `?template=<name>.md`:

- `feature.md` — summary, linked issues, design notes, invariant impact, test plan, docs checklist, explicit out-of-scope.
- `bug_fix.md` — root cause (not just symptom), failing-before/passing-after regression test, risk for other callers.
- `security.md` — gates on undisclosed-vuln path (→ Security Advisory private branch), vulnerability class, affected versions, disclosure timeline.
- `determinism.md` — divergence class, root cause bucket, hash-comparison regression test requirement, explicit tickboxes for the four determinism sub-invariants.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo test --workspace --all-targets --locked` — all pass, including new schema-drift tests
- [x] `cargo test --workspace --doc --locked` clean
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [ ] CI green (new `cargo-deny` and `coverage` jobs)

## Deferred

GitHub Project v2 board + per-sprint issues — separate session per user direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)