### PR TITLE
S3.4: regulatory modifier rewiring operator

### DIFF
--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -38,8 +38,27 @@ pub struct GenomeParams {
     pub body_site_drift_sigma: Q3232,
     /// Per-gene probability of flipping `enabled`.
     pub silencing_toggle_rate: Q3232,
-    /// Per-gene probability of a regulatory rewire.
-    pub regulatory_rewire_rate: Q3232,
+    /// Per-gene probability of inserting a new regulatory [`crate::Modifier`].
+    ///
+    /// One of the three per-locus rewiring rates whose defaults sum to
+    /// `5e-4` (System 01 §3, `REGULATORY_REWIRING_RATE`).
+    pub regulatory_add_rate: Q3232,
+    /// Per-gene probability of removing an existing regulatory
+    /// [`crate::Modifier`]. See [`Self::regulatory_add_rate`] for the
+    /// three-rate split.
+    pub regulatory_remove_rate: Q3232,
+    /// Per-gene probability of drifting an existing
+    /// [`crate::Modifier`]'s strength (and optionally flipping its
+    /// `effect_type`). See [`Self::regulatory_add_rate`] for the
+    /// three-rate split.
+    pub regulatory_mutate_rate: Q3232,
+    /// Gaussian σ used by the regulatory strength-drift operator.
+    pub regulatory_mutate_sigma: Q3232,
+    /// Conditional probability of flipping a [`crate::Modifier`]'s
+    /// `effect_type` given that the mutate-existing operator fired. Kept
+    /// deliberately small (System 01 §3 lists effect-type flips as "rare"
+    /// within the rewiring budget).
+    pub regulatory_effect_type_flip_prob: Q3232,
     /// Per-genome probability of a gene duplication. **Default 0** (v0).
     pub duplication_rate: Q3232,
 }
@@ -54,7 +73,14 @@ impl Default for GenomeParams {
             body_site_drift_rate: Q3232::from_num(1.0e-3_f64),
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::from_num(1.0e-3_f64),
-            regulatory_rewire_rate: Q3232::from_num(5.0e-4_f64),
+            // Three per-locus rewiring rates. System 01 §3 lists the
+            // aggregate `REGULATORY_REWIRING_RATE` as 5e-4; split evenly
+            // (5e-4 / 3 ≈ 1.6666667e-4).
+            regulatory_add_rate: Q3232::from_num(1.6666667e-4_f64),
+            regulatory_remove_rate: Q3232::from_num(1.6666667e-4_f64),
+            regulatory_mutate_rate: Q3232::from_num(1.6666667e-4_f64),
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::from_num(0.05_f64),
             // Disabled for v0 (System 01 §6B).
             duplication_rate: Q3232::ZERO,
         }

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -30,4 +30,4 @@ pub use gene::{EffectVector, Target, Timing, TraitGene};
 pub use genome::{Genome, GenomeParams};
 pub use lineage::LineageTag;
 pub use modifier::{Modifier, ModifierEffect};
-pub use mutation::mutate_point;
+pub use mutation::{mutate_point, mutate_regulatory};

--- a/crates/beast-genome/src/mutation.rs
+++ b/crates/beast-genome/src/mutation.rs
@@ -9,6 +9,7 @@ use beast_core::{gaussian_q3232, reflect_clamp01, Prng, Q3232};
 
 use crate::gene::TraitGene;
 use crate::genome::GenomeParams;
+use crate::modifier::{Modifier, ModifierEffect};
 
 /// Apply all point-level mutations to a single gene.
 ///
@@ -63,6 +64,141 @@ fn mutate_silencing(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng)
     }
 }
 
