### PR TITLE
docs(beast-genome): add usage example (S3 DoD)

### DIFF
--- a/crates/beast-genome/README.md
+++ b/crates/beast-genome/README.md
@@ -36,7 +36,62 @@ provenance type and registry lookups used by duplication). Per
 `CRATE_LAYOUT.md`, this crate sits at Layer 2 and does **not** depend on
 `beast-primitives`, `beast-interpreter`, `beast-ecs`, or anything above.
 
+## Usage
+
+Build a `Genome`, then advance it one tick at a time with
+`apply_mutations`. All randomness flows through a single `Prng` handle —
+derive it from `Stream::Genetics` at the world root and pass it down.
+
+```rust
+use beast_channels::Provenance;
+use beast_core::{Prng, Stream, TickCounter, Q3232};
+use beast_genome::{
+    apply_mutations, BodyVector, EffectVector, Genome, GenomeParams,
+    LineageTag, Target, Timing, TraitGene,
+};
+
+// One trait gene: a passive "kinetic_force" contribution at half strength.
+let effect = EffectVector::new(
+    vec![Q3232::from_num(0.25_f64); 3], // per-channel contributions
+    Q3232::from_num(0.5_f64),           // magnitude
+    Q3232::from_num(0.25_f64),          // radius
+    Timing::Passive,
+    Target::SelfEntity,
+)
+.unwrap();
+
+let gene = TraitGene::new(
+    "kinetic_force",
+    effect,
+    BodyVector::default_internal(),
+    Vec::new(),                  // no regulatory modifiers
+    true,                        // enabled
+    LineageTag::from_raw(1),
+    Provenance::Core,
+)
+.unwrap();
+
+let mut genome = Genome::new(GenomeParams::default(), vec![gene]).unwrap();
+
+// Derive the genetics stream from the master seed once per world.
+let master = Prng::from_seed(0xDEAD_BEEF);
+let mut genetics = master.split_stream(Stream::Genetics);
+
+// Advance the genome for 100 ticks.
+for tick in 0..100u64 {
+    apply_mutations(&mut genome, TickCounter::new(tick), &mut genetics);
+}
+
+// Structural invariants always hold after mutation.
+genome.validate().unwrap();
+```
+
+Individual operators (`mutate_point`, `mutate_regulatory`,
+`mutate_duplicate`, `mutate_duplication_rate`) are also public for tests
+and bespoke pipelines; prefer `apply_mutations` for the canonical
+per-tick order.
+
 ## Status
 
-Sprint S3 work in progress. See the tracker epic (GitHub `label:epic
+Sprint S3 complete. See the tracker epic (GitHub `label:epic
 sprint:s3`) for the story checklist.


### PR DESCRIPTION
## Summary

Closes the final item on the S3 Exit Definition of Done (#15): **README for `beast-genome` with usage examples**.

- Adds a self-contained Rust example in `crates/beast-genome/README.md` showing how to build a `Genome`, derive the `Stream::Genetics` PRNG from the master seed, and advance it via `apply_mutations`.
- Flips the Status line from \"Sprint S3 work in progress\" to \"Sprint S3 complete\" now that all six stories have shipped and every DoD box is ticked.

## S3 Exit DoD status after this PR

- [x] All mutation operators functional (S3.3 point, S3.4 regulatory, S3.5 duplication/genesis, S3.6 `apply_mutations` pipeline)
- [x] Genome structure supports variable-length gene lists (`Vec<TraitGene>`)
- [x] 1000 mutations of 10 genomes: no panics, all values valid (covered by the S3.6 proptest — 64 random genomes × 1000 passes, with tighter invariant checks)
- [x] CI passes (fmt, clippy `-D warnings`, tests)
- [x] README for `beast-genome` with usage examples — **this PR**

## Test plan

- [x] Snippet compiles against current public API (manually verified against lib.rs re-exports; imports match EffectVector/TraitGene/Genome/apply_mutations signatures)
- [x] CI green