### PR TITLE
feat(beast-interpreter): S4 Wave 0 scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-interpreter"
+version = "0.1.0"
+dependencies = [
+ "beast-channels",
+ "beast-core",
+ "beast-genome",
+ "beast-primitives",
+ "proptest",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "beast-primitives"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/beast-channels",
     "crates/beast-primitives",
     "crates/beast-genome",
+    "crates/beast-interpreter",
 ]
 
 [workspace.package]
@@ -35,6 +36,7 @@ beast-core = { path = "crates/beast-core" }
 beast-channels = { path = "crates/beast-channels" }
 beast-primitives = { path = "crates/beast-primitives" }
 beast-genome = { path = "crates/beast-genome" }
+beast-interpreter = { path = "crates/beast-interpreter" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-interpreter/Cargo.toml
+++ b/crates/beast-interpreter/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "beast-interpreter"
+description = "Phenotype interpreter — converts genotypes to deterministic primitive-effect sets for the Beast Evolution Game."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+beast-core = { workspace = true }
+beast-channels = { workspace = true }
+beast-primitives = { workspace = true }
+beast-genome = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+float_arithmetic = "warn"

--- a/crates/beast-interpreter/src/body_map.rs
+++ b/crates/beast-interpreter/src/body_map.rs
@@ -1,0 +1,13 @@
+//! Body-region tiling and per-site aggregation (S4.5 — issue #59).
+//!
+//! When a composition hook references channels marked
+//! `body_site_applicable = true`, emission fans out to one
+//! [`beast_primitives::PrimitiveEffect`] per body region on the creature.
+//! Global channels broadcast their value to every site invocation. This
+//! module also provides `aggregate_to_global(channel, strategy, per_site)`
+//! for UI / combat code that needs a single scalar summary per body-site
+//! channel.
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §6.0B.
+
+// Implementation — see story S4.5 (#59).

--- a/crates/beast-interpreter/src/composition.rs
+++ b/crates/beast-interpreter/src/composition.rs
@@ -1,0 +1,87 @@
+//! Composition hook resolver (S4.3 — issue #57).
+//!
+//! Defines the interpreter-level [`InterpreterHook`] type (wraps the
+//! channel-manifest hook and adds the `emits` list) and the [`FiredHook`]
+//! output consumed by [`crate::emission`].
+//!
+//! The resolver itself — evaluating hooks against channel values and producing
+//! `Vec<FiredHook>` — is implemented by story 4.3. Only the shared data types
+//! are defined here during the Wave 0 scaffold so stories 4.3 and 4.4 share a
+//! stable surface.
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §5.0a and §6.2.
+
+use beast_core::Q3232;
+
+pub use beast_channels::composition::CompositionKind;
+
+use crate::parameter_map::Expr;
+
+/// Stable identifier for an interpreter-level hook. Assigned at load time.
+///
+/// The value is opaque; callers must not rely on its internal layout beyond
+/// ordering for determinism.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HookId(pub u32);
+
+/// A single primitive emission attached to a hook: which primitive to fire and
+/// how its parameters are derived from channel values.
+///
+/// `parameter_mapping` is stored in sorted-key order so iteration is
+/// deterministic. The [`Expr`] values were parsed at manifest load time.
+#[derive(Debug, Clone)]
+pub struct EmitSpec {
+    /// Primitive id in the [`beast_primitives::PrimitiveRegistry`].
+    pub primitive_id: String,
+    /// Parameter name → parsed expression. Sorted by parameter name.
+    pub parameter_mapping: Vec<(String, Expr)>,
+}
+
+/// Interpreter-level composition hook.
+///
+/// Wraps the channel-manifest hook data (kind, thresholds, coefficient, gating
+/// conditions) and extends it with the [`emits`](Self::emits) list, which is
+/// the only path by which the interpreter produces
+/// [`beast_primitives::PrimitiveEffect`]s. Per §6.2 and invariant §2
+/// (mechanics-label separation), the `emits` list references primitives by id
+/// only — never by name.
+#[derive(Debug, Clone)]
+pub struct InterpreterHook {
+    /// Stable hook id.
+    pub id: HookId,
+    /// Composition kind.
+    pub kind: CompositionKind,
+    /// Participating channel ids (sorted by caller convention).
+    pub channel_ids: Vec<String>,
+    /// Per-channel thresholds for [`CompositionKind::Threshold`] /
+    /// [`CompositionKind::Gating`]. Indexed parallel to `channel_ids`.
+    pub thresholds: Vec<Q3232>,
+    /// Scaling coefficient.
+    pub coefficient: Q3232,
+    /// Environmental gating. Empty vec = always-on.
+    pub expression_conditions: Vec<beast_channels::ExpressionCondition>,
+    /// Primitives to fire when this hook triggers.
+    pub emits: Vec<EmitSpec>,
+}
+
+/// Output of the hook resolver — one per hook that fired.
+///
+/// Downstream [`crate::emission`] consumes the [`emits`](Self::emits) list
+/// (borrowed back from the source hook) to build
+/// [`beast_primitives::PrimitiveEffect`] values.
+#[derive(Debug, Clone)]
+pub struct FiredHook {
+    /// The hook that fired.
+    pub hook_id: HookId,
+    /// Kind (preserved for emission-time decisions such as
+    /// Additive/Multiplicative intensity computation).
+    pub kind: CompositionKind,
+    /// Channel values at fire time, parallel to the hook's `channel_ids`.
+    pub channel_values: Vec<Q3232>,
+    /// Coefficient (copied for emission convenience).
+    pub coefficient: Q3232,
+    /// Emission specs to fire (cloned from the source hook).
+    pub emits: Vec<EmitSpec>,
+}
+
+// Resolver implementation — see story S4.3 (#57).

--- a/crates/beast-interpreter/src/emission.rs
+++ b/crates/beast-interpreter/src/emission.rs
@@ -1,0 +1,12 @@
+//! PrimitiveEffect emission, deduplication, and merge (S4.4 — issue #58).
+//!
+//! Consumes [`crate::FiredHook`]s from the resolver ([`crate::composition`]),
+//! evaluates each [`crate::EmitSpec`]'s parameter expressions against the
+//! phenotype's channel vector, materialises one
+//! [`beast_primitives::PrimitiveEffect`] per (primitive_id, body_site) pair,
+//! and merges duplicates using the per-parameter `merge_strategy` declared in
+//! the primitive manifest.
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §6.2 and §6.2B.
+
+// Implementation — see story S4.4 (#58).

--- a/crates/beast-interpreter/src/error.rs
+++ b/crates/beast-interpreter/src/error.rs
@@ -1,0 +1,40 @@
+//! Error type for the interpreter crate.
+//!
+//! Errors surface when callers feed the interpreter something the registries
+//! cannot satisfy — an unknown channel symbol in a parameter expression, an
+//! unknown primitive id on an [`crate::EmitSpec`], or a malformed manifest at
+//! load time. Evaluation-time paths (hook resolution, emission) never fail —
+//! they return empty sets rather than errors, consistent with the design
+//! doc's "dormant channels propagate zero" semantics.
+
+use thiserror::Error;
+
+/// Errors produced by the interpreter.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum InterpreterError {
+    /// A parameter expression referenced a channel symbol that is not
+    /// registered.
+    #[error("unknown channel symbol `{symbol}` in expression")]
+    UnknownChannelSymbol {
+        /// The offending symbol as it appeared in the source expression.
+        symbol: String,
+    },
+
+    /// An [`crate::EmitSpec`] references a primitive id that is not in the
+    /// primitive registry.
+    #[error("unknown primitive id `{primitive_id}` in emit spec")]
+    UnknownPrimitive {
+        /// The missing primitive id.
+        primitive_id: String,
+    },
+
+    /// A parameter expression could not be parsed.
+    #[error("invalid parameter expression: {message}")]
+    ParseError {
+        /// Human-readable description of what failed to parse.
+        message: String,
+    },
+}
+
+/// Crate-specific `Result` alias.
+pub type Result<T> = core::result::Result<T, InterpreterError>;

