### PR TITLE
docs: point tracking at GitHub Project board and sprint epics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Status
 
-This repo is **design-phase only** — no source code, Cargo workspace, or build tooling exists yet. It contains planning and specification documents that define an unimplemented project. Before writing code, read the design docs; do not invent architecture that contradicts them.
+Sprints S1 (fixed-point + PRNG) and S2 (manifests + registries) are shipped. The Cargo workspace is live at the repo root; `crates/beast-core`, `crates/beast-channels`, and `crates/beast-primitives` are implemented. The other planned crates are scaffolded per-sprint — don't pre-stub them.
 
-The only top-level directory is `documentation/`. All substantive content lives there.
+Design docs under `documentation/` remain authoritative for architecture and invariants; before writing code, read the relevant design doc and do not invent architecture that contradicts it.
+
+## Live work tracking
+
+Sprint and story status live on GitHub, not in the markdown planning docs.
+
+- **Project board**: https://github.com/users/BemusedVermin/projects/1 (Sprint / Phase / Points / Status per item).
+- **Sprint epics**: `label:epic` — one tracker issue per sprint (S1–S18) with the story checklist, demo criteria, DoD.
+- **Story issues**: opened per-sprint using the Feature task template; labelled `story` + `sprint:sN` + `crate:*`; reference the sprint epic.
+
+When the user asks "what's the current sprint?" or "what's next?", check the board or the open epic issues — **not** `SPRINTS.md`. The Status columns in `SPRINTS.md` and `EPICS.md` are historical scope and are not kept in sync. `documentation/PROGRESS_LOG.md` is a narrative diary (decisions, pitfalls, commits), not a status tracker.
 
 ## Project Summary
 
@@ -19,7 +29,7 @@ Beast Evolution Game is a deterministic evolution-simulation game planned in **R
 - **Serialization**: `serde` + `bincode` (deterministic config)
 - **Planned workspace**: 17 crates under `crates/` (see `documentation/architecture/CRATE_LAYOUT.md`), strictly layered L0 → L6.
 
-There is no `Cargo.toml` yet. When scaffolding, follow the crate dependency DAG in `CRATE_LAYOUT.md` — don't introduce cycles or skip layers.
+The workspace `Cargo.toml` is at the repo root. When adding new crates, follow the dependency DAG in `CRATE_LAYOUT.md` — don't introduce cycles or skip layers.
 
 ## Documentation Map (read order)
 
@@ -66,7 +76,18 @@ Per-tick budget: ~16ms (60 FPS). When adding a system, place it in the correct s
 
 ## Commands
 
-No build/test/lint commands exist yet — there is no code. Once the Cargo workspace is scaffolded, the planned determinism gate is:
+The checks CI runs on every PR (runnable locally):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets --locked
+cargo test --workspace --doc --locked
+cargo build --workspace --release --locked
+cargo deny check
+```
+
+The planned determinism gate (enforced once `beast-sim` lands in S6):
 
 ```bash
 cargo test --test determinism_test -- --nocapture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 # Contributing
 
