### PR TITLE
S3.1: scaffold beast-genome and add Genome/TraitGene types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-genome"
+version = "0.1.0"
+dependencies = [
+ "beast-channels",
+ "beast-core",
+ "proptest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "beast-primitives"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/beast-core",
     "crates/beast-channels",
     "crates/beast-primitives",
+    "crates/beast-genome",
 ]
 
 [workspace.package]
@@ -33,6 +34,7 @@ regex = "1"
 beast-core = { path = "crates/beast-core" }
 beast-channels = { path = "crates/beast-channels" }
 beast-primitives = { path = "crates/beast-primitives" }
+beast-genome = { path = "crates/beast-genome" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-channels/src/manifest.rs
+++ b/crates/beast-channels/src/manifest.rs
@@ -56,6 +56,10 @@ pub enum BoundsPolicy {
 }
 
 /// Origin of a channel. Mirrors the schema's `provenance` discriminated regex.
+///
+/// Serializes as the same canonical string form used in channel manifest
+/// JSON (`"core"`, `"mod:foo"`, `"genesis:foo:123"`). This keeps save files
+/// self-describing and round-trippable without needing a separate enum tag.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Provenance {
     /// A canonical channel shipped by the core game.
@@ -72,6 +76,28 @@ pub enum Provenance {
 }
 
 impl Provenance {
+    /// Render back into the canonical schema string form.
+    #[must_use]
+    pub fn to_schema_string(&self) -> String {
+        match self {
+            Self::Core => "core".to_owned(),
+            Self::Mod(id) => format!("mod:{id}"),
+            Self::Genesis { parent, generation } => format!("genesis:{parent}:{generation}"),
+        }
+    }
+
+    /// Parse a provenance string in the canonical schema form.
+    ///
+    /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
+    /// is enforced by JSON Schema validation inside the manifest loader.
+    /// This entry point is useful for downstream crates (e.g. `beast-genome`)
+    /// that need to construct a provenance from a freshly minted string —
+    /// it performs the same structural split as [`Provenance::parse`] but
+    /// without the manifest-load error context.
+    pub fn from_schema_str(raw: &str) -> Result<Self, ChannelLoadError> {
+        Self::parse(raw)
+    }
+
     /// Parse the JSON `provenance` string.
     ///
     /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
@@ -102,6 +128,25 @@ impl Provenance {
             });
         }
         Err(ChannelLoadError::InvalidProvenance(raw.to_owned()))