--- a/crates/beast-interpreter/src/expression.rs
+++ b/crates/beast-interpreter/src/expression.rs
@@ -1,0 +1,10 @@
+//! Environmental affordance filter (S4.2 — issue #56).
+//!
+//! Thin interpreter-side wrapper over
+//! [`beast_channels::evaluate_expression_conditions`]. Given an
+//! [`crate::Environment`] and a slice of [`crate::InterpreterHook`]s, returns
+//! the sorted subset of hook ids whose `expression_conditions` pass.
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §5.0c and §6.2.
+
+// Implementation — see story S4.2 (#56).

--- a/crates/beast-interpreter/src/interpreter.rs
+++ b/crates/beast-interpreter/src/interpreter.rs
@@ -1,0 +1,17 @@
+//! Top-level entry point [`interpret_phenotype`].
+//!
+//! Sequencing through the six stages in §6 of the design doc:
+//!
+//! 1. Scale-band filter ([`crate::scale_band`])
+//! 2. Affordance filter ([`crate::expression`])
+//! 3. Composition hook resolve ([`crate::composition`])
+//! 4. Primitive emission + dedup/merge ([`crate::emission`])
+//! 5. Body-region tiling ([`crate::body_map`])
+//!
+//! Behaviour compilation (stage 3 in the doc) lives downstream and is not part
+//! of S4.
+//!
+//! Wired up incrementally as each story in epic #16 lands; the current stub
+//! exists so downstream crates can reference the entry-point signature.
+
+// Implementation — wired up as stories 4.1–4.6 complete.

