### PR TITLE
S3.2: body-site model (BodyVector)

### DIFF
--- a/crates/beast-genome/src/body_site.rs
+++ b/crates/beast-genome/src/body_site.rs
@@ -1,0 +1,155 @@
+//! Body-site vector — where on the organism a trait gene manifests.
+//!
+//! Every [`crate::TraitGene`] carries a [`BodyVector`] describing the
+//! anatomical location and coverage of the trait's physical expression.
+//! The interpreter (System 11) maps these continuous coordinates onto
+//! procedural body topology; this module only owns the numeric storage.
+//!
+//! All fields are in `[0, 1]` and validated at construction.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GenomeError, Result};
+
+/// Anatomical location and coverage of a trait gene's physical expression.
+///
+/// See System 01 §3, Layer 1 ("WHERE on the body it manifests").
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BodyVector {
+    /// 0 = deep organ, 1 = surface protrusion.
+    pub surface_vs_internal: Q3232,
+    /// Continuous anterior/posterior/lateral coordinate in `[0, 1]`;
+    /// mapped to procedural body topology by the interpreter.
+    pub body_region: Q3232,
+    /// Whether the trait is mirrored on the opposite lateral side.
+    pub bilateral_symmetry: bool,
+    /// Fraction of the body region affected, in `[0, 1]`.
+    pub coverage: Q3232,
+}
+
+impl BodyVector {
+    /// Construct a body vector, validating all `Q3232` fields are in `[0, 1]`.
+    pub fn new(
+        surface_vs_internal: Q3232,
+        body_region: Q3232,
+        bilateral_symmetry: bool,
+        coverage: Q3232,
+    ) -> Result<Self> {
+        check_unit("surface_vs_internal", surface_vs_internal)?;
+        check_unit("body_region", body_region)?;
+        check_unit("coverage", coverage)?;
+        Ok(Self {
+            surface_vs_internal,
+            body_region,
+            bilateral_symmetry,
+            coverage,
+        })
+    }
+
+    /// A default body vector: internal (0), anterior (0), non-mirrored, zero coverage.
+    #[inline]
+    #[must_use]
+    pub const fn default_internal() -> Self {
+        Self {
+            surface_vs_internal: Q3232::ZERO,
+            body_region: Q3232::ZERO,
+            bilateral_symmetry: false,
+            coverage: Q3232::ZERO,
+        }
+    }
+}
+
+fn check_unit(field: &'static str, v: Q3232) -> Result<()> {
+    if v < Q3232::ZERO || v > Q3232::ONE {
+        return Err(GenomeError::OutOfUnitRange {
+            field,
+            value: format!("{v:?}"),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_body_vector() {
+        let bv = BodyVector::new(
+            Q3232::from_num(0.5_f64),
+            Q3232::from_num(0.3_f64),
+            true,
+            Q3232::from_num(0.8_f64),
+        )
+        .unwrap();
+        assert!(bv.bilateral_symmetry);
+    }
+
+    #[test]
+    fn accepts_boundary_values() {
+        BodyVector::new(Q3232::ZERO, Q3232::ZERO, false, Q3232::ZERO).unwrap();
+        BodyVector::new(Q3232::ONE, Q3232::ONE, true, Q3232::ONE).unwrap();
+    }
+
+    #[test]
+    fn rejects_out_of_range_surface() {
+        let err =
+            BodyVector::new(Q3232::from_num(1.5_f64), Q3232::ZERO, false, Q3232::ZERO).unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::OutOfUnitRange {
+                field: "surface_vs_internal",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_negative_body_region() {
+        let err = BodyVector::new(Q3232::ZERO, -Q3232::from_num(0.1_f64), false, Q3232::ZERO)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::OutOfUnitRange {
+                field: "body_region",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_range_coverage() {
+        let err =
+            BodyVector::new(Q3232::ZERO, Q3232::ZERO, false, Q3232::from_num(2_i32)).unwrap_err();
+        assert!(matches!(
+            err,
+            GenomeError::OutOfUnitRange {
+                field: "coverage",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let bv = BodyVector::new(
+            Q3232::from_num(0.25_f64),
+            Q3232::from_num(0.75_f64),
+            true,
+            Q3232::from_num(0.5_f64),
+        )
+        .unwrap();
+        let json = serde_json::to_string(&bv).unwrap();
+        let back: BodyVector = serde_json::from_str(&json).unwrap();
+        assert_eq!(bv, back);
+    }
+
+    #[test]
+    fn default_internal_is_valid() {
+        let bv = BodyVector::default_internal();
+        assert_eq!(bv.surface_vs_internal, Q3232::ZERO);
+        assert_eq!(bv.coverage, Q3232::ZERO);
+        assert!(!bv.bilateral_symmetry);
+    }
+}

--- a/crates/beast-genome/src/body_site.rs
+++ b/crates/beast-genome/src/body_site.rs
@@ -10,7 +10,7 @@
 use beast_core::Q3232;
 use serde::{Deserialize, Serialize};
 
-use crate::error::{GenomeError, Result};
+use crate::error::{check_unit, Result};
 
 /// Anatomical location and coverage of a trait gene's physical expression.
 ///
@@ -47,6 +47,15 @@ impl BodyVector {
         })
     }
 
+    /// Re-validate all `Q3232` fields against `[0, 1]`. Called by
+    /// [`crate::TraitGene::validate_local`] to catch post-mutation drift.
+    pub fn validate(&self) -> Result<()> {
+        check_unit("surface_vs_internal", self.surface_vs_internal)?;
+        check_unit("body_region", self.body_region)?;
+        check_unit("coverage", self.coverage)?;
+        Ok(())
+    }
+
     /// A default body vector: internal (0), anterior (0), non-mirrored, zero coverage.
     #[inline]
     #[must_use]
@@ -60,19 +69,10 @@ impl BodyVector {
     }
 }
 
-fn check_unit(field: &'static str, v: Q3232) -> Result<()> {
-    if v < Q3232::ZERO || v > Q3232::ONE {
-        return Err(GenomeError::OutOfUnitRange {
-            field,
-            value: format!("{v:?}"),
-        });
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::GenomeError;
 
     #[test]
     fn accepts_valid_body_vector() {

--- a/crates/beast-genome/src/error.rs
+++ b/crates/beast-genome/src/error.rs
@@ -1,5 +1,6 @@
-//! Error types for genome construction and validation.
+//! Error types and shared validation helpers for genome construction.
 
+use beast_core::Q3232;
 use thiserror::Error;
 
 /// Errors produced while constructing or validating genome types.
@@ -59,3 +60,16 @@ pub enum GenomeError {
 
 /// Convenience `Result` alias for genome-crate errors.
 pub type Result<T> = core::result::Result<T, GenomeError>;
+
+/// Assert a `Q3232` value is in `[0, 1]`, returning `OutOfUnitRange` on
+/// violation. Used by `EffectVector::new`, `BodyVector::new`, and
+/// `validate_local` to share a single validation path.
+pub(crate) fn check_unit(field: &'static str, v: Q3232) -> Result<()> {
+    if v < Q3232::ZERO || v > Q3232::ONE {
+        return Err(GenomeError::OutOfUnitRange {
+            field,
+            value: format!("{v:?}"),
+        });
+    }
+    Ok(())
+}

--- a/crates/beast-genome/src/gene.rs
+++ b/crates/beast-genome/src/gene.rs
@@ -13,7 +13,7 @@ use beast_core::Q3232;
 use serde::{Deserialize, Serialize};
 
 use crate::body_site::BodyVector;
-use crate::error::{GenomeError, Result};
+use crate::error::{check_unit, GenomeError, Result};
 use crate::lineage::LineageTag;
 use crate::modifier::Modifier;
 
@@ -158,6 +158,7 @@ impl TraitGene {
     pub fn validate_local(&self) -> Result<()> {
         check_unit("magnitude", self.effect.magnitude)?;
         check_unit("radius", self.effect.radius)?;
+        self.body_site.validate()?;
         let neg_one = -Q3232::ONE;
         for m in &self.regulatory {
             if m.strength < neg_one || m.strength > Q3232::ONE {
@@ -168,16 +169,6 @@ impl TraitGene {
         }
         Ok(())
     }
-}
-
-fn check_unit(field: &'static str, v: Q3232) -> Result<()> {
-    if v < Q3232::ZERO || v > Q3232::ONE {
-        return Err(GenomeError::OutOfUnitRange {
-            field,
-            value: format!("{v:?}"),
-        });
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/beast-genome/src/gene.rs
+++ b/crates/beast-genome/src/gene.rs
@@ -1,22 +1,18 @@
 //! Trait genes — the unit of mutation and channel contribution.
 //!
 //! A [`TraitGene`] is a compositional record: it declares *what* it produces
-//! (the [`EffectVector`]), *how* it activates ([`Timing`]/[`Target`]), and
-//! (in a follow-up story) *where* on the body it manifests. Ancestry is
-//! tracked via a [`crate::LineageTag`] and a
+//! (the [`EffectVector`]), *where* on the body it manifests (the
+//! [`crate::BodyVector`]), and *how* it activates ([`Timing`]/[`Target`]).
+//! Ancestry is tracked via a [`crate::LineageTag`] and a
 //! [`beast_channels::Provenance`] string so that speciation metrics can
 //! walk back through duplication events without scanning the entire
 //! phylogeny.
-//!
-//! `BodyVector` is introduced in story S3.2; for now every gene carries a
-//! placeholder `body_site` field typed as `Option<BodyVector>` so the shape
-//! is forward-compatible without forcing call sites to supply a default
-//! today.
 
 use beast_channels::Provenance;
 use beast_core::Q3232;
 use serde::{Deserialize, Serialize};
 
+use crate::body_site::BodyVector;
 use crate::error::{GenomeError, Result};
 use crate::lineage::LineageTag;
 use crate::modifier::Modifier;
@@ -117,8 +113,8 @@ pub struct TraitGene {
     pub channel_id: String,
     /// What the gene produces.
     pub effect: EffectVector,
-    /// Where on the body the effect manifests (introduced in S3.2).
-    pub body_site: Option<BodySitePlaceholder>,
+    /// Where on the body the effect manifests.
+    pub body_site: BodyVector,
     /// Outgoing regulatory edges.
     pub regulatory: Vec<Modifier>,
     /// Whether the gene is currently expressed. Silencing toggles flip
@@ -130,15 +126,6 @@ pub struct TraitGene {
     pub provenance: Provenance,
 }
 
-/// Placeholder for the full body-site vector introduced in story S3.2.
-///
-/// Exists so `TraitGene` already reserves the slot and save-file layout is
-/// forward-compatible. Do not add fields here — extend
-/// `crate::body_site::BodyVector` instead when S3.2 lands and swap the
-/// placeholder out.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct BodySitePlaceholder;
-
 impl TraitGene {
     /// Construct a trait gene. Validates local invariants (unit-range
     /// fields, modifier strengths) and returns `Err` on violation.
@@ -147,6 +134,7 @@ impl TraitGene {
     pub fn new(
         channel_id: impl Into<String>,
         effect: EffectVector,
+        body_site: BodyVector,
         regulatory: Vec<Modifier>,
         enabled: bool,
         lineage_tag: LineageTag,
@@ -155,7 +143,7 @@ impl TraitGene {
         let gene = Self {
             channel_id: channel_id.into(),
             effect,
-            body_site: None,
+            body_site,
             regulatory,
             enabled,
             lineage_tag,
@@ -212,6 +200,7 @@ mod tests {
         TraitGene::new(
             "kinetic_force",
             effect(4),
+            BodyVector::default_internal(),
             vec![],
             true,
             LineageTag::from_raw(0xAAAA),
@@ -268,6 +257,7 @@ mod tests {
         let err = TraitGene::new(
             "kinetic_force",
             effect(4),
+            BodyVector::default_internal(),
             vec![bad],
             true,
             LineageTag::from_raw(0xBBBB),
@@ -293,6 +283,7 @@ mod tests {
         let g = TraitGene::new(
             "kinetic_force",
             effect(2),
+            BodyVector::default_internal(),
             vec![],
             true,
             LineageTag::from_raw(1),

--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -157,6 +157,7 @@ impl Genome {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::body_site::BodyVector;
     use crate::gene::{EffectVector, Target, Timing};
     use crate::lineage::LineageTag;
     use crate::modifier::{Modifier, ModifierEffect};
@@ -177,6 +178,7 @@ mod tests {
         TraitGene::new(
             "kinetic_force",
             effect(channels),
+            BodyVector::default_internal(),
             regs,
             true,
             LineageTag::from_raw(tag),

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -16,14 +16,16 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+pub mod body_site;
 pub mod error;
 pub mod gene;
 pub mod genome;
 pub mod lineage;
 pub mod modifier;
 
+pub use body_site::BodyVector;
 pub use error::{GenomeError, Result};
-pub use gene::{BodySitePlaceholder, EffectVector, Target, Timing, TraitGene};
+pub use gene::{EffectVector, Target, Timing, TraitGene};
 pub use genome::{Genome, GenomeParams};
 pub use lineage::LineageTag;
 pub use modifier::{Modifier, ModifierEffect};


### PR DESCRIPTION
## Summary

- New `BodyVector` struct: `surface_vs_internal`, `body_region`, `bilateral_symmetry`, `coverage` — all Q3232 fields validated to [0, 1] at construction
- `BodyVector::default_internal()` const constructor for ergonomic defaults
- Replaces `Option<BodySitePlaceholder>` on `TraitGene` with a required `BodyVector` field
- `TraitGene::new` gains a `body_site: BodyVector` parameter

## Test plan

- [x] 7 new unit tests (validation, boundary, serde, rejection for each field)
- [x] All 27 beast-genome tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #37.