### PR TITLE
S3.3: point mutation operator (Gaussian drift)

### DIFF
--- a/crates/beast-core/src/lib.rs
+++ b/crates/beast-core/src/lib.rs
@@ -34,6 +34,7 @@ pub use error::{Error, Result};
 pub use fixed_point::Q3232;
 pub use math::{
     clamp01, clamp_q3232, gaussian_q3232, inv_lerp_q3232, lerp_q3232, max_q3232, min_q3232,
+    reflect_clamp01,
 };
 pub use prng::{Prng, Stream};
 pub use time::TickCounter;

--- a/crates/beast-core/src/math.rs
+++ b/crates/beast-core/src/math.rs
@@ -39,6 +39,27 @@ pub fn clamp01(v: Q3232) -> Q3232 {
     v.clamp(Q3232::ZERO, Q3232::ONE)
 }
 
+/// Reflect a [`Q3232`] value back into `[0, 1]` off the nearest boundary,
+/// then hard-clamp any residual overshoot.
+///
+/// Reflection preserves the Gaussian distribution shape near boundaries
+/// better than truncation. For a value `v`:
+/// - If `v < 0`: reflect off 0 → `-v`
+/// - If `v > 1`: reflect off 1 → `2 - v`
+///
+/// A final clamp handles pathological outliers (e.g. `v > 2` or `v < -1`)
+/// that overshoot even after one reflection.
+#[inline]
+#[must_use]
+pub fn reflect_clamp01(v: Q3232) -> Q3232 {
+    if v >= Q3232::ZERO && v <= Q3232::ONE {
+        return v;
+    }
+    let two = Q3232::from_num(2_i32);
+    let reflected = if v < Q3232::ZERO { -v } else { two - v };
+    reflected.clamp(Q3232::ZERO, Q3232::ONE)
+}
+
 /// Clamp a [`Q3232`] value to `[lo, hi]`. Debug-asserts `lo <= hi`.
 #[inline]
 #[must_use]