--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -1,0 +1,55 @@
+//! Beast Evolution Game — Layer 2 phenotype interpreter.
+//!
+//! The interpreter is the formal composition law: it converts an evolved
+//! [`beast_genome::Genome`] plus an [`Environment`] into a deterministic
+//! `Set<PrimitiveEffect>` by consulting the channel and primitive registries.
+//! See `documentation/systems/11_phenotype_interpreter.md` for the canonical
+//! specification and `documentation/INVARIANTS.md` for the contracts this
+//! crate enforces.
+//!
+//! **Non-negotiable invariants enforced by every module in this crate:**
+//!
+//! * Mechanics-label separation (INVARIANTS §2): only primitive ids and
+//!   parameters leave the interpreter. Named abilities never appear here.
+//! * Determinism (INVARIANTS §1): all arithmetic in [`beast_core::Q3232`];
+//!   iteration over `BTreeMap` / sorted keys only; no wall-clock reads, no OS
+//!   RNG, no floats in the hot path.
+//! * Scale-band unification (INVARIANTS §5): one pipeline across macro hosts
+//!   and micro pathogens; scale-band filtering is the first stage
+//!   ([`scale_band`]).
+//! * Registry-driven mutability (INVARIANTS §3): every channel and primitive
+//!   reference resolves through the shared registries at load / tick time; no
+//!   hardcoded ids in system code.
+//!
+//! # Sprint scope (S4 — epic [#16])
+//!
+//! | Story | Module                       | Issue |
+//! |-------|------------------------------|-------|
+//! | 4.1   | [`scale_band`]               | #55   |
+//! | 4.2   | [`expression`]               | #56   |
+//! | 4.3   | [`composition`]              | #57   |
+//! | 4.4   | [`parameter_map`], [`emission`] | #58 |
+//! | 4.5   | [`body_map`]                 | #59   |
+//! | 4.6   | `tests/determinism.rs` (integration) | #60 |
+//!
+//! The top-level entry point [`interpreter::interpret_phenotype`] is wired up
+//! incrementally as each story lands.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod body_map;
+pub mod composition;
+pub mod emission;
+pub mod error;
+pub mod expression;
+pub mod interpreter;
+pub mod parameter_map;
+pub mod phenotype;
+pub mod scale_band;
+
+pub use composition::{CompositionKind, EmitSpec, FiredHook, HookId, InterpreterHook};
+pub use error::{InterpreterError, Result};
+pub use parameter_map::Expr;
+pub use phenotype::{BodyRegion, BodySite, Environment, LifeStage, ResolvedPhenotype};

