### PR TITLE
deps: bump rand_core 0.6→0.9 and rand_xoshiro 0.6→0.7 together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "criterion",
  "fixed",
  "proptest",
- "rand_core 0.6.4",
+ "rand_core",
  "rand_xoshiro",
  "serde",
  "serde_json",
@@ -915,7 +915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -925,14 +925,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -949,16 +943,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ publish = false
 
 [workspace.dependencies]
 fixed = { version = "1.28", features = ["serde"] }
-rand_core = "0.6"
-rand_xoshiro = { version = "0.6", features = ["serde1"] }
+rand_core = "0.9"
+rand_xoshiro = { version = "0.7", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/beast-core/src/prng.rs
+++ b/crates/beast-core/src/prng.rs
@@ -202,10 +202,6 @@ impl RngCore for Prng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.inner.fill_bytes(dest)
     }
-    #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.inner.try_fill_bytes(dest)
-    }
 }
 
 // ---------- Tests ----------


### PR DESCRIPTION
## Summary

Supersedes Dependabot PR #9. That PR bumped \`rand_core\` alone, which is nonsense: \`rand_xoshiro\` 0.6 publicly depends on \`rand_core\` 0.6, so the unilateral bump produced two incompatible copies in the graph and broke every \`Xoshiro256PlusPlus: RngCore\` call site. \`rand_core\` and \`rand_xoshiro\` have to move in lockstep.

Both \`rand_core\` 0.9.5 and \`rand_xoshiro\` 0.7.0 declare MSRV **1.63** — well under our own MSRV **1.75** — so the bump lands cleanly without any toolchain change. The follow-on majors (\`rand_core\` 0.10, \`rand_xoshiro\` 0.8) require MSRV 1.85 / edition 2024 and are deliberately out of scope here; those stay where they are until we commit to the MSRV bump.

## Changes

- \`Cargo.toml\`
  - \`rand_core = \"0.6\"\` → \`\"0.9\"\`
  - \`rand_xoshiro = { version = \"0.6\", features = [\"serde1\"] }\` → \`{ version = \"0.7\", features = [\"serde\"] }\`. The optional serde feature was renamed in 0.7; the on-disk format is unchanged.
- \`crates/beast-core/src/prng.rs\`
  - Drop the \`try_fill_bytes\` impl on \`Prng\`. \`rand_core\` 0.9 removed this from \`RngCore\` (alongside \`rand_core::Error\`) because infallible RNGs never needed a fallible byte-fill. \`next_u32\`, \`next_u64\`, and \`fill_bytes\` are unchanged.
- \`Cargo.lock\` — regenerated.

## Linked issues

Supersedes Dependabot PR #9 — will close after this merges.

## Invariant impact

- [x] Touches determinism (fixed-point, sorted iteration, PRNG streams).

**Reviewed:** Xoshiro256PlusPlus is algorithmically fixed; the upstream \`seed_from_u64\` path still runs SplitMix64 to expand to the 256-bit state, producing bit-exact identical output across the 0.6 → 0.7 bump. All existing determinism-sensitive tests pass:

- \`same_seed_produces_identical_sequence\` (1024 draws bit-exact)
- \`split_stream_is_deterministic\` (256 draws × 2 streams)
- \`split_stream_does_not_alias_master\` (regression guard for discriminant 0)
- \`stream_variants_have_distinct_jumps\` (no long-jump collisions)
- \`serde_roundtrip_preserves_sequence\` (serialised state round-trips and continues the same sequence)
- 100k-sample proptest statistical properties

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace --all-targets --locked\` — 94+ tests incl. proptests, all green
- [x] \`cargo test --workspace --doc --locked\` — 4 doctests green
- [x] \`cargo deny check\` — advisories / bans / licenses / sources all pass
- [x] Same checks on CI (Ubuntu + Windows + macOS cross-platform)

## Notes for reviewer

- The PR is intentionally a single coherent bump rather than two separate PRs — \`rand_core\` and \`rand_xoshiro\` are one unit for us since we only ever construct \`Xoshiro256PlusPlus\` and speak to it through \`RngCore\` traits. Splitting them would just re-create the \"two rand_core copies\" failure Dependabot ran into.
- No save files exist yet (Sprint S7 is what lands save/load), so there's no replay-compatibility risk from the \`serde1\` → \`serde\` feature rename. The in-memory serde format for \`Xoshiro256PlusPlus\` has been stable across the rename.
- Does **not** ignore rand_core / rand_xoshiro in \`dependabot.yml\` — future Dependabot bumps of these two will continue to arrive, though majors that pull in rand_core 0.10+ will only be mergeable after we bump MSRV to 1.85. At that point we can decide case-by-case; no point silencing Dependabot pre-emptively.