+/// Apply all regulatory-rewiring operators to a single gene's
+/// [`crate::Modifier`] list.
+///
+/// Operators fire in a fixed order so that identical
+/// `(gene, source_gene_index, genome_len, params, seed)` inputs produce
+/// bit-identical results:
+///
+/// 1. **Add** — push a new modifier targeting a random gene
+///    `!= source_gene_index`
+/// 2. **Remove** — drop a random existing modifier
+/// 3. **Mutate existing** — pick a random modifier and drift its
+///    `strength` (Gaussian, reflect-clamped to `[-1, 1]`); with
+///    `regulatory_effect_type_flip_prob` also swap its `effect_type`
+///    for one of the other two variants
+///
+/// The `Modifier` list is iterated by index, never by hashed order, so
+/// the result is stable across platforms.
+///
+/// `source_gene_index` must match the gene's position in its owning
+/// [`crate::Genome`]; `genome_len` must equal `genome.len()`. These are
+/// passed in rather than looked up to keep this function callable on
+/// unowned `TraitGene` values in tests.
+pub fn mutate_regulatory(
+    gene: &mut TraitGene,
+    source_gene_index: u32,
+    genome_len: usize,
+    params: &GenomeParams,
+    rng: &mut Prng,
+) {
+    try_add_modifier(gene, source_gene_index, genome_len, params, rng);
+    try_remove_modifier(gene, params, rng);
+    try_mutate_modifier(gene, params, rng);
+}
+
+fn try_add_modifier(
+    gene: &mut TraitGene,
+    source: u32,
+    genome_len: usize,
+    params: &GenomeParams,
+    rng: &mut Prng,
+) {
+    if rng.next_q3232_unit() >= params.regulatory_add_rate {
+        return;
+    }
+    // A valid target must be distinct from `source`, so we need at least
+    // two genes in the owning genome.
+    if genome_len < 2 {
+        return;
+    }
+    // Uniform over [0, genome_len - 1); shift past `source` to skip it.
+    // Safe to cast: `genome_len <= u32::MAX` is guaranteed at Genome
+    // construction (see `Genome::validate`).
+    let span = (genome_len - 1) as u64;
+    let raw = rng.gen_range_u64(0, span) as u32;
+    let target = if raw < source { raw } else { raw + 1 };
+    let effect_type = draw_effect_type(rng);
+    let strength = draw_strength(rng);
+    gene.regulatory.push(Modifier {
+        target_gene_index: target,
+        effect_type,
+        strength,
+    });
+}
+
+fn try_remove_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() >= params.regulatory_remove_rate {
+        return;
+    }
+    let n = gene.regulatory.len();
+    if n == 0 {
+        return;
+    }
+    let idx = rng.gen_range_u64(0, n as u64) as usize;
+    gene.regulatory.remove(idx);
+}
+
+fn try_mutate_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
+    if rng.next_q3232_unit() >= params.regulatory_mutate_rate {
+        return;
+    }
+    let n = gene.regulatory.len();
+    if n == 0 {
+        return;
+    }
+    let idx = rng.gen_range_u64(0, n as u64) as usize;
+    let delta = gaussian_q3232(rng, Q3232::ZERO, params.regulatory_mutate_sigma);
+    let new_strength = reflect_clamp_signed_unit(gene.regulatory[idx].strength + delta);
+    gene.regulatory[idx].strength = new_strength;
+    if rng.next_q3232_unit() < params.regulatory_effect_type_flip_prob {
+        let current = gene.regulatory[idx].effect_type;
+        let pick = rng.gen_range_u64(0, 2) as u8;
+        gene.regulatory[idx].effect_type = flipped_effect_type(current, pick);
+    }
+}
+
+fn draw_effect_type(rng: &mut Prng) -> ModifierEffect {
+    match rng.gen_range_u64(0, 3) {
+        0 => ModifierEffect::Activate,
+        1 => ModifierEffect::Suppress,
+        _ => ModifierEffect::Modulate,
+    }
+}
+
+/// Draw a strength in `[-1, 1]` by remapping a unit-range draw.
+fn draw_strength(rng: &mut Prng) -> Q3232 {
+    let u = rng.next_q3232_unit();
+    u * Q3232::from_num(2_i32) - Q3232::ONE
+}
+
+/// Reflect a [`Q3232`] value back into `[-1, 1]` off the nearest
+/// boundary, then hard-clamp any residual overshoot. Analogous to
+/// [`beast_core::reflect_clamp01`] but over the signed-unit interval.
+fn reflect_clamp_signed_unit(v: Q3232) -> Q3232 {
+    let neg_one = -Q3232::ONE;
+    if v >= neg_one && v <= Q3232::ONE {
+        return v;
+    }
+    let two = Q3232::from_num(2_i32);
+    let reflected = if v < neg_one { -two - v } else { two - v };
+    reflected.clamp(neg_one, Q3232::ONE)
+}
+
+/// Return one of the other two [`ModifierEffect`] variants, chosen by
+/// `pick ∈ {0, 1}`.
+fn flipped_effect_type(current: ModifierEffect, pick: u8) -> ModifierEffect {
+    match (current, pick) {
+        (ModifierEffect::Activate, 0) => ModifierEffect::Suppress,
+        (ModifierEffect::Activate, _) => ModifierEffect::Modulate,
+        (ModifierEffect::Suppress, 0) => ModifierEffect::Activate,
+        (ModifierEffect::Suppress, _) => ModifierEffect::Modulate,
+        (ModifierEffect::Modulate, 0) => ModifierEffect::Activate,
+        (ModifierEffect::Modulate, _) => ModifierEffect::Suppress,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,7 +242,11 @@ mod tests {
             body_site_drift_rate: Q3232::ONE,
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::ONE,
-            regulatory_rewire_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ZERO,
+            regulatory_remove_rate: Q3232::ZERO,
+            regulatory_mutate_rate: Q3232::ZERO,
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::ZERO,
             duplication_rate: Q3232::ZERO,
         }
     }
@@ -137,7 +277,11 @@ mod tests {
             body_site_drift_rate: Q3232::ZERO,
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::ZERO,
-            regulatory_rewire_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ZERO,
+            regulatory_remove_rate: Q3232::ZERO,
+            regulatory_mutate_rate: Q3232::ZERO,
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::ZERO,
             duplication_rate: Q3232::ZERO,
         };
         let original = make_gene(4);
@@ -186,7 +330,11 @@ mod tests {
             body_site_drift_rate: Q3232::ZERO,
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::ZERO,
-            regulatory_rewire_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ZERO,
+            regulatory_remove_rate: Q3232::ZERO,
+            regulatory_mutate_rate: Q3232::ZERO,
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::ZERO,
             duplication_rate: Q3232::ZERO,
         };
         let mut gene = make_gene(4);
@@ -215,7 +363,11 @@ mod tests {
             body_site_drift_rate: Q3232::ZERO,
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::ONE,
-            regulatory_rewire_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ZERO,
+            regulatory_remove_rate: Q3232::ZERO,
+            regulatory_mutate_rate: Q3232::ZERO,
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::ZERO,
             duplication_rate: Q3232::ZERO,
         };
         let mut gene = make_gene(2);
@@ -237,7 +389,11 @@ mod tests {
             body_site_drift_rate: Q3232::ZERO,
             body_site_drift_sigma: Q3232::from_num(0.1_f64),
             silencing_toggle_rate: Q3232::ZERO,
-            regulatory_rewire_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ZERO,
+            regulatory_remove_rate: Q3232::ZERO,
+            regulatory_mutate_rate: Q3232::ZERO,
+            regulatory_mutate_sigma: Q3232::from_num(0.15_f64),
+            regulatory_effect_type_flip_prob: Q3232::ZERO,
             duplication_rate: Q3232::ZERO,
         };
         let n = 10_000_i32;
@@ -281,5 +437,240 @@ mod tests {
         assert_eq!(gene.lineage_tag, original.lineage_tag);
         assert_eq!(gene.provenance, original.provenance);
         assert_eq!(gene.channel_id, original.channel_id);
+    }
+
+    // --- S3.4 regulatory rewiring ------------------------------------------
+
+    fn rewiring_params() -> GenomeParams {
+        GenomeParams {
+            point_mutation_rate: Q3232::ZERO,
+            point_mutation_sigma: Q3232::from_num(0.1_f64),
+            channel_shift_rate: Q3232::ZERO,
+            channel_shift_sigma: Q3232::from_num(0.15_f64),
+            body_site_drift_rate: Q3232::ZERO,
+            body_site_drift_sigma: Q3232::from_num(0.1_f64),
+            silencing_toggle_rate: Q3232::ZERO,
+            regulatory_add_rate: Q3232::ONE,
+            regulatory_remove_rate: Q3232::ONE,
+            regulatory_mutate_rate: Q3232::ONE,
+            regulatory_mutate_sigma: Q3232::from_num(0.25_f64),
+            regulatory_effect_type_flip_prob: Q3232::from_num(0.1_f64),
+            duplication_rate: Q3232::ZERO,
+        }
+    }
+
+    #[test]
+    fn rewiring_zero_rates_no_change() {
+        let mut params = rewiring_params();
+        params.regulatory_add_rate = Q3232::ZERO;
+        params.regulatory_remove_rate = Q3232::ZERO;
+        params.regulatory_mutate_rate = Q3232::ZERO;
+        let original = make_gene(2);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(42);
+        for _ in 0..1000 {
+            mutate_regulatory(&mut gene, 0, 4, &params, &mut rng);
+        }
+        assert_eq!(gene, original);
+    }
+
+    #[test]
+    fn rewiring_determinism_same_seed() {
+        let params = rewiring_params();
+        for seed in [1u64, 42, 999, 0xDEAD] {
+            let mut gene_a = make_gene(2);
+            let mut gene_b = make_gene(2);
+            let mut rng_a = Prng::from_seed(seed);
+            let mut rng_b = Prng::from_seed(seed);
+            for _ in 0..1000 {
+                mutate_regulatory(&mut gene_a, 0, 4, &params, &mut rng_a);
+                mutate_regulatory(&mut gene_b, 0, 4, &params, &mut rng_b);
+            }
+            assert_eq!(
+                gene_a.regulatory, gene_b.regulatory,
+                "regulatory diverged at seed {seed}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewiring_never_produces_self_loop() {
+        let params = rewiring_params();
+        let source: u32 = 2;
+        let genome_len = 5;
+        let mut gene = make_gene(2);
+        let mut rng = Prng::from_seed(7);
+        for _ in 0..10_000 {
+            mutate_regulatory(&mut gene, source, genome_len, &params, &mut rng);
+            for m in &gene.regulatory {
+                assert_ne!(
+                    m.target_gene_index, source,
+                    "modifier targeted its own source gene index"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rewiring_target_gene_index_in_range() {
+        let params = rewiring_params();
+        let genome_len = 6;
+        let mut gene = make_gene(2);
+        let mut rng = Prng::from_seed(11);
+        for _ in 0..10_000 {
+            mutate_regulatory(&mut gene, 3, genome_len, &params, &mut rng);
+            for m in &gene.regulatory {
+                assert!(
+                    (m.target_gene_index as usize) < genome_len,
+                    "target_gene_index {} out of range (genome_len={})",
+                    m.target_gene_index,
+                    genome_len
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rewiring_strength_stays_in_signed_unit() {
+        let params = rewiring_params();
+        let mut gene = make_gene(2);
+        let mut rng = Prng::from_seed(17);
+        let neg_one = -Q3232::ONE;
+        for _ in 0..10_000 {
+            mutate_regulatory(&mut gene, 0, 4, &params, &mut rng);
+            for m in &gene.regulatory {
+                assert!(
+                    m.strength >= neg_one && m.strength <= Q3232::ONE,
+                    "modifier strength out of range: {:?}",
+                    m.strength
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rewiring_add_needs_genome_len_ge_two() {
+        let mut params = rewiring_params();
+        params.regulatory_remove_rate = Q3232::ZERO;
+        params.regulatory_mutate_rate = Q3232::ZERO;
+        let mut gene = make_gene(2);
+        let mut rng = Prng::from_seed(99);
+        for _ in 0..500 {
+            mutate_regulatory(&mut gene, 0, 1, &params, &mut rng);
+        }
+        assert!(
+            gene.regulatory.is_empty(),
+            "singleton genome must never grow a modifier (need a distinct target)"
+        );
+    }
+
+    #[test]
+    fn rewiring_remove_on_empty_is_noop() {
+        let mut params = rewiring_params();
+        params.regulatory_add_rate = Q3232::ZERO;
+        params.regulatory_mutate_rate = Q3232::ZERO;
+        let original = make_gene(2);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(5);
+        for _ in 0..500 {
+            mutate_regulatory(&mut gene, 0, 4, &params, &mut rng);
+        }
+        assert_eq!(gene, original);
+    }
+
+    #[test]
+    fn rewiring_mutate_on_empty_is_noop() {
+        let mut params = rewiring_params();
+        params.regulatory_add_rate = Q3232::ZERO;
+        params.regulatory_remove_rate = Q3232::ZERO;
+        let original = make_gene(2);
+        let mut gene = original.clone();
+        let mut rng = Prng::from_seed(3);
+        for _ in 0..500 {
+            mutate_regulatory(&mut gene, 0, 4, &params, &mut rng);
+        }
+        assert_eq!(gene, original);
+    }
+
+    #[test]
+    fn rewiring_add_populates_modifiers_when_valid() {
+        let mut params = rewiring_params();
+        params.regulatory_remove_rate = Q3232::ZERO;
+        params.regulatory_mutate_rate = Q3232::ZERO;
+        let mut gene = make_gene(2);
+        let mut rng = Prng::from_seed(33);
+        for _ in 0..10 {
+            mutate_regulatory(&mut gene, 1, 4, &params, &mut rng);
+        }
+        assert_eq!(
+            gene.regulatory.len(),
+            10,
+            "add-only pipeline should push exactly one modifier per call"
+        );
+    }
+
+    #[test]
+    fn reflect_clamp_signed_unit_in_range_passthrough() {
+        assert_eq!(reflect_clamp_signed_unit(Q3232::ZERO), Q3232::ZERO);
+        assert_eq!(reflect_clamp_signed_unit(Q3232::ONE), Q3232::ONE);
+        assert_eq!(reflect_clamp_signed_unit(-Q3232::ONE), -Q3232::ONE);
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(0.5_f64)),
+            Q3232::from_num(0.5_f64)
+        );
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(-0.5_f64)),
+            Q3232::from_num(-0.5_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp_signed_unit_reflects_above_one() {
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(1.3_f64)),
+            Q3232::from_num(0.7_f64)
+        );
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(1.9_f64)),
+            Q3232::from_num(0.1_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp_signed_unit_reflects_below_neg_one() {
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(-1.3_f64)),
+            Q3232::from_num(-0.7_f64)
+        );
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(-1.9_f64)),
+            Q3232::from_num(-0.1_f64)
+        );
+    }
+
+    #[test]
+    fn reflect_clamp_signed_unit_clamps_pathological() {
+        // Beyond one reflection off each boundary — final clamp saves us.
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(3.5_f64)),
+            -Q3232::ONE
+        );
+        assert_eq!(
+            reflect_clamp_signed_unit(Q3232::from_num(-3.5_f64)),
+            Q3232::ONE
+        );
+    }
+
+    #[test]
+    fn flipped_effect_type_always_different() {
+        for current in [
+            ModifierEffect::Activate,
+            ModifierEffect::Suppress,
+            ModifierEffect::Modulate,
+        ] {
+            for pick in [0_u8, 1_u8] {
+                assert_ne!(flipped_effect_type(current, pick), current);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Introduces `mutate_regulatory` in `beast-genome` — three deterministic per-locus operators over `TraitGene.regulatory` whose default rates sum to `5e-4` (System 01 §3 `REGULATORY_REWIRING_RATE`).

- **Add**: insert a new `Modifier` targeting a random gene index `!= source_gene_index`. Effect type uniform over `{Activate, Suppress, Modulate}`; strength uniform in `[-1, 1]`.
- **Remove**: drop a random existing `Modifier` (no-op when the list is empty).
- **Mutate existing**: Gaussian drift on `strength` with `regulatory_mutate_sigma` (reflect-clamped to `[-1, 1]` via a new module-private helper), plus a small conditional `regulatory_effect_type_flip_prob` of swapping `effect_type` for one of the other two variants.

`Modifier` lists iterate by insertion index, never by hashed order, so identical `(gene, source_gene_index, genome_len, params, seed)` inputs produce bit-identical results — preserves Invariant §1 (determinism).

`GenomeParams` replaces the scalar `regulatory_rewire_rate` with three distinct per-locus rates (`regulatory_add_rate`, `regulatory_remove_rate`, `regulatory_mutate_rate`) plus `regulatory_mutate_sigma` and `regulatory_effect_type_flip_prob`. Defaults preserve the System 01 aggregate by splitting `5e-4` evenly across the three rates.

Closes #39.

## Acceptance criteria

- [x] Tests: rewiring never produces self-loops (`rewiring_never_produces_self_loop`, 10 000 iterations)
- [x] Tests: `target_gene_index` always in range (`rewiring_target_gene_index_in_range`, 10 000 iterations)
- [x] Tests: strength always stays in `[-1, 1]` (`rewiring_strength_stays_in_signed_unit`)
- [x] Determinism: same seed → same rewiring sequence over 1000 iterations (`rewiring_determinism_same_seed` over 4 seeds)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --all-targets --locked\` clean (49 tests in \`beast-genome\`, 13 new)

## Test plan

- [x] \`cargo test -p beast-genome --lib\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets --locked\`
- [x] \`cargo test --workspace --doc --locked\`

## Out of scope

- Tarjan SCC cycle detection — belongs to \`beast-interpreter\` per \`documentation/systems/01_evolutionary_model.md\` §Layer 2.
- Full \`apply_mutations\` top-level pipeline wiring — lands with the S3.6 property harness (#41).
- Per-tick genome-wide apply loop — comes with the S6 tick loop / determinism gate (#18).