### PR TITLE
fix(bench): use std::hint::black_box for criterion 0.8 compatibility

### DIFF
--- a/crates/beast-core/benches/core_bench.rs
+++ b/crates/beast-core/benches/core_bench.rs
@@ -5,8 +5,10 @@
 //! PRNG `next_u64`, and Gaussian sampling. Higher-level throughput
 //! benchmarks live in `beast-cli` once the tick loop exists.
 
+use std::hint::black_box;
+
 use beast_core::{gaussian_q3232, Prng, Stream, Q3232};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 
 fn bench_q3232_mul(c: &mut Criterion) {
     let mut group = c.benchmark_group("q3232");


### PR DESCRIPTION
## Summary

Criterion 0.8 deprecates \`criterion::black_box\` in favour of \`std::hint::black_box\`. With our \`-D warnings\` CI policy the deprecation fires as a hard error, so Dependabot PR #10 (bumping criterion 0.5.1 → 0.8.2) currently fails to compile the benches.

\`std::hint::black_box\` has been stable since Rust 1.66 — well under our MSRV of 1.75 — and is the recommended replacement with identical semantics. Switching the import on master keeps the benches working on criterion 0.5 today and unblocks Dependabot PR #10 on rebase, with no public API surface change.

## Changes

- \`crates/beast-core/benches/core_bench.rs\`: replace \`use criterion::{black_box, ...}\` with \`use std::hint::black_box\` (top-of-module per rustfmt grouping).

## Linked issues

Unblocks Dependabot PR #10 (criterion 0.8.2).

## Invariant impact

- [x] No invariant touched.

Benches are dev-only; no change to simulation state, determinism, or any public API.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean on criterion 0.5 (master baseline)
- [ ] CI runs the same checks on this PR
- [ ] Dependabot PR #10 auto-rebases onto master post-merge and goes green

## Notes for reviewer

One-line-ish change; I verified locally that \`cargo check --benches -p beast-core\` still builds cleanly on criterion 0.5.1 (our current pin). The fix is forward-compatible with criterion 0.8.