--- a/crates/beast-interpreter/src/parameter_map.rs
+++ b/crates/beast-interpreter/src/parameter_map.rs
@@ -1,0 +1,44 @@
+//! Parameter-mapping expression parser and evaluator (S4.4 — issue #58).
+//!
+//! Expressions look like `ch[vocal_modulation] * 8 + ch[auditory_sensitivity]`
+//! in the manifest source. They are parsed **once at manifest load time**
+//! (sprint plan Q2) into an [`Expr`] AST where channel symbols have already
+//! been resolved to channel ids (Q4). Evaluation is a pure fold over Q32.32
+//! fixed-point arithmetic.
+//!
+//! The **minimal operator set** shipped in S4 is listed below; everything
+//! else is tracked in issue #61.
+//!
+//! | Construct          | S4.4 | Deferred (#61) |
+//! |--------------------|------|----------------|
+//! | `ch[<symbol>]`     | ✓    |                |
+//! | scalar literal     | ✓    |                |
+//! | `+`, `*`           | ✓    |                |
+//! | `sqrt(...)`        |      | ✓              |
+//! | `[lo, hi]` range   |      | ✓              |
+//! | implicit `clamp`   |      | ✓              |
+//! | `-`, `/`           |      | ✓              |
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §6.2.
+
+use beast_core::Q3232;
+
+/// Parsed parameter expression.
+///
+/// `ChannelRef` carries a resolved channel id (sprint plan Q4): the parser
+/// looks the symbol up in the [`beast_channels::ChannelRegistry`] at load
+/// time and rejects unknown symbols early. Evaluator therefore does not need
+/// the registry — it walks the AST over a pre-indexed channel-value vector.
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// A literal Q32.32 value.
+    Literal(Q3232),
+    /// Reference to a channel value by resolved id.
+    ChannelRef(String),
+    /// Binary addition.
+    Add(Box<Expr>, Box<Expr>),
+    /// Binary multiplication.
+    Mul(Box<Expr>, Box<Expr>),
+}
+
+// Parser + evaluator implementation — see story S4.4 (#58).

--- a/crates/beast-interpreter/src/phenotype.rs
+++ b/crates/beast-interpreter/src/phenotype.rs
@@ -1,0 +1,127 @@
+//! Interpreter input: [`ResolvedPhenotype`] and its supporting types.
+//!
+//! The `ResolvedPhenotype` is the materialised view of a creature's genotype
+//! that the interpreter consumes. It carries the per-channel global values,
+//! per-body-region amplitudes, and the environmental context that gates
+//! expression.
+//!
+//! Shape maps 1:1 to §3.1 of the design doc
+//! (`documentation/systems/11_phenotype_interpreter.md`). Fields are kept
+//! narrow on purpose — upstream systems are responsible for populating only
+//! what the interpreter actually reads.
+
+use std::collections::BTreeMap;
+
+use beast_core::{TickCounter, Q3232};
+
+/// Canonical body-site enum. Ordinal order is the deterministic iteration
+/// order used by per-site emission in [`crate::body_map`]. Do **not** reorder
+/// variants without updating fixture tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BodySite {
+    /// The creature as a whole (global emissions).
+    Global,
+    /// Head.
+    Head,
+    /// Jaw / mouth.
+    Jaw,
+    /// Body core / torso.
+    Core,
+    /// Left limb.
+    LimbLeft,
+    /// Right limb.
+    LimbRight,
+    /// Tail.
+    Tail,
+    /// Generic appendage (antenna, tentacle, etc.).
+    Appendage,
+}
+
+/// Life stage used as an expression-condition gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LifeStage {
+    /// Juvenile.
+    Juvenile,
+    /// Adult.
+    Adult,
+    /// Elderly.
+    Elderly,
+}
+
+impl LifeStage {
+    /// Stable lowercase label used when matching schema-loaded strings.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Juvenile => "juvenile",
+            Self::Adult => "adult",
+            Self::Elderly => "elderly",
+        }
+    }
+}
+
+/// One body region with its per-region channel amplitudes.
+///
+/// `channel_amplitudes` is keyed by channel id. `BTreeMap` — not `HashMap` —
+/// so iteration order is stable without relying on hash randomisation.
+#[derive(Debug, Clone)]
+pub struct BodyRegion {
+    /// Stable region id (unique within the phenotype). Assigned by the
+    /// upstream body-plan builder.
+    pub id: u32,
+    /// Anatomical site this region represents.
+    pub body_site: BodySite,
+    /// Surface-vs-internal coordinate in `[0, 1]` (0 = deep, 1 = surface).
+    pub surface_vs_internal: Q3232,
+    /// Per-channel amplitudes (post-resolution). Keyed by channel id.
+    pub channel_amplitudes: BTreeMap<String, Q3232>,
+}
+
+/// Environmental context that gates channel / hook expression.
+#[derive(Debug, Clone, Default)]
+pub struct Environment {
+    /// Biome flags active at the creature's location.
+    pub biome_flags: Vec<String>,
+    /// Current season label (e.g. `"spring"`).
+    pub season: Option<String>,
+    /// Local light level `[0, 1]` — 0 = dark, 1 = full sunlight.
+    pub light_level: Option<Q3232>,
+    /// Local temperature in °C.
+    pub temperature_c: Option<Q3232>,
+    /// Local population density (individuals per km²).
+    pub population_density_per_km2: Option<Q3232>,
+}
+
+/// Materialised phenotype input passed to [`crate::interpreter::interpret_phenotype`].
+#[derive(Debug, Clone)]
+pub struct ResolvedPhenotype {
+    /// Per-channel global values, keyed by channel id. `BTreeMap` guarantees
+    /// deterministic iteration order.
+    pub global_channels: BTreeMap<String, Q3232>,
+    /// Body-region breakdown. Populated when any channel has
+    /// `body_site_applicable = true`.
+    pub body_map: Vec<BodyRegion>,
+    /// Creature body mass in kg (used by [`crate::scale_band`]).
+    pub body_mass_kg: Q3232,
+    /// Life stage.
+    pub life_stage: LifeStage,
+    /// Tick at which this phenotype was first expressed (provenance metadata).
+    pub expression_tick: TickCounter,
+    /// Environmental context.
+    pub environment: Environment,
+}
+
+impl ResolvedPhenotype {
+    /// Build an empty phenotype at the given mass and life stage. Used
+    /// primarily by tests; production callers materialise from a
+    /// [`beast_genome::Genome`] + environment snapshot.
+    pub fn new(body_mass_kg: Q3232, life_stage: LifeStage) -> Self {
+        Self {
+            global_channels: BTreeMap::new(),
+            body_map: Vec::new(),
+            body_mass_kg,
+            life_stage,
+            expression_tick: TickCounter::default(),
+            environment: Environment::default(),
+        }
+    }
+}