@@ -143,6 +164,46 @@ mod tests {
         assert_eq!(clamp01(Q3232::from_num(-0.1_f64)), Q3232::ZERO);
         assert_eq!(clamp01(Q3232::from_num(1.1_f64)), Q3232::ONE);
         assert_eq!(clamp01(Q3232::from_num(0.5_f64)), Q3232::from_num(0.5_f64));
+    }
+
+    #[test]
+    fn reflect_clamp01_in_range_passthrough() {
+        assert_eq!(reflect_clamp01(Q3232::ZERO), Q3232::ZERO);
+        assert_eq!(reflect_clamp01(Q3232::ONE), Q3232::ONE);
+        assert_eq!(
+            reflect_clamp01(Q3232::from_num(0.5_f64)),
+            Q3232::from_num(0.5_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp01_reflects_above_one() {
+        assert_eq!(
+            reflect_clamp01(Q3232::from_num(1.3_f64)),
+            Q3232::from_num(0.7_f64)
+        );
+        assert_eq!(
+            reflect_clamp01(Q3232::from_num(1.8_f64)),
+            Q3232::from_num(0.2_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp01_reflects_below_zero() {
+        assert_eq!(
+            reflect_clamp01(Q3232::from_num(-0.3_f64)),
+            Q3232::from_num(0.3_f64)
+        );
+        assert_eq!(
+            reflect_clamp01(Q3232::from_num(-0.9_f64)),
+            Q3232::from_num(0.9_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp01_clamps_pathological() {
+        assert_eq!(reflect_clamp01(Q3232::from_num(2.5_f64)), Q3232::ZERO);
+        assert_eq!(reflect_clamp01(Q3232::from_num(-1.5_f64)), Q3232::ONE);
     }
 
     #[test]

--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -12,7 +12,11 @@ use std::collections::BTreeSet;
 use crate::error::{GenomeError, Result};
 use crate::gene::TraitGene;
 
-/// Per-genome mutation rates. All rates are probability-per-tick in `[0, 1]`.
+/// Per-genome mutation rates and Gaussian standard deviations.
+///
+/// Rate fields are probability-per-tick in `[0, 1]`. Sigma fields are the
+/// standard deviation passed to `gaussian_q3232` when the corresponding
+/// mutation fires.
 ///
 /// The canonical default values mirror System 01 §3 and §6B. In particular
 /// `duplication_rate` defaults to `0.0` — per §6B the genesis operators are
@@ -22,10 +26,16 @@ use crate::gene::TraitGene;
 pub struct GenomeParams {
     /// Per-gene probability of a point-magnitude mutation each tick.
     pub point_mutation_rate: Q3232,
+    /// Gaussian σ for point-magnitude mutations.
+    pub point_mutation_sigma: Q3232,
     /// Per-gene probability of a channel-shift mutation.
     pub channel_shift_rate: Q3232,
+    /// Gaussian σ for channel-shift mutations.
+    pub channel_shift_sigma: Q3232,
     /// Per-gene probability of a body-site drift mutation.
     pub body_site_drift_rate: Q3232,
+    /// Gaussian σ for body-site drift mutations.
+    pub body_site_drift_sigma: Q3232,
     /// Per-gene probability of flipping `enabled`.
     pub silencing_toggle_rate: Q3232,
     /// Per-gene probability of a regulatory rewire.
@@ -38,8 +48,11 @@ impl Default for GenomeParams {
     fn default() -> Self {
         Self {
             point_mutation_rate: Q3232::from_num(1.0e-3_f64),
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
             channel_shift_rate: Q3232::from_num(5.0e-4_f64),
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
             body_site_drift_rate: Q3232::from_num(1.0e-3_f64),
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::from_num(1.0e-3_f64),
             regulatory_rewire_rate: Q3232::from_num(5.0e-4_f64),
             // Disabled for v0 (System 01 §6B).

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -22,6 +22,7 @@ pub mod gene;
 pub mod genome;
 pub mod lineage;
 pub mod modifier;
+pub mod mutation;
 
 pub use body_site::BodyVector;
 pub use error::{GenomeError, Result};
@@ -29,3 +30,4 @@ pub use gene::{EffectVector, Target, Timing, TraitGene};
 pub use genome::{Genome, GenomeParams};
 pub use lineage::LineageTag;
 pub use modifier::{Modifier, ModifierEffect};
+pub use mutation::mutate_point;

--- a/crates/beast-genome/src/mutation.rs
+++ b/crates/beast-genome/src/mutation.rs
@@ -1,0 +1,285 @@
+//! Deterministic point-mutation operators for individual trait genes.
+//!
+//! Each operator draws from the caller-supplied [`beast_core::Prng`], which
+//! must be derived from [`beast_core::Stream::Genetics`]. Draw order within
+//! [`mutate_point`] is fixed so that identical `(gene, params, seed)` triples
+//! produce bit-identical results across platforms.
+
+use beast_core::{gaussian_q3232, reflect_clamp01, Prng, Q3232};
+
+use crate::gene::TraitGene;
+use crate::genome::GenomeParams;
+
+/// Apply all point-level mutations to a single gene.
+///
+/// Mutations fire independently (one Bernoulli trial per type) in a fixed
+/// order that must not change across versions:
+///
+/// 1. **Magnitude** — N(0, σ) drift, reflect-clamped to `[0, 1]`
+/// 2. **Channel shift** — N(0, σ) per channel entry (unbounded)
+/// 3. **Body-site drift** — N(0, σ) on `surface_vs_internal` and
+///    `body_region`, reflect-clamped to `[0, 1]`
+/// 4. **Silencing toggle** — flip `enabled`
+///
+/// Channel contributions are intentionally unbounded (inhibitory / synergistic
+/// values are legal); clamping happens downstream in the interpreter.
+pub fn mutate_point(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    mutate_magnitude(gene, params, rng);
+    mutate_channels(gene, params, rng);
+    mutate_body_site(gene, params, rng);
+    mutate_silencing(gene, params, rng);
+}
+
+fn mutate_magnitude(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() < params.point_mutation_rate {
+        let delta = gaussian_q3232(rng, Q3232::ZERO, params.point_mutation_sigma);
+        gene.effect.magnitude = reflect_clamp01(gene.effect.magnitude + delta);
+    }
+}
+
+fn mutate_channels(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() < params.channel_shift_rate {
+        for ch in &mut gene.effect.channel {
+            let delta = gaussian_q3232(rng, Q3232::ZERO, params.channel_shift_sigma);
+            *ch += delta;
+        }
+    }
+}
+
+fn mutate_body_site(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() < params.body_site_drift_rate {
+        let delta_s = gaussian_q3232(rng, Q3232::ZERO, params.body_site_drift_sigma);
+        gene.body_site.surface_vs_internal =
+            reflect_clamp01(gene.body_site.surface_vs_internal + delta_s);
+
+        let delta_r = gaussian_q3232(rng, Q3232::ZERO, params.body_site_drift_sigma);
+        gene.body_site.body_region = reflect_clamp01(gene.body_site.body_region + delta_r);
+    }
+}
+
+fn mutate_silencing(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() < params.silencing_toggle_rate {
+        gene.enabled = !gene.enabled;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::body_site::BodyVector;
+    use crate::gene::{EffectVector, Target, Timing};
+    use crate::lineage::LineageTag;
+    use beast_channels::Provenance;
+
+    fn make_gene(channels: usize) -> TraitGene {
+        TraitGene::new(
+            "kinetic_force",
+            EffectVector::new(
+                vec![Q3232::from_num(0.5_f64); channels],
+                Q3232::from_num(0.5_f64),
+                Q3232::from_num(0.25_f64),
+                Timing::Passive,
+                Target::SelfEntity,
+            )
+            .unwrap(),
+            BodyVector::new(
+                Q3232::from_num(0.5_f64),
+                Q3232::from_num(0.5_f64),
+                false,
+                Q3232::from_num(0.5_f64),
+            )
+            .unwrap(),
+            vec![],
+            true,
+            LineageTag::from_raw(1),
+            Provenance::Core,
+        )
+        .unwrap()
+    }
+
+    fn high_rate_params() -> GenomeParams {
+        GenomeParams {
+            point_mutation_rate: Q3232::ONE,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ONE,
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
+            body_site_drift_rate: Q3232::ONE,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ONE,
+            regulatory_rewire_rate: Q3232::ZERO,
+            duplication_rate: Q3232::ZERO,
+        }
+    }
+
+    #[test]
+    fn determinism_same_seed() {
+        let params = high_rate_params();
+        for seed in [1u64, 42, 999, 0xDEAD] {
+            let mut gene_a = make_gene(4);
+            let mut gene_b = make_gene(4);
+            let mut rng_a = Prng::from_seed(seed);
+            let mut rng_b = Prng::from_seed(seed);
+            for _ in 0..1000 {
+                mutate_point(&mut gene_a, &params, &mut rng_a);
+                mutate_point(&mut gene_b, &params, &mut rng_b);
+            }
+            assert_eq!(gene_a, gene_b, "diverged at seed {seed}");
+        }
+    }
+
+    #[test]
+    fn zero_rate_no_mutation() {
+        let params = GenomeParams {
+            point_mutation_rate: Q3232::ZERO,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ZERO,
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
+            body_site_drift_rate: Q3232::ZERO,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ZERO,
+            regulatory_rewire_rate: Q3232::ZERO,
+            duplication_rate: Q3232::ZERO,
+        };
+        let original = make_gene(4);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(42);
+        for _ in 0..1000 {
+            mutate_point(&mut gene, &params, &mut rng);
+        }
+        assert_eq!(gene, original);
+    }
+
+    #[test]
+    fn unit_range_preserved_after_many_mutations() {
+        let params = high_rate_params();
+        let mut gene = make_gene(4);
+        let mut rng = Prng::from_seed(7);
+        for _ in 0..10_000 {
+            mutate_point(&mut gene, &params, &mut rng);
+            assert!(
+                gene.effect.magnitude >= Q3232::ZERO && gene.effect.magnitude <= Q3232::ONE,
+                "magnitude out of range: {:?}",
+                gene.effect.magnitude
+            );
+            assert!(
+                gene.body_site.surface_vs_internal >= Q3232::ZERO
+                    && gene.body_site.surface_vs_internal <= Q3232::ONE,
+                "surface_vs_internal out of range: {:?}",
+                gene.body_site.surface_vs_internal
+            );
+            assert!(
+                gene.body_site.body_region >= Q3232::ZERO
+                    && gene.body_site.body_region <= Q3232::ONE,
+                "body_region out of range: {:?}",
+                gene.body_site.body_region
+            );
+        }
+    }
+
+    #[test]
+    fn channels_are_unbounded() {
+        let params = GenomeParams {
+            point_mutation_rate: Q3232::ZERO,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ONE,
+            channel_shift_sigma: Q3232::from_num(1_i32),
+            body_site_drift_rate: Q3232::ZERO,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ZERO,
+            regulatory_rewire_rate: Q3232::ZERO,
+            duplication_rate: Q3232::ZERO,
+        };
+        let mut gene = make_gene(4);
+        let mut rng = Prng::from_seed(99);
+        for _ in 0..500 {
+            mutate_point(&mut gene, &params, &mut rng);
+        }
+        let any_outside_unit = gene
+            .effect
+            .channel
+            .iter()
+            .any(|&c| c < Q3232::ZERO || c > Q3232::ONE);
+        assert!(
+            any_outside_unit,
+            "expected at least one channel outside [0,1] after 500 large-sigma shifts"
+        );
+    }
+
+    #[test]
+    fn silencing_always_toggles_at_rate_one() {
+        let params = GenomeParams {
+            point_mutation_rate: Q3232::ZERO,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ZERO,
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
+            body_site_drift_rate: Q3232::ZERO,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ONE,
+            regulatory_rewire_rate: Q3232::ZERO,
+            duplication_rate: Q3232::ZERO,
+        };
+        let mut gene = make_gene(2);
+        assert!(gene.enabled);
+        let mut rng = Prng::from_seed(1);
+        mutate_point(&mut gene, &params, &mut rng);
+        assert!(!gene.enabled);
+        mutate_point(&mut gene, &params, &mut rng);
+        assert!(gene.enabled);
+    }
+
+    #[test]
+    fn magnitude_drift_empirical_mean() {
+        let params = GenomeParams {
+            point_mutation_rate: Q3232::ONE,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ZERO,
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
+            body_site_drift_rate: Q3232::ZERO,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ZERO,
+            regulatory_rewire_rate: Q3232::ZERO,
+            duplication_rate: Q3232::ZERO,
+        };
+        let n = 10_000_i32;
+        let start = Q3232::from_num(0.5_f64);
+        let mut sum = Q3232::ZERO;
+        let mut rng = Prng::from_seed(42);
+        for _ in 0..n {
+            let mut gene = make_gene(2);
+            mutate_point(&mut gene, &params, &mut rng);
+            sum += gene.effect.magnitude - start;
+        }
+        let mean_drift: f64 = (sum / Q3232::from_num(n)).to_num();
+        assert!(
+            mean_drift.abs() < 0.01,
+            "mean drift {mean_drift} too far from 0"
+        );
+    }
+
+    #[test]
+    fn coverage_and_radius_unchanged() {
+        let params = high_rate_params();
+        let original = make_gene(4);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(55);
+        for _ in 0..1000 {
+            mutate_point(&mut gene, &params, &mut rng);
+        }
+        assert_eq!(gene.effect.radius, original.effect.radius);
+        assert_eq!(gene.body_site.coverage, original.body_site.coverage);
+    }
+
+    #[test]
+    fn provenance_and_lineage_unchanged() {
+        let params = high_rate_params();
+        let original = make_gene(4);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(77);
+        for _ in 0..1000 {
+            mutate_point(&mut gene, &params, &mut rng);
+        }
+        assert_eq!(gene.lineage_tag, original.lineage_tag);
+        assert_eq!(gene.provenance, original.provenance);
+        assert_eq!(gene.channel_id, original.channel_id);
+    }
+}


### PR DESCRIPTION
## Summary

Implements deterministic point-mutation operators for individual trait genes (issue #38).

- **`reflect_clamp01`** in `beast-core::math` — reflects values off `[0, 1]` boundaries instead of truncating, preserving Gaussian distribution shape near bounds
- **Sigma fields** added to `GenomeParams` (`point_mutation_sigma`, `channel_shift_sigma`, `body_site_drift_sigma`) with defaults from System 01 §3
- **`beast-genome::mutation`** module with `mutate_point` entry point covering four mutation types in fixed draw order:
  1. Magnitude drift — N(0, 0.1), reflect-clamped to [0, 1]
  2. Channel shift — N(0, 0.15) per channel (unbounded, as spec requires)
  3. Body-site drift — N(0, 0.1) on `surface_vs_internal` and `body_region`, reflect-clamped
  4. Silencing toggle — flips `enabled`

### Design decisions
- **Radius and coverage are not mutated** — matches the System 01 §3 pseudocode which only drifts magnitude
- **Channel contributions stay unbounded** — inhibitory/synergistic values are legal; interpreter clamps downstream
- **Single Bernoulli gate per mutation type** — when channel shift fires, all channels are perturbed (not individually gated)

Closes #38

## Test plan
- [x] Determinism: same seed → identical gene after 1000 mutations (4 seeds)
- [x] Zero-rate params produce no mutation after 1000 passes
- [x] Unit-range invariants hold after 10k mutations at rate 1.0
- [x] Channels escape [0, 1] with large sigma (unboundedness)
- [x] Silencing toggles every pass at rate 1.0
- [x] Empirical mean drift ≈ 0 over 10k single-mutation samples
- [x] Radius, coverage, provenance, lineage unchanged by point mutations
- [x] `cargo fmt`, `cargo clippy -D warnings`, all workspace tests pass