+    }
+}
+
+impl Serialize for Provenance {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_schema_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Provenance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/beast-channels/src/manifest.rs
+++ b/crates/beast-channels/src/manifest.rs
@@ -89,21 +89,10 @@ impl Provenance {
     /// Parse a provenance string in the canonical schema form.
     ///
     /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
-    /// is enforced by JSON Schema validation inside the manifest loader.
-    /// This entry point is useful for downstream crates (e.g. `beast-genome`)
-    /// that need to construct a provenance from a freshly minted string —
-    /// it performs the same structural split as [`Provenance::parse`] but
-    /// without the manifest-load error context.
-    pub fn from_schema_str(raw: &str) -> Result<Self, ChannelLoadError> {
-        Self::parse(raw)
-    }
-
-    /// Parse the JSON `provenance` string.
-    ///
-    /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
-    /// is enforced by JSON Schema validation, so this parser assumes the
-    /// structural shape is well-formed and only does the split.
-    pub(crate) fn parse(raw: &str) -> Result<Self, ChannelLoadError> {
+    /// is enforced by JSON Schema validation inside the manifest loader,
+    /// so this parser assumes the structural shape is well-formed and only
+    /// does the split.
+    pub fn parse(raw: &str) -> Result<Self, ChannelLoadError> {
         if raw == "core" {
             return Ok(Self::Core);
         }

--- a/crates/beast-genome/Cargo.toml
+++ b/crates/beast-genome/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "beast-genome"
+description = "Genotype data structures (genes, body sites, regulatory networks) and deterministic mutation operators for the Beast Evolution Game."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+beast-core = { workspace = true }
+beast-channels = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde_json = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+float_arithmetic = "warn"

--- a/crates/beast-genome/README.md
+++ b/crates/beast-genome/README.md
@@ -1,0 +1,42 @@
+# beast-genome
+
+Layer 2 genotype and mutation crate for Beast Evolution Game.
+
+This crate owns the *structure* of an organism's genome — trait genes, body
+sites, regulatory modifiers, and lineage metadata — along with the
+deterministic mutation operators that act on them. Downstream crates
+(`beast-interpreter`, `beast-sim`) consume `Genome` values; this crate is
+pure-data + pure-function, with no ECS or tick-loop awareness.
+
+## Responsibilities
+
+- **Genome data structures** — `Genome`, `TraitGene`, `EffectVector`,
+  `BodyVector`, `Modifier`, `LineageTag`. All numeric fields are
+  `beast_core::Q3232`.
+- **Mutation operators** — point mutation (Gaussian drift), channel shift,
+  body-site drift, silencing toggle, regulatory rewiring, and gene
+  duplication / genesis (default-off per System 01 §6B).
+- **Provenance tracking** — new paralogs carry `genesis:{parent}:{tick}`
+  strings that satisfy the INVARIANTS §3 regex shared with channel
+  manifests.
+
+## Determinism
+
+- No `f32`/`f64` in sim-state types. `clippy::float_arithmetic = "warn"`
+  guards the arithmetic surface.
+- All randomness flows through a single `beast_core::Prng` handle derived
+  from `Stream::Genetics` — this crate never constructs its own streams.
+- Genomes iterate by index (`Vec<TraitGene>`); no `HashMap`/`HashSet`
+  in structure that affects sim state.
+
+## Layering
+
+Depends on `beast-core` (foundations) and `beast-channels` (for the
+provenance type and registry lookups used by duplication). Per
+`CRATE_LAYOUT.md`, this crate sits at Layer 2 and does **not** depend on
+`beast-primitives`, `beast-interpreter`, `beast-ecs`, or anything above.
+
+## Status
+
+Sprint S3 work in progress. See the tracker epic (GitHub `label:epic
+sprint:s3`) for the story checklist.

--- a/crates/beast-genome/src/error.rs
+++ b/crates/beast-genome/src/error.rs
@@ -1,0 +1,61 @@
+//! Error types for genome construction and validation.
+
+use thiserror::Error;
+
+/// Errors produced while constructing or validating genome types.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GenomeError {
+    /// A `Q3232` field was outside its declared [0, 1] canonical range.
+    #[error("{field} must be in [0, 1]; got {value}")]
+    OutOfUnitRange {
+        /// Field name (e.g. `"magnitude"`, `"radius"`).
+        field: &'static str,
+        /// Debug-formatted value from the offending `Q3232`.
+        value: String,
+    },
+
+    /// A modifier pointed at a gene index that doesn't exist.
+    #[error("modifier target_gene_index {index} is out of bounds (genome has {len} genes)")]
+    ModifierIndexOutOfBounds {
+        /// The offending index.
+        index: u32,
+        /// Current genome length.
+        len: usize,
+    },
+
+    /// A modifier's strength was outside `[-1, 1]`.
+    #[error("modifier strength must be in [-1, 1]; got {value}")]
+    ModifierStrengthOutOfRange {
+        /// Debug-formatted strength.
+        value: String,
+    },
+
+    /// A modifier targets its own gene — self-loops are forbidden.
+    #[error(
+        "modifier target_gene_index equals source gene index ({index}); self-loops are forbidden"
+    )]
+    ModifierSelfLoop {
+        /// Offending index.
+        index: u32,
+    },
+
+    /// A channel vector had a different length than the registry declared at
+    /// construction time.
+    #[error("effect vector has {got} channels, expected {expected}")]
+    ChannelCountMismatch {
+        /// Expected channel count (from registry).
+        expected: usize,
+        /// Actual channel count on the gene.
+        got: usize,
+    },
+
+    /// Two genes shared the same `LineageTag`.
+    #[error("duplicate lineage tag {tag} within genome")]
+    DuplicateLineageTag {
+        /// Offending tag, as `u64`.
+        tag: u64,
+    },
+}
+
+/// Convenience `Result` alias for genome-crate errors.
+pub type Result<T> = core::result::Result<T, GenomeError>;

--- a/crates/beast-genome/src/gene.rs
+++ b/crates/beast-genome/src/gene.rs
@@ -56,8 +56,11 @@ pub enum Target {
 /// What a gene produces when expressed.
 ///
 /// The `channel` vector is indexed by position in the loaded
-/// [`beast_channels::ChannelRegistry`]. All other numeric fields are in the
-/// canonical `[0, 1]` range (see [`Q3232`]).
+/// [`beast_channels::ChannelRegistry`]. Channel contributions are
+/// intentionally **unbounded** — they may be negative (inhibitory) or
+/// exceed 1.0 (synergistic). Clamping happens downstream in the network
+/// resolver and interpreter, not here. `magnitude` and `radius` are the
+/// only unit-range `[0, 1]` fields validated at construction.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EffectVector {
     /// Per-channel contribution, one entry per channel in the registry.
@@ -137,9 +140,10 @@ pub struct TraitGene {
 pub struct BodySitePlaceholder;
 
 impl TraitGene {
-    /// Construct a trait gene. Performs only the validations that are local
-    /// to a single gene; inter-gene checks (modifier index bounds, lineage
-    /// uniqueness) happen in [`crate::Genome::validate`].
+    /// Construct a trait gene. Validates local invariants (unit-range
+    /// fields, modifier strengths) and returns `Err` on violation.
+    /// Inter-gene checks (modifier index bounds, lineage uniqueness)
+    /// happen in [`crate::Genome::validate`].
     pub fn new(
         channel_id: impl Into<String>,
         effect: EffectVector,
@@ -147,8 +151,8 @@ impl TraitGene {
         enabled: bool,
         lineage_tag: LineageTag,
         provenance: Provenance,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let gene = Self {
             channel_id: channel_id.into(),
             effect,
             body_site: None,
@@ -156,7 +160,9 @@ impl TraitGene {
             enabled,
             lineage_tag,
             provenance,
-        }
+        };
+        gene.validate_local()?;
+        Ok(gene)
     }
 
     /// Validate local ranges (effect magnitudes, modifier strengths). Does
@@ -211,6 +217,7 @@ mod tests {
             LineageTag::from_raw(0xAAAA),
             Provenance::Core,
         )
+        .unwrap()
     }
 
     #[test]
@@ -252,16 +259,23 @@ mod tests {
     }
 
     #[test]
-    fn validate_local_catches_modifier_strength() {
-        let mut g = gene();
-        // Bypass Modifier::new's validation by pushing a raw struct.
-        g.regulatory.push(Modifier {
+    fn new_rejects_bad_modifier_strength() {
+        let bad = Modifier {
             target_gene_index: 0,
             effect_type: ModifierEffect::Activate,
             strength: Q3232::from_num(2_i32),
-        });
+        };
+        let err = TraitGene::new(
+            "kinetic_force",
+            effect(4),
+            vec![bad],
+            true,
+            LineageTag::from_raw(0xBBBB),
+            Provenance::Core,
+        )
+        .unwrap_err();
         assert!(matches!(
-            g.validate_local().unwrap_err(),
+            err,
             GenomeError::ModifierStrengthOutOfRange { .. }
         ));
     }
@@ -286,7 +300,8 @@ mod tests {
                 parent: "kinetic_force".to_owned(),
                 generation: 42,
             },
-        );
+        )
+        .unwrap();
         let json = serde_json::to_string(&g).unwrap();
         assert!(json.contains("\"genesis:kinetic_force:42\""));
         let back: TraitGene = serde_json::from_str(&json).unwrap();

--- a/crates/beast-genome/src/gene.rs
+++ b/crates/beast-genome/src/gene.rs
@@ -1,0 +1,295 @@
+//! Trait genes — the unit of mutation and channel contribution.
+//!
+//! A [`TraitGene`] is a compositional record: it declares *what* it produces
+//! (the [`EffectVector`]), *how* it activates ([`Timing`]/[`Target`]), and
+//! (in a follow-up story) *where* on the body it manifests. Ancestry is
+//! tracked via a [`crate::LineageTag`] and a
+//! [`beast_channels::Provenance`] string so that speciation metrics can
+//! walk back through duplication events without scanning the entire
+//! phylogeny.
+//!
+//! `BodyVector` is introduced in story S3.2; for now every gene carries a
+//! placeholder `body_site` field typed as `Option<BodyVector>` so the shape
+//! is forward-compatible without forcing call sites to supply a default
+//! today.
+
+use beast_channels::Provenance;
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GenomeError, Result};
+use crate::lineage::LineageTag;
+use crate::modifier::Modifier;
+
+/// When a gene's effect fires during the tick loop.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Timing {
+    /// Always on (background expression).
+    Passive,
+    /// Fires when this entity touches another.
+    OnContact,
+    /// Fires when this entity takes damage.
+    OnDamage,
+    /// Fires on a cooldown timer (period controlled by interpreter).
+    OnCooldown,
+    /// Fires every `N` ticks while conditions hold.
+    Periodic,
+}
+
+/// Who a gene's effect targets when it fires.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Target {
+    /// The gene's own entity.
+    SelfEntity,
+    /// The entity this gene's owner just touched.
+    TouchedEntity,
+    /// An area around the owner containing friendly entities.
+    AreaFriend,
+    /// An area around the owner containing foes.
+    AreaFoe,
+    /// The surrounding environment (biome cell).
+    Environment,
+}
+
+/// What a gene produces when expressed.
+///
+/// The `channel` vector is indexed by position in the loaded
+/// [`beast_channels::ChannelRegistry`]. All other numeric fields are in the
+/// canonical `[0, 1]` range (see [`Q3232`]).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectVector {
+    /// Per-channel contribution, one entry per channel in the registry.
+    pub channel: Vec<Q3232>,
+    /// Overall expression strength in `[0, 1]`.
+    pub magnitude: Q3232,
+    /// Spatial reach in `[0, 1]` (0 = self-only, 1 = wide AoE).
+    pub radius: Q3232,
+    /// When the effect fires.
+    pub timing: Timing,
+    /// Who the effect is applied to.
+    pub target: Target,
+}
+
+impl EffectVector {
+    /// Construct a new effect vector, validating unit-range fields.
+    pub fn new(
+        channel: Vec<Q3232>,
+        magnitude: Q3232,
+        radius: Q3232,
+        timing: Timing,
+        target: Target,
+    ) -> Result<Self> {
+        check_unit("magnitude", magnitude)?;
+        check_unit("radius", radius)?;
+        Ok(Self {
+            channel,
+            magnitude,
+            radius,
+            timing,
+            target,
+        })
+    }
+
+    /// Number of channels declared by this effect.
+    #[inline]
+    #[must_use]
+    pub fn channel_count(&self) -> usize {
+        self.channel.len()
+    }
+}
+
+/// A single trait gene.
+///
+/// Field ordering matches the design doc (System 01 §3, Layer 1). Fields
+/// are `pub` so mutation operators can rewrite them in place; constructors
+/// validate ranges so newly minted genes can't be out-of-spec.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraitGene {
+    /// The `id` of the channel family this gene primarily serves (used for
+    /// reclassification and duplication provenance). Free-form snake_case;
+    /// validated against the live [`beast_channels::ChannelRegistry`] at a
+    /// higher layer.
+    pub channel_id: String,
+    /// What the gene produces.
+    pub effect: EffectVector,
+    /// Where on the body the effect manifests (introduced in S3.2).
+    pub body_site: Option<BodySitePlaceholder>,
+    /// Outgoing regulatory edges.
+    pub regulatory: Vec<Modifier>,
+    /// Whether the gene is currently expressed. Silencing toggles flip
+    /// this without deleting the gene.
+    pub enabled: bool,
+    /// Phylogenetic identifier for this lineage.
+    pub lineage_tag: LineageTag,
+    /// Where the gene came from (`core`, a mod, or a genesis paralog).
+    pub provenance: Provenance,
+}
+
+/// Placeholder for the full body-site vector introduced in story S3.2.
+///
+/// Exists so `TraitGene` already reserves the slot and save-file layout is
+/// forward-compatible. Do not add fields here — extend
+/// `crate::body_site::BodyVector` instead when S3.2 lands and swap the
+/// placeholder out.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BodySitePlaceholder;
+
+impl TraitGene {
+    /// Construct a trait gene. Performs only the validations that are local
+    /// to a single gene; inter-gene checks (modifier index bounds, lineage
+    /// uniqueness) happen in [`crate::Genome::validate`].
+    pub fn new(
+        channel_id: impl Into<String>,
+        effect: EffectVector,
+        regulatory: Vec<Modifier>,
+        enabled: bool,
+        lineage_tag: LineageTag,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            effect,
+            body_site: None,
+            regulatory,
+            enabled,
+            lineage_tag,
+            provenance,
+        }
+    }
+
+    /// Validate local ranges (effect magnitudes, modifier strengths). Does
+    /// not validate modifier target indices — the owning genome does that.
+    pub fn validate_local(&self) -> Result<()> {
+        check_unit("magnitude", self.effect.magnitude)?;
+        check_unit("radius", self.effect.radius)?;
+        let neg_one = -Q3232::ONE;
+        for m in &self.regulatory {
+            if m.strength < neg_one || m.strength > Q3232::ONE {
+                return Err(GenomeError::ModifierStrengthOutOfRange {
+                    value: format!("{:?}", m.strength),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn check_unit(field: &'static str, v: Q3232) -> Result<()> {
+    if v < Q3232::ZERO || v > Q3232::ONE {
+        return Err(GenomeError::OutOfUnitRange {
+            field,
+            value: format!("{v:?}"),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modifier::ModifierEffect;
+
+    fn effect(channels: usize) -> EffectVector {
+        EffectVector::new(
+            vec![Q3232::from_num(0.1_f64); channels],
+            Q3232::from_num(0.5_f64),
+            Q3232::from_num(0.25_f64),
+            Timing::Passive,
+            Target::SelfEntity,
+        )
+        .unwrap()
+    }
+
+    fn gene() -> TraitGene {
+        TraitGene::new(
+            "kinetic_force",
+            effect(4),
+            vec![],
+            true,
+            LineageTag::from_raw(0xAAAA),
+            Provenance::Core,
+        )
+    }
+
+    #[test]
+    fn rejects_out_of_range_magnitude() {
+        let err = EffectVector::new(
+            vec![Q3232::ZERO; 2],
+            Q3232::from_num(1.5_f64),
+            Q3232::ZERO,
+            Timing::Passive,
+            Target::SelfEntity,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::OutOfUnitRange {
+                field: "magnitude",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_range_radius() {
+        let err = EffectVector::new(
+            vec![Q3232::ZERO; 2],
+            Q3232::ZERO,
+            -Q3232::from_num(0.1_f64),
+            Timing::Passive,
+            Target::SelfEntity,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::OutOfUnitRange {
+                field: "radius",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_local_catches_modifier_strength() {
+        let mut g = gene();
+        // Bypass Modifier::new's validation by pushing a raw struct.
+        g.regulatory.push(Modifier {
+            target_gene_index: 0,
+            effect_type: ModifierEffect::Activate,
+            strength: Q3232::from_num(2_i32),
+        });
+        assert!(matches!(
+            g.validate_local().unwrap_err(),
+            GenomeError::ModifierStrengthOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn serde_roundtrip_full_gene() {
+        let g = gene();
+        let json = serde_json::to_string(&g).unwrap();
+        let back: TraitGene = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+    }
+
+    #[test]
+    fn serde_preserves_provenance_genesis_form() {
+        let g = TraitGene::new(
+            "kinetic_force",
+            effect(2),
+            vec![],
+            true,
+            LineageTag::from_raw(1),
+            Provenance::Genesis {
+                parent: "kinetic_force".to_owned(),
+                generation: 42,
+            },
+        );
+        let json = serde_json::to_string(&g).unwrap();
+        assert!(json.contains("\"genesis:kinetic_force:42\""));
+        let back: TraitGene = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+    }
+}

--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -1,0 +1,287 @@
+//! The [`Genome`] — a variable-length, index-ordered collection of trait genes
+//! plus per-genome mutation parameters.
+//!
+//! Iteration order is always index-order. This crate never stores genes in a
+//! `HashMap` (or any hash-backed container) because hash randomization would
+//! break the determinism invariant documented in `INVARIANTS.md` §1.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use crate::error::{GenomeError, Result};
+use crate::gene::TraitGene;
+
+/// Per-genome mutation rates. All rates are probability-per-tick in `[0, 1]`.
+///
+/// The canonical default values mirror System 01 §3 and §6B. In particular
+/// `duplication_rate` defaults to `0.0` — per §6B the genesis operators are
+/// **disabled for v0** until telemetry confirms baseline evolution is stable.
+/// Tests that exercise duplication supply an explicit non-zero rate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenomeParams {
+    /// Per-gene probability of a point-magnitude mutation each tick.
+    pub point_mutation_rate: Q3232,
+    /// Per-gene probability of a channel-shift mutation.
+    pub channel_shift_rate: Q3232,
+    /// Per-gene probability of a body-site drift mutation.
+    pub body_site_drift_rate: Q3232,
+    /// Per-gene probability of flipping `enabled`.
+    pub silencing_toggle_rate: Q3232,
+    /// Per-gene probability of a regulatory rewire.
+    pub regulatory_rewire_rate: Q3232,
+    /// Per-genome probability of a gene duplication. **Default 0** (v0).
+    pub duplication_rate: Q3232,
+}
+
+impl Default for GenomeParams {
+    fn default() -> Self {
+        Self {
+            point_mutation_rate: Q3232::from_num(1.0e-3_f64),
+            channel_shift_rate: Q3232::from_num(5.0e-4_f64),
+            body_site_drift_rate: Q3232::from_num(1.0e-3_f64),
+            silencing_toggle_rate: Q3232::from_num(1.0e-3_f64),
+            regulatory_rewire_rate: Q3232::from_num(5.0e-4_f64),
+            // Disabled for v0 (System 01 §6B).
+            duplication_rate: Q3232::ZERO,
+        }
+    }
+}
+
+/// A full monster genome.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Genome {
+    /// Mutation-rate parameters for this genome. Mutable so they can evolve
+    /// (see §6B — `duplication_rate` is itself mutable).
+    pub params: GenomeParams,
+    /// Ordered list of genes. Indices are referenced directly by
+    /// [`crate::Modifier::target_gene_index`].
+    pub genes: Vec<TraitGene>,
+}
+
+impl Genome {
+    /// Construct an empty genome with the given parameters.
+    #[inline]
+    #[must_use]
+    pub fn with_params(params: GenomeParams) -> Self {
+        Self {
+            params,
+            genes: Vec::new(),
+        }
+    }
+
+    /// Construct from a gene list. Runs [`Genome::validate`] so the returned
+    /// value is guaranteed in-spec; prefer this entry point over populating
+    /// `genes` directly in tests and fixtures.
+    pub fn new(params: GenomeParams, genes: Vec<TraitGene>) -> Result<Self> {
+        let g = Self { params, genes };
+        g.validate()?;
+        Ok(g)
+    }
+
+    /// Number of genes in the genome.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.genes.len()
+    }
+
+    /// Whether the genome has zero genes.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.genes.is_empty()
+    }
+
+    /// Full structural validation:
+    ///
+    /// * Every gene passes [`TraitGene::validate_local`].
+    /// * Every [`crate::Modifier::target_gene_index`] is in-bounds.
+    /// * Every modifier is non-self-loop.
+    /// * Lineage tags are unique across the genome.
+    /// * All genes share the same channel vector length.
+    pub fn validate(&self) -> Result<()> {
+        let len = self.genes.len();
+        let mut seen_tags: BTreeSet<u64> = BTreeSet::new();
+        let expected_channels = self.genes.first().map(|g| g.effect.channel_count());
+
+        for (src_idx, gene) in self.genes.iter().enumerate() {
+            gene.validate_local()?;
+
+            if let Some(expected) = expected_channels {
+                let got = gene.effect.channel_count();
+                if got != expected {
+                    return Err(GenomeError::ChannelCountMismatch { expected, got });
+                }
+            }
+
+            if !seen_tags.insert(gene.lineage_tag.as_u64()) {
+                return Err(GenomeError::DuplicateLineageTag {
+                    tag: gene.lineage_tag.as_u64(),
+                });
+            }
+
+            let src_u32 = src_idx as u32;
+            for m in &gene.regulatory {
+                if (m.target_gene_index as usize) >= len {
+                    return Err(GenomeError::ModifierIndexOutOfBounds {
+                        index: m.target_gene_index,
+                        len,
+                    });
+                }
+                if m.target_gene_index == src_u32 {
+                    return Err(GenomeError::ModifierSelfLoop {
+                        index: m.target_gene_index,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Iterate genes in index order.
+    #[inline]
+    pub fn iter(&self) -> std::slice::Iter<'_, TraitGene> {
+        self.genes.iter()
+    }
+
+    /// Iterate genes mutably in index order.
+    #[inline]
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, TraitGene> {
+        self.genes.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gene::{EffectVector, Target, Timing};
+    use crate::lineage::LineageTag;
+    use crate::modifier::{Modifier, ModifierEffect};
+    use beast_channels::Provenance;
+
+    fn effect(channels: usize) -> EffectVector {
+        EffectVector::new(
+            vec![Q3232::from_num(0.25_f64); channels],
+            Q3232::from_num(0.5_f64),
+            Q3232::from_num(0.25_f64),
+            Timing::Passive,
+            Target::SelfEntity,
+        )
+        .unwrap()
+    }
+
+    fn gene(tag: u64, channels: usize, regs: Vec<Modifier>) -> TraitGene {
+        TraitGene::new(
+            "kinetic_force",
+            effect(channels),
+            regs,
+            true,
+            LineageTag::from_raw(tag),
+            Provenance::Core,
+        )
+    }
+
+    #[test]
+    fn default_params_disable_duplication_for_v0() {
+        let p = GenomeParams::default();
+        assert_eq!(p.duplication_rate, Q3232::ZERO);
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_genome() {
+        let g = Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, 3, vec![]), gene(2, 3, vec![])],
+        )
+        .unwrap();
+        assert_eq!(g.len(), 2);
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_lineage_tags() {
+        let err = Genome::new(
+            GenomeParams::default(),
+            vec![gene(7, 3, vec![]), gene(7, 3, vec![])],
+        )
+        .unwrap_err();
+        assert!(matches!(err, GenomeError::DuplicateLineageTag { tag: 7 }));
+    }
+
+    #[test]
+    fn validate_rejects_out_of_bounds_modifier() {
+        let bad = Modifier {
+            target_gene_index: 99,
+            effect_type: ModifierEffect::Activate,
+            strength: Q3232::from_num(0.5_f64),
+        };
+        let err = Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, 3, vec![bad]), gene(2, 3, vec![])],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::ModifierIndexOutOfBounds { index: 99, len: 2 }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_self_loop_modifier() {
+        let bad = Modifier {
+            target_gene_index: 0,
+            effect_type: ModifierEffect::Activate,
+            strength: Q3232::from_num(0.5_f64),
+        };
+        let err = Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, 3, vec![bad]), gene(2, 3, vec![])],
+        )
+        .unwrap_err();
+        assert!(matches!(err, GenomeError::ModifierSelfLoop { index: 0 }));
+    }
+
+    #[test]
+    fn validate_rejects_channel_count_mismatch() {
+        let err = Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, 3, vec![]), gene(2, 4, vec![])],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::ChannelCountMismatch {
+                expected: 3,
+                got: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let g = Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, 2, vec![]), gene(2, 2, vec![])],
+        )
+        .unwrap();
+        let json = serde_json::to_string(&g).unwrap();
+        let back: Genome = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+        back.validate().unwrap();
+    }
+
+    #[test]
+    fn iteration_is_index_ordered() {
+        let g = Genome::new(
+            GenomeParams::default(),
+            vec![
+                gene(10, 2, vec![]),
+                gene(20, 2, vec![]),
+                gene(30, 2, vec![]),
+            ],
+        )
+        .unwrap();
+        let tags: Vec<u64> = g.iter().map(|gg| gg.lineage_tag.as_u64()).collect();
+        assert_eq!(tags, vec![10, 20, 30]);
+    }
+}

--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -121,7 +121,9 @@ impl Genome {
                 });
             }
 
-            let src_u32 = src_idx as u32;
+            let src_u32 = u32::try_from(src_idx).expect(
+                "genome size exceeds u32::MAX — Modifier::target_gene_index can't address this",
+            );
             for m in &gene.regulatory {
                 if (m.target_gene_index as usize) >= len {
                     return Err(GenomeError::ModifierIndexOutOfBounds {
@@ -180,6 +182,7 @@ mod tests {
             LineageTag::from_raw(tag),
             Provenance::Core,
         )
+        .unwrap()
     }
 
     #[test]

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -1,0 +1,29 @@
+//! Beast Evolution Game — Layer 2 genotype & mutation crate.
+//!
+//! See `crates/beast-genome/README.md` and
+//! `documentation/systems/01_evolutionary_model.md` for the canonical
+//! specification. Non-negotiable invariants enforced here:
+//!
+//! * All numeric fields on sim-state types use [`beast_core::Q3232`].
+//! * All randomness comes from the caller-supplied [`beast_core::Prng`]
+//!   handle (derived from [`beast_core::Stream::Genetics`]).
+//! * Genomes iterate by index; no hashing in any sim-state container.
+//!
+//! Sprint S3 lands each story as its own module; the public surface is
+//! re-exported below.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod error;
+pub mod gene;
+pub mod genome;
+pub mod lineage;
+pub mod modifier;
+
+pub use error::{GenomeError, Result};
+pub use gene::{BodySitePlaceholder, EffectVector, Target, Timing, TraitGene};
+pub use genome::{Genome, GenomeParams};
+pub use lineage::LineageTag;
+pub use modifier::{Modifier, ModifierEffect};

--- a/crates/beast-genome/src/lineage.rs
+++ b/crates/beast-genome/src/lineage.rs
@@ -1,0 +1,87 @@
+//! Lineage tags for phylogenetic tracking.
+//!
+//! Every [`crate::TraitGene`] carries a [`LineageTag`] — an opaque 64-bit
+//! identifier that survives mutation and inheritance. When a paralog is
+//! created by gene duplication (System 01 §2B) the parent keeps its tag and
+//! the new paralog receives a fresh one, giving speciation metrics a stable
+//! ancestor marker without walking a full phylogenetic tree.
+//!
+//! Tags are drawn from the caller's PRNG so allocation is deterministic. The
+//! 64-bit space means collision within a single world is astronomically
+//! unlikely, but callers that care about hard uniqueness can validate with
+//! [`crate::Genome::validate`] — the genome refuses to hold two genes with
+//! the same tag.
+
+use beast_core::Prng;
+use serde::{Deserialize, Serialize};
+
+/// A phylogenetic tag identifying a gene's lineage.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LineageTag(u64);
+
+impl LineageTag {
+    /// Construct a tag from an explicit `u64`. Use in tests or when loading
+    /// from a save file; live code should prefer [`LineageTag::fresh`].
+    #[inline]
+    #[must_use]
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Draw a fresh tag from the `Genetics` PRNG stream.
+    ///
+    /// Takes `&mut Prng` rather than an owned PRNG so callers can continue
+    /// to use the stream for the rest of their mutation batch.
+    #[inline]
+    #[must_use]
+    pub fn fresh(rng: &mut Prng) -> Self {
+        Self(rng.next_u64())
+    }
+
+    /// Return the raw `u64` value.
+    #[inline]
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl core::fmt::Display for LineageTag {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:016x}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_is_deterministic() {
+        let mut a = Prng::from_seed(42);
+        let mut b = Prng::from_seed(42);
+        for _ in 0..128 {
+            assert_eq!(LineageTag::fresh(&mut a), LineageTag::fresh(&mut b));
+        }
+    }
+
+    #[test]
+    fn fresh_does_not_collide_trivially() {
+        // 1024 draws from a good 64-bit PRNG should be collision-free.
+        let mut rng = Prng::from_seed(7);
+        let mut seen = std::collections::BTreeSet::new();
+        for _ in 0..1024 {
+            let tag = LineageTag::fresh(&mut rng);
+            assert!(seen.insert(tag), "unexpected collision");
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let tag = LineageTag::from_raw(0xABCD_1234_5678_9ABCu64);
+        let json = serde_json::to_string(&tag).unwrap();
+        let back: LineageTag = serde_json::from_str(&json).unwrap();
+        assert_eq!(tag, back);
+    }
+}

--- a/crates/beast-genome/src/modifier.rs
+++ b/crates/beast-genome/src/modifier.rs
@@ -1,0 +1,105 @@
+//! Regulatory modifiers — directed edges in the gene regulatory network.
+//!
+//! A [`Modifier`] lives on a source [`crate::TraitGene`] and perturbs the
+//! expression level of another gene in the same genome. This module only
+//! owns the data structure — the network relaxation algorithm that
+//! consumes modifiers lives in `beast-interpreter` (see System 01 §Layer 2
+//! and cut-scope issue for Tarjan SCC damping).
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GenomeError, Result};
+
+/// How a modifier perturbs its target's expression.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModifierEffect {
+    /// Add signed influence to target expression (see §Layer 2).
+    Activate,
+    /// Subtract signed influence from target expression.
+    Suppress,
+    /// Multiplicatively modulate target expression.
+    Modulate,
+}
+
+/// A directed regulatory edge from one gene to another within the same
+/// [`crate::Genome`].
+///
+/// `target_gene_index` is a plain `u32` offset into the owning genome's
+/// `Vec<TraitGene>`. This keeps iteration deterministic (index order) and
+/// cheap; it also means modifiers are fragile under gene deletion, which
+/// is why the duplication and loss operators have to re-number modifiers
+/// on mutation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Modifier {
+    /// Index into the owning genome's gene vector.
+    pub target_gene_index: u32,
+    /// How the modifier perturbs its target.
+    pub effect_type: ModifierEffect,
+    /// Signed influence strength in `[-1, 1]`.
+    pub strength: Q3232,
+}
+
+impl Modifier {
+    /// Construct a modifier, validating `strength ∈ [-1, 1]` and that
+    /// `target_gene_index != source_gene_index`.
+    pub fn new(
+        source_gene_index: u32,
+        target_gene_index: u32,
+        effect_type: ModifierEffect,
+        strength: Q3232,
+    ) -> Result<Self> {
+        if source_gene_index == target_gene_index {
+            return Err(GenomeError::ModifierSelfLoop {
+                index: target_gene_index,
+            });
+        }
+        let neg_one = -Q3232::ONE;
+        if strength < neg_one || strength > Q3232::ONE {
+            return Err(GenomeError::ModifierStrengthOutOfRange {
+                value: format!("{strength:?}"),
+            });
+        }
+        Ok(Self {
+            target_gene_index,
+            effect_type,
+            strength,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_self_loop() {
+        let err = Modifier::new(3, 3, ModifierEffect::Activate, Q3232::ZERO).unwrap_err();
+        assert!(matches!(err, GenomeError::ModifierSelfLoop { index: 3 }));
+    }
+
+    #[test]
+    fn rejects_out_of_range_strength() {
+        let s = Q3232::from_num(1.5_f64);
+        let err = Modifier::new(0, 1, ModifierEffect::Suppress, s).unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::ModifierStrengthOutOfRange { .. }
+        ));
+    }
+
+    #[test]
+    fn accepts_boundary_strengths() {
+        Modifier::new(0, 1, ModifierEffect::Activate, Q3232::ONE).unwrap();
+        Modifier::new(0, 1, ModifierEffect::Suppress, -Q3232::ONE).unwrap();
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let m = Modifier::new(1, 2, ModifierEffect::Modulate, Q3232::from_num(0.5_f64)).unwrap();
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Modifier = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+}


### PR DESCRIPTION
## Summary

- Scaffold `crates/beast-genome` (Layer 2, workspace member, no-deps-above per `CRATE_LAYOUT.md`)
- Core genotype data structures from System 01 §3: `Genome`, `GenomeParams`, `TraitGene`, `EffectVector`, `Modifier`, `LineageTag`, and `Timing`/`Target`/`ModifierEffect` enums
- `Genome::validate` covers channel count match, lineage-tag uniqueness, modifier bounds, and self-loop rejection
- `GenomeParams::duplication_rate` defaults to `0.0` per System 01 §6B ("Currently Disabled for v0")
- Add serde support to `beast_channels::Provenance` so genesis-tagged paralogs round-trip through save files in the canonical schema-string form (`"genesis:parent:42"`)

## Out of scope

- Body-site vector fields (stub `BodySitePlaceholder` reserves the slot) — S3.2
- Mutation operators — S3.3 / S3.4 / S3.5
- Channel correlation application (#42), Tarjan SCC (#43), reclassification (#44), gene loss (#45)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked` (20 new unit tests + all existing)
- [x] `cargo test --workspace --doc --locked`

Closes #36.