--- a/crates/beast-interpreter/src/scale_band.rs
+++ b/crates/beast-interpreter/src/scale_band.rs
@@ -1,0 +1,12 @@
+//! Stage 1A: scale-band channel filtering (S4.1 — issue #55).
+//!
+//! Filters the channel values on a [`crate::ResolvedPhenotype`] so that any
+//! channel whose manifest `scale_band` excludes the creature's body mass is
+//! reduced to [`beast_core::Q3232::ZERO`]. This makes the dormant-channel
+//! propagation rule in §6.2 (zero operand ⇒ threshold fails, zero parameter
+//! ⇒ zero intensity) fall out of the arithmetic automatically.
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §6.0 and
+//! INVARIANTS §5 (scale-band unification).
+
+// Implementation — see story S4.1 (#55).


### PR DESCRIPTION
## Summary

Stands up the `beast-interpreter` crate (Layer 2) as the Wave 0 base for sprint S4. Only shared types and per-story module stubs land here — the actual logic for each story ships in its own follow-up PR.

- `Cargo.toml` workspace entry
- Shared input types: `ResolvedPhenotype`, `Environment`, `BodyRegion`, `BodySite`, `LifeStage`
- Shared resolver types: `InterpreterHook`, `EmitSpec`, `FiredHook`, `HookId`
- `Expr` AST stub for parameter mapping (minimal operator set per sprint plan Q3 — extended operators tracked in #61)
- `InterpreterError` / `Result`
- Per-story module stubs pointing at their tracker issues

## Sprint plan decisions baked in

- **Q1**: `emits` lives on `InterpreterHook` (L2), not on `beast-channels::CompositionHook` (L1). This avoids an L1→L1 dependency on `beast-primitives`.
- **Q2**: Parameter expressions are parsed at manifest **load time** → `Expr` AST; evaluator will walk the AST in the hot path.
- **Q3**: Minimal operator set in S4 (`ch[_]`, literal, `+`, `*`); `sqrt`, ranges, clamp, div/sub tracked in #61.
- **Q4**: Channel symbols are resolved to ids at parse time; evaluator takes a pre-indexed value vector.

## Scope explicitly out

All six story implementations. Each is its own follow-up PR:
- #55 (4.1 scale-band)
- #56 (4.2 expression)
- #57 (4.3 composition)
- #58 (4.4 param-map/emission)
- #59 (4.5 body-map)
- #60 (4.6 determinism tests).

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Merge into master so Wave 1 agents (4.1 / 4.2 / 4.3) can branch from the scaffold

Parent epic: #16