+## Tracking work
+
+All work is tracked on GitHub, not in the markdown planning docs.
+
+- **[Project board](https://github.com/users/BemusedVermin/projects/1)** — single view of every sprint with Sprint / Phase / Points / Status fields.
+- **Sprint epic issues** ([`label:epic`](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)) — one per sprint (S1–S18) with the story checklist, demo criteria, DoD, and invariant notes.
+- **Story issues** — opened when a sprint starts, via the **Feature task** issue template. Label each story with `story`, `sprint:sN`, and the relevant `crate:*` (e.g. `crate:beast-genome`). Reference the sprint epic (`Part of #NN`) so it shows up under the epic's task list.
+- **Bugs, features, security reports, determinism regressions** — use the dedicated issue templates (blank issues are disabled).
+
+The markdown docs under `documentation/planning/` (`SPRINTS.md`, `EPICS.md`, `RISK_REGISTER.md`) document *design intent*: scope, risks, branch options. Do **not** edit their status columns to reflect current progress — the board is the source of truth. Design-intent changes (scope, deferred stories, new risks) still land in those docs via PR.
+
+`documentation/PROGRESS_LOG.md` remains a narrative diary: decisions taken, pitfalls, commit references. It is historical context, not a status tracker.
+
 ## Development setup
 
 1. Clone the repo.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,33 @@
 
 A deterministic evolution-simulation game in Rust. Genomes mutate, phenotypes express against biomes, creatures interact, and a separate "Chronicler" layer observes emergent behaviour and names it — sim code emits only *primitive effects* and never hand-authored ability names. Every tick is replayable bit-for-bit from a seed plus input journal.
 
-**Status**: design + Sprint S1 foundations complete. Sprint S2 (manifests + registries) is next.
+**Status**: Sprints S1 (fixed-point + PRNG) and S2 (manifests + registries) complete. Sprint S3 (genome + mutation) is next.
+
+## Live project tracking — on GitHub
+
+Sprint/story status, work-in-progress, and the up-to-date roadmap live on GitHub, **not** in the markdown planning docs. Anything here about "current sprint" or "story status" in `documentation/` is a snapshot for context; the board and issues are the source of truth.
+
+- **Project board**: https://github.com/users/BemusedVermin/projects/1 — 18 sprint epics with Sprint, Phase, Points, and Status fields. Filter by Phase or Sprint for focused views.
+- **Sprint epics**: [`label:epic`](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic) — one tracker issue per sprint (S1–S18) with goal, story checklist, demo criteria, and DoD.
+- **Current sprint issues**: filter by `label:sprint:sN` (e.g. [`sprint:s3`](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aopen+label%3Asprint%3As3)).
+- **Open a story issue**: use the "Feature task" GitHub issue template, label it `story` + `sprint:sN` + the relevant `crate:*`, and reference the sprint epic.
+
+The planning markdown under `documentation/planning/` (EPICS.md, SPRINTS.md, RISK_REGISTER.md) captures *design intent*: scope, risks, branch options, dependency graph. It is not edited to reflect day-to-day status.
 
 ## Quick orientation
 
 If you're picking this up fresh (human or Claude session), read in this order:
 
-1. **`documentation/PROGRESS_LOG.md`** — running session-to-session handoff. Current sprint, story status, open decisions, what landed in which commit, what to do next. Single source of truth for "where are we?".
-2. **`CLAUDE.md`** — repo conventions, tooling, invariants called out for Claude Code.
-3. **`documentation/INVARIANTS.md`** — the load-bearing contract (determinism, mechanics-label separation, registry monolithicism, scale-band unification, UI-vs-sim state). Violating any of these is a bug regardless of what else looks right.
-4. **`documentation/architecture/IMPLEMENTATION_ARCHITECTURE.md`** — primary architecture doc (stack, tradeoffs, data flow).
-5. **`documentation/architecture/CRATE_LAYOUT.md`** — all 17 planned crates, strict L0→L6 layering, inter-crate dependency DAG.
-6. **`documentation/architecture/ECS_SCHEDULE.md`** — 8-stage tick loop, per-stage parallelism, RNG-stream rules, per-system performance budget.
-7. **`documentation/systems/01_*.md` … `23_*.md`** — design spec per game system. Consult the specific file before implementing its crate.
-8. **`documentation/schemas/`** — authoritative JSON schemas for channel and primitive manifests. Mods and core data must validate against these.
-9. **`documentation/planning/`** — `IMPLEMENTATION_PLAN.md`, `EPICS.md`, `SPRINTS.md`, `RISK_REGISTER.md`. Sprint-level scope and sequencing.
+1. **[Project board](https://github.com/users/BemusedVermin/projects/1)** and the **[sprint epic for the active sprint](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)** — what's actually in flight right now.
+2. **`documentation/PROGRESS_LOG.md`** — session-to-session handoff diary: decisions taken, pitfalls, commit references. Historical; the GitHub board tracks live status.
+3. **`CLAUDE.md`** — repo conventions, tooling, invariants called out for Claude Code.
+4. **`documentation/INVARIANTS.md`** — the load-bearing contract (determinism, mechanics-label separation, registry monolithicism, scale-band unification, UI-vs-sim state). Violating any of these is a bug regardless of what else looks right.
+5. **`documentation/architecture/IMPLEMENTATION_ARCHITECTURE.md`** — primary architecture doc (stack, tradeoffs, data flow).
+6. **`documentation/architecture/CRATE_LAYOUT.md`** — all 17 planned crates, strict L0→L6 layering, inter-crate dependency DAG.
+7. **`documentation/architecture/ECS_SCHEDULE.md`** — 8-stage tick loop, per-stage parallelism, RNG-stream rules, per-system performance budget.
+8. **`documentation/systems/01_*.md` … `23_*.md`** — design spec per game system. Consult the specific file before implementing its crate.
+9. **`documentation/schemas/`** — authoritative JSON schemas for channel and primitive manifests. Mods and core data must validate against these.
+10. **`documentation/planning/`** — `IMPLEMENTATION_PLAN.md`, `EPICS.md`, `SPRINTS.md`, `RISK_REGISTER.md`. Sprint-level *scope and sequencing* (design intent); live status lives on the GitHub board.
 
 `documentation/Beast_Evolution_Game_Master_Design.docx` is the original design doc — prefer the markdown when possible.
 

--- a/documentation/PROGRESS_LOG.md
+++ b/documentation/PROGRESS_LOG.md
@@ -4,13 +4,15 @@ This file is the canonical running log of implementation work on the Beast Evolu
 
 **Convention**: newest entries on top under each section. Keep entries terse but concrete — file paths, decisions, and pitfalls encountered. Do NOT let this file grow past ~800 lines; when it does, rotate older content into `PROGRESS_LOG_ARCHIVE_YYYY_MM.md`.
 
+**Scope**: this log is a narrative diary — decisions, pitfalls, commit references. **Live sprint/story status is on the [GitHub Project board](https://github.com/users/BemusedVermin/projects/1) and in the [sprint epic issues](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic), not here.** The snapshot below is refreshed opportunistically but is not the source of truth; filter the board by `Sprint = Sn` or `Status = In Progress` for current state.
+
 ---
 
 ## Current Status Snapshot
 
-- **Active Sprint**: S2 — Manifests & Registries (beast-channels, beast-primitives) [Week 2] — **implementation complete, PR pending**
-- **Completed Sprints**: S1 — Fixed-Point & PRNG (beast-core) [Week 1]
-- **Next Sprint**: S3 — Genome & Mutation (beast-genome) [Week 3]
+- **Active Sprint**: S3 — Genome & Mutation (beast-genome) [Week 3] — not yet started
+- **Completed Sprints**: S1 — Fixed-Point & PRNG (beast-core) [Week 1]; S2 — Manifests & Registries (beast-channels, beast-primitives) [Week 2]
+- **Next Sprint**: S4 — Phenotype Interpreter (beast-interpreter) [Week 4]
 - **Phase**: 1 — Foundations & Core Sim
 - **Workspace scaffolded**: yes (beast-core, beast-channels, beast-primitives; other 14 crates deferred to their sprints)
 - **CI**: `.github/workflows/ci.yml` runs on every PR — fmt, clippy, test, doctests, release build, and cross-platform tests on windows/macOS. First run on PR #2 passed all 4 jobs.
@@ -62,6 +64,38 @@ This file is the canonical running log of implementation work on the Beast Evolu
 ---
 
 ## Session Log (reverse chronological)
+
+### 2026-04-15 — GitHub Project board + per-sprint issues (Claude)
+
+Migrated sprint/story tracking from the markdown planning docs to GitHub
+so live status has one source of truth and parallel sprints are easier
+to see at a glance.
+
+- **49 labels** created: `sprint:s1..s18`, `phase:1..4`, `epic`, `story`,
+  `determinism`, `invariant`, `security`, plus `crate:*` for all 13
+  workspace crates.
+- **18 sprint epic issues** (#13–#30) with sprint goal, story checklist,
+  demo criteria, DoD, invariant notes, and design-doc pointers sourced
+  from `SPRINTS.md`. S1/S2 closed as done with PR links; S3–S18 are Todo.
+- **Project v2 board** "Beast Evolution Game — Roadmap" at
+  https://github.com/users/BemusedVermin/projects/1 with custom fields:
+  **Sprint** (S1–S18 single-select), **Phase** (1–4 single-select),
+  **Points** (number). All 18 items added and populated.
+- **Documentation updates** (this commit): top-level `README.md` and
+  `CONTRIBUTING.md` now point at the board + issues as the source of
+  truth for live status; `documentation/planning/README.md` drops the
+  "update SPRINTS.md status columns weekly" workflow in favour of moving
+  issues on the board; tracking banners prepended to `SPRINTS.md` and
+  `EPICS.md` clarifying that their Status columns are historical scope.
+  This log gets a pointer at the top too — PROGRESS_LOG stays a narrative
+  diary, not a status tracker.
+
+Rationale: the markdown Status columns had already drifted out of date
+during the S2 session, and the one-to-many relationship (one sprint →
+many stories, each potentially a PR) is more naturally expressed as
+labelled issues than as rows in a table. The planning docs remain the
+reference for design intent — scope, risks, branch options — which does
+not change every sprint.
 
 ### 2026-04-15 — Post-S2 infra: cargo-deny, Dependabot, schema drift, coverage (Claude)
 
@@ -323,3 +357,7 @@ _(updated as files are created)_
 - `.githooks/pre-push` — opt-in master-push gate (PR #3).
 - `crates/beast-channels/` — Sprint S2 channel registry crate: `Cargo.toml`, `README.md`, `src/{lib,manifest,composition,expression,registry,schema}.rs`, `tests/{example_manifests,malformed_manifests}.rs`.
 - `crates/beast-primitives/` — Sprint S2 primitive registry crate: `Cargo.toml`, `README.md`, `src/{lib,manifest,category,cost,effect,math,registry,schema}.rs`, `tests/{example_manifests,malformed_manifests}.rs`.
+
+### GitHub-side tracking (live, not in-repo)
+- **[Project board](https://github.com/users/BemusedVermin/projects/1)** — Sprint/Phase/Points/Status per item for all 18 sprints.
+- **[Sprint epic issues](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)** (#13–#30) — one per sprint, with story checklists.

--- a/documentation/planning/EPICS.md
+++ b/documentation/planning/EPICS.md
@@ -1,6 +1,12 @@
 # Beast Evolution Game: Epic Definitions & Tracking
 
-This document provides a detailed breakdown of all 14 epics with acceptance criteria, dependencies, and tracking metrics.
+This document defines the 14 epics with acceptance criteria, dependencies, and tracking metrics.
+
+> **Live epic status is on GitHub — not in this file.**
+>
+> The `**Status**:` lines below reflect initial planning and are kept as historical scope. They are **not** updated as work progresses.
+>
+> For current status see the **[Project board](https://github.com/users/BemusedVermin/projects/1)** and the **[Sprint epic issues](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)**. Sprint-level rollup on the board maps 1:1 to the epics defined here.
 
 ---
 

--- a/documentation/planning/README.md
+++ b/documentation/planning/README.md
@@ -1,6 +1,14 @@
 # Beast Evolution Game: Planning Documentation
 
-This directory contains comprehensive planning and tracking documents for the Beast Evolution Game implementation.
+This directory contains the **design-intent** planning documents for the Beast Evolution Game: scope, risks, dependency graph, branch options, milestone definitions. It is the reference you read when deciding *what* to build and *why*.
+
+> **Live tracking is on GitHub, not in these markdown files.**
+>
+> - **[Project board](https://github.com/users/BemusedVermin/projects/1)** — the authoritative view of sprint/story/epic status (Sprint, Phase, Points, Status fields).
+> - **[Sprint epics](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)** — one per sprint (S1–S18), each with a story checklist derived from `SPRINTS.md`.
+> - **Story issues** — opened per sprint via the Feature task template, labelled `story` + `sprint:sN` + `crate:*`, referencing the sprint epic.
+>
+> Status tables and Story tables in `EPICS.md` / `SPRINTS.md` reflect planned scope, not progress. **Do not edit them to reflect current progress** — update the board and issues instead. Scope *changes* (deferred stories, re-sized points, new risks) still land in these docs via PR.
 
 ---
 
@@ -108,11 +116,13 @@ This directory contains comprehensive planning and tracking documents for the Be
 5. Reference RISK_REGISTER.md for sprint-specific risks
 
 ### For Monitoring Progress
-1. Update story status in SPRINTS.md (weekly)
-2. Track velocity: count completed story points
+1. Move issues across columns on the [Project board](https://github.com/users/BemusedVermin/projects/1) as work progresses; tick story checkboxes in the sprint epic when a story lands
+2. Track velocity: sum the `Points` field for items in the `Done` column at sprint end
 3. Compare actual velocity to baseline 40 pts/sprint
 4. If velocity drops, adjust timeline (see IMPLEMENTATION_PLAN.md "Velocity & Adjustment")
 5. Escalate any risk with score > 15 (see RISK_REGISTER.md "Risk Monitoring")
+
+Do **not** edit `SPRINTS.md` or `EPICS.md` status columns to track progress — those tables are historical scope, not live state.
 
 ### For Deep System Branching (Post-MVP)
 1. At end of S14, choose one of four options (A/B/C/D)
@@ -236,18 +246,17 @@ Choose one deep system (Evolution/Disease/Economy/Culture) and develop for 4 spr
 
 ## Notes for Dev
 
-### Before Starting S1
-1. Ensure beast-core crate is set up with Cargo workspace
-2. Add dependencies: `fixed` (Q3232), `rand_xoshiro` (PRNG), `serde`, `serde_json`
-3. Set up CI/CD: GitHub Actions, cargo test on every commit
-4. Create GitHub issues for each story (S1–S14, copy from SPRINTS.md)
-5. Establish determinism test harness (will use starting S6)
+### Before Starting a Sprint
+1. Open the sprint's epic issue (e.g. `Sprint S3: Genome & Mutation`) on GitHub
+2. Confirm dependencies listed in the epic are closed / merged
+3. Open a story issue per story in the epic's checklist using the **Feature task** template, labelled `story` + `sprint:sN` + `crate:*`, referencing the epic (`Part of #NN`)
+4. Move the epic to `In Progress` on the [Project board](https://github.com/users/BemusedVermin/projects/1) and assign yourself
 
 ### During Each Sprint
-1. At sprint start: copy stories from SPRINTS.md into GitHub Issues
-2. At daily standup: review story status, identify blockers
-3. At sprint mid-point: check velocity; adjust sprint scope if needed
-4. At sprint end: mark stories complete, update EPICS.md and SPRINTS.md status
+1. Pick the next story issue; move it to `In Progress`
+2. Work in a topic branch; open a PR using the appropriate PR template when ready
+3. On merge: close the story issue, tick the matching checkbox in the sprint epic
+4. At sprint end: move the epic to `Done` once the DoD checklist is complete; record velocity via the `Points` field
 
 ### Risk Management
 1. At sprint start: review RISK_REGISTER.md "Sprint Risk Focus" (if provided)

--- a/documentation/planning/SPRINTS.md
+++ b/documentation/planning/SPRINTS.md
@@ -1,5 +1,15 @@
 # Beast Evolution Game: Sprint Plan & Detailed Breakdown
 
+> **Live status is on GitHub — not in this file.**
+>
+> The Status columns in the sprint tables below reflect *initial planning* and are kept as historical scope. They are **not** updated as work completes.
+>
+> For current sprint/story status use:
+> - **[Project board](https://github.com/users/BemusedVermin/projects/1)** — Sprint, Phase, Points, Status per item.
+> - **[Sprint epics](https://github.com/BemusedVermin/evolution-simulation/issues?q=is%3Aissue+label%3Aepic)** — one tracker issue per sprint.
+>
+> Scope changes (deferred stories, re-sized points, new stories) still land in this file via PR; in-progress status does not.
+
 ---
 
 ## Sprint Calendar (14 Sprints, MVP + 1 Deep System)


### PR DESCRIPTION
## Summary

- Point repository documentation at the [GitHub Project board](https://github.com/users/BemusedVermin/projects/1) and the per-sprint epic issues (`label:epic`, #13–#30) as the source of truth for sprint/story status.
- Clarify that the markdown planning docs under `documentation/planning/` (EPICS.md, SPRINTS.md) retain *design intent* — scope, risks, branch options, dependency graph — but their Status columns/lines are historical scope and are no longer updated as work progresses.
- Refresh `CLAUDE.md` and `README.md` to match current repo reality (S1 + S2 shipped; workspace with three crates live) and give future sessions a clear "check the board, not SPRINTS.md" instruction.

## Changes

- \`README.md\` — new \"Live project tracking — on GitHub\" section up front; orientation list starts with the board + active sprint epic; status line updated to reflect S1 + S2 complete.
- \`CONTRIBUTING.md\` — new \"Tracking work\" section covering project board, sprint epics, story issues via Feature task template, other specialised templates.
- \`CLAUDE.md\` — replaces \"design-phase only\" / \"no Cargo.toml yet\" with current state; adds \"Live work tracking\" section; \`Commands\` section shows the real CI checks (\`fmt\`, \`clippy -D warnings\`, tests, doctests, release build, \`cargo deny\`).
- \`documentation/PROGRESS_LOG.md\` — scope clarified as a narrative diary; Status Snapshot refreshed; new session-log entry records the tracking migration; File Index points to the board + epic issues.
- \`documentation/planning/README.md\` — top banner redirecting to board/epics; \"Monitoring Progress\" and \"Before/During Each Sprint\" rewritten around issues and the board.
- \`documentation/planning/SPRINTS.md\` + \`EPICS.md\` — short banners at the top noting Status columns/lines are historical scope.

## Linked issues

Follow-up on the post-S2 infra recommendation (GitHub Project board + per-sprint issues, previously deferred). No code issues are closed by this PR.

## Invariant impact

- [x] No invariant touched.

Docs-only; no effect on determinism, mechanics-label separation, channel registry, or any other invariant.

## Test plan

- [x] \`cargo fmt --all -- --check\` (no code changes, expected no-op)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (no code changes)
- [x] Visual review of the seven modified docs — especially the README + CLAUDE.md top-of-file, since those are the first thing new sessions read.
- [x] Click-through on the hard-coded project/issue URLs to confirm they resolve (board URL, epics filter URL, \`sprint:s3\` filter URL).

## Notes for reviewer

- The GitHub Project board + 18 sprint epic issues were created in-session before this PR; the board URL is fixed at \`/users/BemusedVermin/projects/1\`, so the documentation can safely hard-link to it.
- Not touched: \`documentation/planning/IMPLEMENTATION_PLAN.md\` and \`RISK_REGISTER.md\`. Both are pure design-intent content (no active Status columns driving day-to-day work), and the banner on \`planning/README.md\` covers them by reference. Happy to add per-file banners there too if you prefer consistency across the directory.