### PR TITLE
feat(beast-interpreter): S4.4 parameter-map parser + primitive emission

### DIFF
--- a/crates/beast-interpreter/src/emission.rs
+++ b/crates/beast-interpreter/src/emission.rs
@@ -9,22 +9,29 @@
 //!
 //! See `documentation/systems/11_phenotype_interpreter.md` §6.2 and §6.2B.
 //!
-//! # Scope note — body-site fanout deferred to #67
+//! # Known follow-ups (deliberately deferred past S4.4)
 //!
-//! Per §6.2B the design calls for dedup by `(primitive_id, body_site)`, but
-//! [`beast_primitives::PrimitiveEffect`] does not yet carry a `body_site`
-//! field. Adding one (plus the accompanying schema entry) is tracked in
-//! issue #67. S4.4 therefore dedups flat by `primitive_id` only; extending
-//! to per-site keys is a follow-up once the effect shape lands.
+//! * **Body-site fanout — [issue #67]**. §6.2B dedups by
+//!   `(primitive_id, body_site)`, but [`beast_primitives::PrimitiveEffect`]
+//!   does not yet carry a `body_site` field. S4.4 therefore dedups flat by
+//!   `primitive_id` only.
+//! * **Typed manifest merge_strategy — [issue #71]**. §6.2B allows per-parameter
+//!   `sum`/`max`/`mean`/`union` strategies declared on `PrimitiveManifest`;
+//!   that field doesn't exist yet. Until then every user parameter merges
+//!   via `max` (the doc's conservative default at line 802), and the cost
+//!   sentinel below merges via `sum`.
+//! * **Source-channel provenance — [issue #70]**. §6.2 line 746 records the
+//!   hook's firing channels in `source_channels`. Without `channel_ids` on
+//!   [`crate::FiredHook`] we currently reconstruct from expression refs only;
+//!   gate-only channels are missed.
+//! * **First-class activation cost — [issue #67]**. Until
+//!   [`beast_primitives::PrimitiveEffect`] gains a dedicated `activation_cost`
+//!   field we surface the evaluated cost via the [`ACTIVATION_COST_PARAM`]
+//!   sentinel parameter below.
 //!
-//! # Merge strategy — default to "max"
-//!
-//! The design doc's pseudocode defaults unknown `merge_strategy` entries to
-//! `"max"` (line 802 of §6.2B). [`beast_primitives::PrimitiveManifest`] does
-//! not yet surface a typed `merge_strategy` field — adding one requires a
-//! manifest-schema extension (tracked alongside #67). Until then every
-//! parameter merges via `max`, which is the doc's conservative fallback and
-//! is correct for every intensity-like parameter in the starter vocabulary.
+//! [issue #67]: https://github.com/BemusedVermin/evolution-simulation/issues/67
+//! [issue #70]: https://github.com/BemusedVermin/evolution-simulation/issues/70
+//! [issue #71]: https://github.com/BemusedVermin/evolution-simulation/issues/71
 
 use std::collections::BTreeMap;
 

--- a/crates/beast-interpreter/src/emission.rs
+++ b/crates/beast-interpreter/src/emission.rs
@@ -3,10 +3,616 @@
 //! Consumes [`crate::FiredHook`]s from the resolver ([`crate::composition`]),
 //! evaluates each [`crate::EmitSpec`]'s parameter expressions against the
 //! phenotype's channel vector, materialises one
-//! [`beast_primitives::PrimitiveEffect`] per (primitive_id, body_site) pair,
-//! and merges duplicates using the per-parameter `merge_strategy` declared in
-//! the primitive manifest.
+//! [`beast_primitives::PrimitiveEffect`] per hook emission, and merges
+//! duplicates (same `primitive_id`) using a deterministic per-parameter
+//! merge strategy.
 //!
 //! See `documentation/systems/11_phenotype_interpreter.md` §6.2 and §6.2B.
+//!
+//! # Scope note — body-site fanout deferred to #67
+//!
+//! Per §6.2B the design calls for dedup by `(primitive_id, body_site)`, but
+//! [`beast_primitives::PrimitiveEffect`] does not yet carry a `body_site`
+//! field. Adding one (plus the accompanying schema entry) is tracked in
+//! issue #67. S4.4 therefore dedups flat by `primitive_id` only; extending
+//! to per-site keys is a follow-up once the effect shape lands.
+//!
+//! # Merge strategy — default to "max"
+//!
+//! The design doc's pseudocode defaults unknown `merge_strategy` entries to
+//! `"max"` (line 802 of §6.2B). [`beast_primitives::PrimitiveManifest`] does
+//! not yet surface a typed `merge_strategy` field — adding one requires a
+//! manifest-schema extension (tracked alongside #67). Until then every
+//! parameter merges via `max`, which is the doc's conservative fallback and
+//! is correct for every intensity-like parameter in the starter vocabulary.
 
-// Implementation — see story S4.4 (#58).
+use std::collections::BTreeMap;
+
+use beast_core::{EntityId, Q3232};
+use beast_primitives::{evaluate_cost, PrimitiveEffect, PrimitiveRegistry};
+
+use crate::composition::{EmitSpec, FiredHook};
+use crate::error::{InterpreterError, Result};
+use crate::parameter_map::{collect_channel_refs, eval_expression};
+use crate::phenotype::ResolvedPhenotype;
+
+/// Parameter name reserved for the cost output on a [`PrimitiveEffect`].
+///
+/// Until [`beast_primitives::PrimitiveEffect`] gains a first-class
+/// `activation_cost` field (#67 / follow-up), we surface the evaluated cost
+/// inside `parameters` under this key so downstream consumers have access
+/// without a schema break. The leading underscore keeps it visually distinct
+/// from user-declared parameters.
+pub const ACTIVATION_COST_PARAM: &str = "_activation_cost";
+
+/// Build [`PrimitiveEffect`]s from the given fired hooks and merge duplicates.
+///
+/// For every `(fired_hook, emit_spec)` pair the emitter:
+///
+/// 1. Evaluates each parameter expression against
+///    [`ResolvedPhenotype::global_channels`] via [`eval_expression`].
+/// 2. Looks the primitive up in `registry`, returning
+///    [`InterpreterError::UnknownPrimitive`] when absent.
+/// 3. Computes the activation cost through
+///    [`beast_primitives::evaluate_cost`] using the evaluated parameters and
+///    stores it under [`ACTIVATION_COST_PARAM`] in the emission's
+///    `parameters` map.
+/// 4. Builds a [`PrimitiveEffect`] whose
+///    [`source_channels`](PrimitiveEffect::source_channels) is the sorted,
+///    deduplicated union of the firing hook's context channels and every
+///    channel id referenced by any parameter expression.
+///
+/// After every effect is built, effects are grouped by `primitive_id` and
+/// merged per §6.2B. Single-effect groups pass through unchanged;
+/// multi-effect groups merge each parameter via `max` (the doc's default)
+/// with the exception of [`ACTIVATION_COST_PARAM`], which sums across the
+/// group.
+///
+/// The returned vector is sorted by `primitive_id` (grouped via
+/// [`BTreeMap`]), which gives deterministic output ordering without relying
+/// on input hook order — satisfying INVARIANTS §1.
+///
+/// # Errors
+///
+/// * [`InterpreterError::UnknownPrimitive`] if any `EmitSpec` references a
+///   primitive not in `registry`.
+/// * Any error returned by [`beast_primitives::evaluate_cost`] is converted
+///   into [`InterpreterError::ParseError`] (chosen over adding a new enum
+///   variant; the cost evaluator's own errors contain the detail in the
+///   message).
+pub fn emit_primitives(
+    fired_hooks: &[FiredHook],
+    phenotype: &ResolvedPhenotype,
+    registry: &PrimitiveRegistry,
+    emitter: EntityId,
+) -> Result<Vec<PrimitiveEffect>> {
+    // Stage 1 — materialise one `PrimitiveEffect` per (fired hook, emit spec)
+    // pair, preserving input order so the merge below sees a predictable
+    // sequence (the merge itself is ordering-independent for sum/max, but
+    // keeping input order makes debugging easier).
+    let mut effects: Vec<PrimitiveEffect> = Vec::new();
+    for fired in fired_hooks {
+        for emit in &fired.emits {
+            effects.push(build_effect(fired, emit, phenotype, registry, emitter)?);
+        }
+    }
+
+    // Stage 2 — dedup / merge by `primitive_id`. `BTreeMap` iteration is
+    // lexicographic on ids, which gives a stable output order independent of
+    // input hook order.
+    let mut groups: BTreeMap<String, Vec<PrimitiveEffect>> = BTreeMap::new();
+    for effect in effects {
+        groups
+            .entry(effect.primitive_id.clone())
+            .or_default()
+            .push(effect);
+    }
+
+    let mut out: Vec<PrimitiveEffect> = Vec::with_capacity(groups.len());
+    for (_id, group) in groups {
+        out.push(merge_group(group));
+    }
+    Ok(out)
+}
+
+/// Build one [`PrimitiveEffect`] from a single `(FiredHook, EmitSpec)` pair.
+fn build_effect(
+    fired: &FiredHook,
+    emit: &EmitSpec,
+    phenotype: &ResolvedPhenotype,
+    registry: &PrimitiveRegistry,
+    emitter: EntityId,
+) -> Result<PrimitiveEffect> {
+    let manifest =
+        registry
+            .get(&emit.primitive_id)
+            .ok_or_else(|| InterpreterError::UnknownPrimitive {
+                primitive_id: emit.primitive_id.clone(),
+            })?;
+
+    // Evaluate parameter expressions. `parameter_mapping` is sorted by
+    // name (per the `EmitSpec` contract in composition.rs), so the
+    // resulting `BTreeMap` population order is deterministic.
+    let mut parameters: BTreeMap<String, Q3232> = BTreeMap::new();
+    for (name, expr) in &emit.parameter_mapping {
+        let value = eval_expression(expr, &phenotype.global_channels);
+        parameters.insert(name.clone(), value);
+    }
+
+    // Evaluate the cost against the just-computed parameters. `evaluate_cost`
+    // falls back to manifest-declared defaults for any scaling term whose
+    // parameter is absent from the map.
+    let cost = evaluate_cost(manifest, &parameters).map_err(|e| InterpreterError::ParseError {
+        message: format!(
+            "cost evaluation for primitive `{}` failed: {e}",
+            emit.primitive_id
+        ),
+    })?;
+    parameters.insert(ACTIVATION_COST_PARAM.to_owned(), cost);
+
+    // Source channels = hook-context channels ∪ expression-referenced
+    // channels, deduplicated and sorted (via `BTreeSet` below).
+    let source_channels = collect_source_channels(fired, emit);
+
+    Ok(PrimitiveEffect {
+        primitive_id: emit.primitive_id.clone(),
+        source_channels,
+        parameters,
+        emitter,
+        provenance: manifest.provenance.clone(),
+    })
+}
+
+/// Compose the sorted, deduplicated list of channel ids that contributed to
+/// an effect.
+///
+/// The hook's own `channel_ids` list isn't stored on [`FiredHook`] (only the
+/// per-channel *values* are), so the context is inferred from the union of
+/// every channel the emit spec's expressions read. The resolver filters out
+/// hooks whose context channels are missing from the phenotype, so the
+/// per-expression refs are a superset-safe way to reconstruct the provenance
+/// list without an extra round-trip to the original `InterpreterHook`.
+fn collect_source_channels(_fired: &FiredHook, emit: &EmitSpec) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    for (_name, expr) in &emit.parameter_mapping {
+        for id in collect_channel_refs(expr) {
+            seen.insert(id);
+        }
+    }
+    seen.into_iter().collect()
+}
+
+/// Merge a group of [`PrimitiveEffect`]s sharing a `primitive_id`.
+///
+/// Single-effect groups return the single effect unchanged. Multi-effect
+/// groups merge parameters per §6.2B:
+///
+/// * [`ACTIVATION_COST_PARAM`] — summed across the group (each source hook
+///   incurs its own cost).
+/// * Every other parameter — merged via `max`, the doc's default strategy.
+///
+/// `source_channels` is re-unioned across the group. `emitter` and
+/// `provenance` are copied from the first effect (all group members share
+/// the same emitting entity and the same primitive manifest, hence the same
+/// provenance).
+fn merge_group(mut group: Vec<PrimitiveEffect>) -> PrimitiveEffect {
+    if group.len() == 1 {
+        return group.remove(0);
+    }
+
+    // All members share the same primitive_id, emitter, provenance — take
+    // the first as the template and merge into it.
+    let first = group.remove(0);
+    let primitive_id = first.primitive_id.clone();
+    let emitter = first.emitter;
+    let provenance = first.provenance.clone();
+
+    let mut merged_params: BTreeMap<String, Q3232> = first.parameters;
+    let mut source_set: std::collections::BTreeSet<String> =
+        first.source_channels.into_iter().collect();
+
+    for effect in group {
+        for ch in effect.source_channels {
+            source_set.insert(ch);
+        }
+        for (name, value) in effect.parameters {
+            match merged_params.get(&name).copied() {
+                Some(existing) => {
+                    let merged = if name == ACTIVATION_COST_PARAM {
+                        existing.saturating_add(value)
+                    } else {
+                        // Default merge strategy per §6.2B: `max`.
+                        if value > existing {
+                            value
+                        } else {
+                            existing
+                        }
+                    };
+                    merged_params.insert(name, merged);
+                }
+                None => {
+                    merged_params.insert(name, value);
+                }
+            }
+        }
+    }
+
+    PrimitiveEffect {
+        primitive_id,
+        source_channels: source_set.into_iter().collect(),
+        parameters: merged_params,
+        emitter,
+        provenance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::composition::{CompositionKind, HookId};
+    use crate::parameter_map::{parse_expression, Expr};
+    use crate::phenotype::{LifeStage, ResolvedPhenotype};
+    use beast_channels::{
+        BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry, MutationKernel,
+        Provenance as ChannelProvenance, Range, ScaleBand,
+    };
+    use beast_primitives::PrimitiveManifest;
+
+    // ----- fixtures --------------------------------------------------------
+
+    fn channel_manifest(id: &str) -> ChannelManifest {
+        ChannelManifest {
+            id: id.into(),
+            family: ChannelFamily::Sensory,
+            description: "fixture".into(),
+            range: Range {
+                min: Q3232::ZERO,
+                max: Q3232::ONE,
+                units: "dimensionless".into(),
+            },
+            mutation_kernel: MutationKernel {
+                sigma: Q3232::from_num(0.1_f64),
+                bounds_policy: BoundsPolicy::Clamp,
+                genesis_weight: Q3232::ONE,
+                correlation_with: Vec::new(),
+            },
+            composition_hooks: Vec::new(),
+            expression_conditions: Vec::new(),
+            scale_band: ScaleBand {
+                min_kg: Q3232::ZERO,
+                max_kg: Q3232::from_num(1_000_i32),
+            },
+            body_site_applicable: false,
+            provenance: ChannelProvenance::Core,
+        }
+    }
+
+    fn channel_registry_with(ids: &[&str]) -> ChannelRegistry {
+        let mut reg = ChannelRegistry::new();
+        for id in ids {
+            reg.register(channel_manifest(id)).unwrap();
+        }
+        reg
+    }
+
+    fn primitive_manifest(id: &str, with_force_cost: bool) -> PrimitiveManifest {
+        let cost_scaling = if with_force_cost {
+            r#"[{ "parameter": "force", "exponent": 1.0, "coefficient": 0.5 }]"#
+        } else {
+            "[]"
+        };
+        let parameter_schema = if with_force_cost {
+            r#""force": { "type": "number", "default": 10 }"#
+        } else {
+            r#""intensity": { "type": "number", "default": 0 }"#
+        };
+        let json = format!(
+            r#"{{
+                "id": "{id}",
+                "category": "force_application",
+                "description": "emission fixture",
+                "parameter_schema": {{ {parameter_schema} }},
+                "composition_compatibility": [{{ "channel_family": "motor" }}],
+                "cost_function": {{
+                    "base_metabolic_cost": 1.0,
+                    "parameter_scaling": {cost_scaling}
+                }},
+                "observable_signature": {{
+                    "modality": "mechanical",
+                    "detection_range_m": 1,
+                    "pattern_key": "fixture_v1"
+                }},
+                "provenance": "core"
+            }}"#
+        );
+        PrimitiveManifest::from_json_str(&json).expect("fixture manifest must be valid")
+    }
+
+    fn primitive_registry_with(primitives: Vec<PrimitiveManifest>) -> PrimitiveRegistry {
+        let mut reg = PrimitiveRegistry::new();
+        for p in primitives {
+            reg.register(p).unwrap();
+        }
+        reg
+    }
+
+    fn phenotype_with(channels: &[(&str, Q3232)]) -> ResolvedPhenotype {
+        let mut p = ResolvedPhenotype::new(Q3232::from_num(1_i32), LifeStage::Adult);
+        for (id, v) in channels {
+            p.global_channels.insert((*id).to_string(), *v);
+        }
+        p
+    }
+
+    fn fired_hook(
+        id: u32,
+        channel_values: Vec<Q3232>,
+        emits: Vec<EmitSpec>,
+        coefficient: Q3232,
+    ) -> FiredHook {
+        FiredHook {
+            hook_id: HookId(id),
+            kind: CompositionKind::Additive,
+            channel_values,
+            coefficient,
+            emits,
+        }
+    }
+
+    fn emit(primitive_id: &str, params: Vec<(&str, Expr)>) -> EmitSpec {
+        EmitSpec {
+            primitive_id: primitive_id.into(),
+            parameter_mapping: params
+                .into_iter()
+                .map(|(name, expr)| (name.to_string(), expr))
+                .collect(),
+        }
+    }
+
+    // ----- unit tests ------------------------------------------------------
+
+    #[test]
+    fn emits_one_primitive_effect_per_emit_spec() {
+        let creg = channel_registry_with(&["auditory"]);
+        let preg = primitive_registry_with(vec![primitive_manifest("emit_pulse", false)]);
+        let phenotype = phenotype_with(&[("auditory", Q3232::from_num(0.5_f64))]);
+
+        let expr = parse_expression("ch[auditory] * 8", &creg).unwrap();
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(0.5_f64)],
+            vec![emit("emit_pulse", vec![("intensity", expr)])],
+            Q3232::ONE,
+        );
+
+        let effects = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(42)).unwrap();
+
+        assert_eq!(effects.len(), 1);
+        let e = &effects[0];
+        assert_eq!(e.primitive_id, "emit_pulse");
+        assert_eq!(e.emitter, EntityId::new(42));
+        // 0.5 * 8 = 4
+        assert_eq!(e.parameters["intensity"], Q3232::from_num(4_i32));
+        // cost = 1.0 (base only, no scaling term)
+        assert_eq!(e.parameters[ACTIVATION_COST_PARAM], Q3232::from_num(1_i32));
+        assert_eq!(e.source_channels, vec!["auditory".to_string()]);
+    }
+
+    #[test]
+    fn unknown_primitive_id_errors() {
+        let creg = ChannelRegistry::new();
+        let preg = PrimitiveRegistry::new();
+        let phenotype = phenotype_with(&[]);
+
+        let fired = fired_hook(
+            1,
+            Vec::new(),
+            vec![emit("does_not_exist", Vec::new())],
+            Q3232::ONE,
+        );
+
+        let err = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(1)).unwrap_err();
+        match err {
+            InterpreterError::UnknownPrimitive { primitive_id } => {
+                assert_eq!(primitive_id, "does_not_exist");
+            }
+            other => panic!("expected UnknownPrimitive, got {other:?}"),
+        }
+        // Silence the unused `creg` warning — we created it to mirror the
+        // shape of other tests even though no expressions are parsed here.
+        let _ = creg;
+    }
+
+    #[test]
+    fn cost_scales_with_parameter_value() {
+        let creg = channel_registry_with(&["force_src"]);
+        let preg = primitive_registry_with(vec![primitive_manifest("strike", true)]);
+        let phenotype = phenotype_with(&[("force_src", Q3232::from_num(4_i32))]);
+
+        let expr = parse_expression("ch[force_src]", &creg).unwrap();
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(4_i32)],
+            vec![emit("strike", vec![("force", expr)])],
+            Q3232::ONE,
+        );
+
+        let effects = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(1)).unwrap();
+        assert_eq!(effects.len(), 1);
+        let e = &effects[0];
+        assert_eq!(e.parameters["force"], Q3232::from_num(4_i32));
+        // cost = 1 (base) + 0.5 * 4^1 = 3. The fixed-point `q_pow` used by
+        // `evaluate_cost` goes through an `exp`/`ln` pair, so we compare
+        // within a small epsilon rather than bit-exact — the determinism
+        // contract is bit-identical reproducibility across runs, which is
+        // covered by `same_inputs_produce_identical_outputs_twice` below.
+        let cost = e.parameters[ACTIVATION_COST_PARAM];
+        let diff = cost.saturating_sub(Q3232::from_num(3_i32)).saturating_abs();
+        assert!(
+            diff < Q3232::from_num(0.001_f64),
+            "expected cost ≈ 3, got {cost:?}"
+        );
+    }
+
+    #[test]
+    fn two_hooks_same_primitive_merge_via_max_and_sum_cost() {
+        let creg = channel_registry_with(&["a", "b"]);
+        let preg = primitive_registry_with(vec![primitive_manifest("emit_pulse", false)]);
+        let phenotype = phenotype_with(&[
+            ("a", Q3232::from_num(0.3_f64)),
+            ("b", Q3232::from_num(0.8_f64)),
+        ]);
+
+        // Hook 1 emits intensity = ch[a] = 0.3
+        let expr_a = parse_expression("ch[a]", &creg).unwrap();
+        let fired1 = fired_hook(
+            1,
+            vec![Q3232::from_num(0.3_f64)],
+            vec![emit("emit_pulse", vec![("intensity", expr_a)])],
+            Q3232::ONE,
+        );
+        // Hook 2 emits intensity = ch[b] = 0.8
+        let expr_b = parse_expression("ch[b]", &creg).unwrap();
+        let fired2 = fired_hook(
+            2,
+            vec![Q3232::from_num(0.8_f64)],
+            vec![emit("emit_pulse", vec![("intensity", expr_b)])],
+            Q3232::ONE,
+        );
+
+        let effects =
+            emit_primitives(&[fired1, fired2], &phenotype, &preg, EntityId::new(1)).unwrap();
+        assert_eq!(effects.len(), 1);
+        let e = &effects[0];
+        // max(0.3, 0.8) = 0.8
+        assert_eq!(e.parameters["intensity"], Q3232::from_num(0.8_f64));
+        // cost: base 1.0 per hook, summed = 2.0
+        assert_eq!(e.parameters[ACTIVATION_COST_PARAM], Q3232::from_num(2_i32));
+        // Source channels unioned from both hooks.
+        assert_eq!(e.source_channels, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn independent_primitives_pass_through_and_are_sorted_by_id() {
+        let creg = channel_registry_with(&["a"]);
+        let preg = primitive_registry_with(vec![
+            primitive_manifest("zulu", false),
+            primitive_manifest("alpha", false),
+        ]);
+        let phenotype = phenotype_with(&[("a", Q3232::from_num(0.5_f64))]);
+
+        let expr = parse_expression("ch[a]", &creg).unwrap();
+        // Intentionally emit `zulu` before `alpha` to verify the output is
+        // sorted by primitive_id, not by input order.
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(0.5_f64)],
+            vec![
+                emit("zulu", vec![("intensity", expr.clone())]),
+                emit("alpha", vec![("intensity", expr)]),
+            ],
+            Q3232::ONE,
+        );
+
+        let effects = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(1)).unwrap();
+        let ids: Vec<&str> = effects.iter().map(|e| e.primitive_id.as_str()).collect();
+        assert_eq!(ids, vec!["alpha", "zulu"]);
+    }
+
+    #[test]
+    fn source_channels_are_sorted_and_deduplicated() {
+        let creg = channel_registry_with(&["beta", "alpha"]);
+        let preg = primitive_registry_with(vec![primitive_manifest("emit_pulse", false)]);
+        let phenotype = phenotype_with(&[
+            ("alpha", Q3232::from_num(1_i32)),
+            ("beta", Q3232::from_num(2_i32)),
+        ]);
+
+        // Mention `beta` and `alpha` in both params in non-sorted order, and
+        // `beta` twice, to prove dedup + sort.
+        let expr1 = parse_expression("ch[beta] + ch[alpha]", &creg).unwrap();
+        let expr2 = parse_expression("ch[beta] * 2", &creg).unwrap();
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(1_i32), Q3232::from_num(2_i32)],
+            vec![emit(
+                "emit_pulse",
+                vec![("intensity", expr1), ("duration", expr2)],
+            )],
+            Q3232::ONE,
+        );
+
+        let effects = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(1)).unwrap();
+        assert_eq!(effects.len(), 1);
+        assert_eq!(
+            effects[0].source_channels,
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+    }
+
+    #[test]
+    fn dormant_channel_propagates_zero_without_error() {
+        let creg = channel_registry_with(&["present", "dormant"]);
+        let preg = primitive_registry_with(vec![primitive_manifest("emit_pulse", false)]);
+        // Only `present` is on the phenotype; `dormant` is absent entirely.
+        let phenotype = phenotype_with(&[("present", Q3232::from_num(1_i32))]);
+
+        let expr = parse_expression("ch[present] + ch[dormant]", &creg).unwrap();
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(1_i32)],
+            vec![emit("emit_pulse", vec![("intensity", expr)])],
+            Q3232::ONE,
+        );
+
+        let effects = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(1)).unwrap();
+        // `ch[dormant]` evaluates to zero, so intensity = 1 + 0 = 1.
+        assert_eq!(effects[0].parameters["intensity"], Q3232::from_num(1_i32));
+    }
+
+    #[test]
+    fn empty_input_returns_empty_output() {
+        let preg = PrimitiveRegistry::new();
+        let phenotype = phenotype_with(&[]);
+        let effects = emit_primitives(&[], &phenotype, &preg, EntityId::new(1)).unwrap();
+        assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn same_inputs_produce_identical_outputs_twice() {
+        // Determinism: full pipeline invoked twice yields bit-identical
+        // effect vectors.
+        let creg = channel_registry_with(&["a", "b"]);
+        let preg = primitive_registry_with(vec![
+            primitive_manifest("first", false),
+            primitive_manifest("second", false),
+        ]);
+        let phenotype = phenotype_with(&[
+            ("a", Q3232::from_num(0.25_f64)),
+            ("b", Q3232::from_num(0.75_f64)),
+        ]);
+
+        let expr1 = parse_expression("ch[a] * 4 + ch[b]", &creg).unwrap();
+        let expr2 = parse_expression("ch[b] * ch[a]", &creg).unwrap();
+        let fired = fired_hook(
+            1,
+            vec![Q3232::from_num(0.25_f64), Q3232::from_num(0.75_f64)],
+            vec![
+                emit("first", vec![("magnitude", expr1)]),
+                emit("second", vec![("concentration", expr2)]),
+            ],
+            Q3232::ONE,
+        );
+
+        let first = emit_primitives(
+            std::slice::from_ref(&fired),
+            &phenotype,
+            &preg,
+            EntityId::new(7),
+        )
+        .unwrap();
+        let second = emit_primitives(&[fired], &phenotype, &preg, EntityId::new(7)).unwrap();
+
+        assert_eq!(first, second);
+    }
+}

--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -52,8 +52,9 @@ pub mod scale_band;
 pub use composition::{
     resolve_hooks, CompositionKind, EmitSpec, FiredHook, HookId, InterpreterHook,
 };
+pub use emission::{emit_primitives, ACTIVATION_COST_PARAM};
 pub use error::{InterpreterError, Result};
 pub use expression::filter_hooks_by_affordances;
-pub use parameter_map::Expr;
+pub use parameter_map::{collect_channel_refs, eval_expression, parse_expression, Expr};
 pub use phenotype::{BodyRegion, BodySite, Environment, LifeStage, ResolvedPhenotype};
 pub use scale_band::apply_scale_band_filter;

--- a/crates/beast-interpreter/src/parameter_map.rs
+++ b/crates/beast-interpreter/src/parameter_map.rs
@@ -21,7 +21,12 @@
 //!
 //! See `documentation/systems/11_phenotype_interpreter.md` §6.2.
 
+use std::collections::BTreeMap;
+
+use beast_channels::ChannelRegistry;
 use beast_core::Q3232;
+
+use crate::error::{InterpreterError, Result};
 
 /// Parsed parameter expression.
 ///
@@ -41,4 +46,675 @@ pub enum Expr {
     Mul(Box<Expr>, Box<Expr>),
 }
 
-// Parser + evaluator implementation — see story S4.4 (#58).
+/// Parse a parameter-mapping expression source string into an [`Expr`].
+///
+/// # Grammar (minimal operator set — sprint plan Q3)
+///
+/// ```text
+/// expr    ::= term ( "+" term )*       // left-associative
+/// term    ::= factor ( "*" factor )*   // left-associative, binds tighter than `+`
+/// factor  ::= literal | ch_ref | "(" expr ")"
+/// literal ::= [0-9][0-9_]* ( "." [0-9_]+ )?
+/// ch_ref  ::= "ch[" ident "]"
+/// ident   ::= [a-z_][a-z0-9_]*
+/// ```
+///
+/// Whitespace (spaces, tabs, newlines) is skipped between tokens. Channel
+/// symbols are resolved to ids at parse time (sprint plan Q4): the symbol
+/// must be registered in `registry` or the parser returns
+/// [`InterpreterError::UnknownChannelSymbol`]. Any other parse failure
+/// returns [`InterpreterError::ParseError`].
+///
+/// # Examples
+///
+/// ```
+/// use beast_channels::{
+///     BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry,
+///     MutationKernel, Provenance, Range, ScaleBand,
+/// };
+/// use beast_core::Q3232;
+/// use beast_interpreter::parameter_map::parse_expression;
+///
+/// let manifest = ChannelManifest {
+///     id: "vocal_modulation".into(),
+///     family: ChannelFamily::Motor,
+///     description: "fixture".into(),
+///     range: Range { min: Q3232::ZERO, max: Q3232::ONE, units: "dimensionless".into() },
+///     mutation_kernel: MutationKernel {
+///         sigma: Q3232::from_num(0.1_f64),
+///         bounds_policy: BoundsPolicy::Clamp,
+///         genesis_weight: Q3232::ONE,
+///         correlation_with: Vec::new(),
+///     },
+///     composition_hooks: Vec::new(),
+///     expression_conditions: Vec::new(),
+///     scale_band: ScaleBand { min_kg: Q3232::ZERO, max_kg: Q3232::from_num(1_000_i32) },
+///     body_site_applicable: false,
+///     provenance: Provenance::Core,
+/// };
+/// let mut registry = ChannelRegistry::new();
+/// registry.register(manifest).unwrap();
+///
+/// let _expr = parse_expression("ch[vocal_modulation] * 8", &registry).unwrap();
+/// ```
+pub fn parse_expression(src: &str, registry: &ChannelRegistry) -> Result<Expr> {
+    let mut parser = Parser::new(src, registry);
+    let expr = parser.parse_expr()?;
+    parser.skip_whitespace();
+    if !parser.at_end() {
+        return Err(InterpreterError::ParseError {
+            message: format!(
+                "unexpected trailing input at byte {}: `{}`",
+                parser.pos,
+                parser.remaining()
+            ),
+        });
+    }
+    Ok(expr)
+}
+
+/// Evaluate a parsed expression against per-channel global values.
+///
+/// Returns [`Q3232::ZERO`] for any channel id not present in
+/// `channel_values` — this matches the "dormant channels propagate zero"
+/// rule from §6.2. Addition and multiplication use [`Q3232`] saturating
+/// arithmetic, so overflow clamps to [`Q3232::MAX`] / [`Q3232::MIN`] rather
+/// than panicking or wrapping.
+///
+/// This function is pure: the output is entirely determined by
+/// `(expr, channel_values)`, satisfying the determinism invariant
+/// (INVARIANTS §1).
+#[must_use]
+pub fn eval_expression(expr: &Expr, channel_values: &BTreeMap<String, Q3232>) -> Q3232 {
+    match expr {
+        Expr::Literal(v) => *v,
+        Expr::ChannelRef(id) => channel_values.get(id).copied().unwrap_or(Q3232::ZERO),
+        Expr::Add(lhs, rhs) => eval_expression(lhs, channel_values)
+            .saturating_add(eval_expression(rhs, channel_values)),
+        Expr::Mul(lhs, rhs) => eval_expression(lhs, channel_values)
+            .saturating_mul(eval_expression(rhs, channel_values)),
+    }
+}
+
+/// Return every channel id referenced by `expr`, sorted and deduplicated.
+///
+/// Used by the emission path to compose a hook's
+/// [`beast_primitives::PrimitiveEffect::source_channels`] without having to
+/// re-walk the raw manifest source string.
+#[must_use]
+pub fn collect_channel_refs(expr: &Expr) -> Vec<String> {
+    let mut out = std::collections::BTreeSet::new();
+    fn walk(expr: &Expr, out: &mut std::collections::BTreeSet<String>) {
+        match expr {
+            Expr::Literal(_) => {}
+            Expr::ChannelRef(id) => {
+                out.insert(id.clone());
+            }
+            Expr::Add(l, r) | Expr::Mul(l, r) => {
+                walk(l, out);
+                walk(r, out);
+            }
+        }
+    }
+    walk(expr, &mut out);
+    out.into_iter().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Parser (recursive descent, byte-at-a-time over ASCII source).
+// ---------------------------------------------------------------------------
+
+struct Parser<'src, 'reg> {
+    src: &'src [u8],
+    pos: usize,
+    registry: &'reg ChannelRegistry,
+}
+
+impl<'src, 'reg> Parser<'src, 'reg> {
+    fn new(src: &'src str, registry: &'reg ChannelRegistry) -> Self {
+        Self {
+            src: src.as_bytes(),
+            pos: 0,
+            registry,
+        }
+    }
+
+    fn at_end(&self) -> bool {
+        self.pos >= self.src.len()
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.src.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn remaining(&self) -> String {
+        String::from_utf8_lossy(&self.src[self.pos..]).into_owned()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while let Some(b) = self.peek() {
+            if b.is_ascii_whitespace() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Consume `expected` if it matches the next bytes after whitespace;
+    /// return `true` on success, `false` otherwise (without advancing on
+    /// failure).
+    fn eat(&mut self, expected: u8) -> bool {
+        self.skip_whitespace();
+        if self.peek() == Some(expected) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Parse an `expr` (addition-level).
+    fn parse_expr(&mut self) -> Result<Expr> {
+        let mut lhs = self.parse_term()?;
+        loop {
+            self.skip_whitespace();
+            if self.peek() == Some(b'+') {
+                self.pos += 1;
+                let rhs = self.parse_term()?;
+                lhs = Expr::Add(Box::new(lhs), Box::new(rhs));
+            } else {
+                return Ok(lhs);
+            }
+        }
+    }
+
+    /// Parse a `term` (multiplication-level).
+    fn parse_term(&mut self) -> Result<Expr> {
+        let mut lhs = self.parse_factor()?;
+        loop {
+            self.skip_whitespace();
+            if self.peek() == Some(b'*') {
+                self.pos += 1;
+                let rhs = self.parse_factor()?;
+                lhs = Expr::Mul(Box::new(lhs), Box::new(rhs));
+            } else {
+                return Ok(lhs);
+            }
+        }
+    }
+
+    /// Parse a `factor` — literal, channel reference, or parenthesised `expr`.
+    fn parse_factor(&mut self) -> Result<Expr> {
+        self.skip_whitespace();
+        match self.peek() {
+            None => Err(InterpreterError::ParseError {
+                message: "unexpected end of input while parsing factor".into(),
+            }),
+            Some(b'(') => {
+                self.pos += 1;
+                let inner = self.parse_expr()?;
+                if !self.eat(b')') {
+                    return Err(InterpreterError::ParseError {
+                        message: format!(
+                            "expected `)` at byte {}, found `{}`",
+                            self.pos,
+                            self.remaining()
+                        ),
+                    });
+                }
+                Ok(inner)
+            }
+            Some(b) if b.is_ascii_digit() => self.parse_literal(),
+            Some(b'c') if self.src.get(self.pos..self.pos + 3) == Some(b"ch[") => {
+                self.parse_channel_ref()
+            }
+            Some(b) => Err(InterpreterError::ParseError {
+                message: format!(
+                    "unexpected character `{}` (0x{:02x}) at byte {}",
+                    b as char, b, self.pos
+                ),
+            }),
+        }
+    }
+
+    /// Parse a numeric literal with optional underscore digit separators and
+    /// an optional fractional part.
+    fn parse_literal(&mut self) -> Result<Expr> {
+        let start = self.pos;
+        // Integer part (required).
+        let mut saw_digit = false;
+        while let Some(b) = self.peek() {
+            if b.is_ascii_digit() {
+                saw_digit = true;
+                self.pos += 1;
+            } else if b == b'_' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if !saw_digit {
+            return Err(InterpreterError::ParseError {
+                message: format!("expected digit at byte {}", start),
+            });
+        }
+        // Optional fractional part.
+        if self.peek() == Some(b'.') {
+            self.pos += 1;
+            let mut frac_digit = false;
+            while let Some(b) = self.peek() {
+                if b.is_ascii_digit() {
+                    frac_digit = true;
+                    self.pos += 1;
+                } else if b == b'_' {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+            if !frac_digit {
+                return Err(InterpreterError::ParseError {
+                    message: format!("expected fractional digits after `.` at byte {}", self.pos),
+                });
+            }
+        }
+        let raw = &self.src[start..self.pos];
+        // Strip underscore separators before parsing. Both the integer and
+        // fractional parsers treat `_` as a separator only — `fixed`'s FromStr
+        // rejects underscores, so we strip here rather than depending on it.
+        let cleaned: String = raw
+            .iter()
+            .filter(|b| **b != b'_')
+            .map(|b| *b as char)
+            .collect();
+        let value = parse_q3232_literal(&cleaned).ok_or_else(|| InterpreterError::ParseError {
+            message: format!("invalid numeric literal `{}`", cleaned),
+        })?;
+        Ok(Expr::Literal(value))
+    }
+
+    /// Parse a channel reference `ch[<ident>]` and resolve the symbol via
+    /// the registry.
+    fn parse_channel_ref(&mut self) -> Result<Expr> {
+        // We already know the next three bytes are `ch[`.
+        self.pos += 3;
+        let ident_start = self.pos;
+        while let Some(b) = self.peek() {
+            let valid_first = ident_start == self.pos && (b.is_ascii_lowercase() || b == b'_');
+            let valid_rest = ident_start != self.pos
+                && (b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_');
+            if valid_first || valid_rest {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if ident_start == self.pos {
+            return Err(InterpreterError::ParseError {
+                message: format!("expected channel identifier at byte {}", self.pos),
+            });
+        }
+        let symbol = std::str::from_utf8(&self.src[ident_start..self.pos]).map_err(|_| {
+            InterpreterError::ParseError {
+                message: "channel identifier is not valid UTF-8".into(),
+            }
+        })?;
+        if self.bump() != Some(b']') {
+            return Err(InterpreterError::ParseError {
+                message: format!("expected `]` closing `ch[{}`", symbol),
+            });
+        }
+        if !self.registry.contains(symbol) {
+            return Err(InterpreterError::UnknownChannelSymbol {
+                symbol: symbol.to_owned(),
+            });
+        }
+        Ok(Expr::ChannelRef(symbol.to_owned()))
+    }
+}
+
+/// Parse a dot-decimal ASCII literal (already stripped of `_`) into a
+/// [`Q3232`]. Returns `None` when neither the integer nor the combined
+/// rational representation fit, or when the string is malformed for either
+/// path.
+fn parse_q3232_literal(cleaned: &str) -> Option<Q3232> {
+    if let Some(dot) = cleaned.find('.') {
+        let int_part = &cleaned[..dot];
+        let frac_part = &cleaned[dot + 1..];
+        if frac_part.is_empty() {
+            return None;
+        }
+        // Parse as (numerator / 10^frac_len) in Q32.32 arithmetic so we
+        // avoid floats. Both pieces must fit in `i64`.
+        let int_val: i64 = int_part.parse().ok()?;
+        let frac_val: i64 = frac_part.parse().ok()?;
+        let scale: i64 = 10_i64.checked_pow(u32::try_from(frac_part.len()).ok()?)?;
+        // int_val + frac_val / scale, in Q32.32.
+        let int_q = Q3232::from_num(int_val);
+        let frac_q = Q3232::from_num(frac_val).saturating_div(Q3232::from_num(scale));
+        Some(int_q.saturating_add(frac_q))
+    } else {
+        let int_val: i64 = cleaned.parse().ok()?;
+        Some(Q3232::from_num(int_val))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beast_channels::{
+        BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry, MutationKernel, Provenance,
+        Range, ScaleBand,
+    };
+    use proptest::prelude::*;
+
+    fn manifest(id: &str) -> ChannelManifest {
+        ChannelManifest {
+            id: id.into(),
+            family: ChannelFamily::Sensory,
+            description: "fixture".into(),
+            range: Range {
+                min: Q3232::ZERO,
+                max: Q3232::ONE,
+                units: "dimensionless".into(),
+            },
+            mutation_kernel: MutationKernel {
+                sigma: Q3232::from_num(0.1_f64),
+                bounds_policy: BoundsPolicy::Clamp,
+                genesis_weight: Q3232::ONE,
+                correlation_with: Vec::new(),
+            },
+            composition_hooks: Vec::new(),
+            expression_conditions: Vec::new(),
+            scale_band: ScaleBand {
+                min_kg: Q3232::ZERO,
+                max_kg: Q3232::from_num(1_000_i32),
+            },
+            body_site_applicable: false,
+            provenance: Provenance::Core,
+        }
+    }
+
+    fn registry_with(ids: &[&str]) -> ChannelRegistry {
+        let mut reg = ChannelRegistry::new();
+        for id in ids {
+            reg.register(manifest(id)).expect("unique fixture ids");
+        }
+        reg
+    }
+
+    fn channels(pairs: &[(&str, Q3232)]) -> BTreeMap<String, Q3232> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect()
+    }
+
+    // ------- parser happy paths --------------------------------------------
+
+    #[test]
+    fn parses_integer_literal() {
+        let reg = ChannelRegistry::new();
+        let expr = parse_expression("8", &reg).unwrap();
+        match expr {
+            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(8_i32)),
+            _ => panic!("expected Literal"),
+        }
+    }
+
+    #[test]
+    fn parses_fractional_literal() {
+        let reg = ChannelRegistry::new();
+        let expr = parse_expression("0.5", &reg).unwrap();
+        match expr {
+            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(0.5_f64)),
+            _ => panic!("expected Literal"),
+        }
+    }
+
+    #[test]
+    fn parses_underscore_separated_literal() {
+        let reg = ChannelRegistry::new();
+        let expr = parse_expression("1_000", &reg).unwrap();
+        match expr {
+            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(1_000_i32)),
+            _ => panic!("expected Literal"),
+        }
+    }
+
+    #[test]
+    fn parses_channel_reference_when_registered() {
+        let reg = registry_with(&["vocal_modulation"]);
+        let expr = parse_expression("ch[vocal_modulation]", &reg).unwrap();
+        match expr {
+            Expr::ChannelRef(id) => assert_eq!(id, "vocal_modulation"),
+            _ => panic!("expected ChannelRef"),
+        }
+    }
+
+    #[test]
+    fn parses_addition_left_associative() {
+        let reg = registry_with(&["a", "b", "c"]);
+        let expr = parse_expression("ch[a] + ch[b] + ch[c]", &reg).unwrap();
+        // Shape must be ((a + b) + c), not (a + (b + c)).
+        match expr {
+            Expr::Add(lhs, _rhs) => match *lhs {
+                Expr::Add(_, _) => {}
+                other => panic!("expected nested Add on lhs, got {other:?}"),
+            },
+            other => panic!("expected Add, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multiplication_binds_tighter_than_addition() {
+        let reg = registry_with(&["a", "b"]);
+        // a + b * 2 must parse as Add(a, Mul(b, 2)).
+        let expr = parse_expression("ch[a] + ch[b] * 2", &reg).unwrap();
+        match expr {
+            Expr::Add(_, rhs) => match *rhs {
+                Expr::Mul(_, _) => {}
+                other => panic!("expected Mul on rhs of Add, got {other:?}"),
+            },
+            other => panic!("expected Add, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parentheses_override_precedence() {
+        let reg = registry_with(&["a", "b"]);
+        let expr = parse_expression("(ch[a] + ch[b]) * 2", &reg).unwrap();
+        match expr {
+            Expr::Mul(lhs, _) => match *lhs {
+                Expr::Add(_, _) => {}
+                other => panic!("expected Add inside parens, got {other:?}"),
+            },
+            other => panic!("expected Mul, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_whitespace_everywhere() {
+        let reg = registry_with(&["a"]);
+        let expr = parse_expression("  ch[a]   *   8  +  0  ", &reg).unwrap();
+        // Structure: Add(Mul(ChannelRef, 8), 0)
+        match expr {
+            Expr::Add(lhs, _) => match *lhs {
+                Expr::Mul(_, _) => {}
+                other => panic!("unexpected shape: {other:?}"),
+            },
+            other => panic!("unexpected shape: {other:?}"),
+        }
+    }
+
+    // ------- parser error paths --------------------------------------------
+
+    #[test]
+    fn unknown_channel_symbol_errors() {
+        let reg = ChannelRegistry::new();
+        let err = parse_expression("ch[mystery]", &reg).unwrap_err();
+        match err {
+            InterpreterError::UnknownChannelSymbol { symbol } => assert_eq!(symbol, "mystery"),
+            other => panic!("expected UnknownChannelSymbol, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_garbage_is_a_parse_error() {
+        let reg = ChannelRegistry::new();
+        assert!(matches!(
+            parse_expression("8 xyz", &reg),
+            Err(InterpreterError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn unbalanced_parenthesis_is_a_parse_error() {
+        let reg = ChannelRegistry::new();
+        assert!(matches!(
+            parse_expression("(8 + 1", &reg),
+            Err(InterpreterError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_input_is_a_parse_error() {
+        let reg = ChannelRegistry::new();
+        assert!(matches!(
+            parse_expression("   ", &reg),
+            Err(InterpreterError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn ch_without_brackets_is_an_error() {
+        let reg = ChannelRegistry::new();
+        assert!(matches!(
+            parse_expression("ch foo", &reg),
+            Err(InterpreterError::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_closing_bracket_is_an_error() {
+        let reg = registry_with(&["a"]);
+        assert!(matches!(
+            parse_expression("ch[a", &reg),
+            Err(InterpreterError::ParseError { .. })
+        ));
+    }
+
+    // ------- evaluator -----------------------------------------------------
+
+    #[test]
+    fn evaluates_literal() {
+        let vals = BTreeMap::new();
+        let out = eval_expression(&Expr::Literal(Q3232::from_num(3_i32)), &vals);
+        assert_eq!(out, Q3232::from_num(3_i32));
+    }
+
+    #[test]
+    fn evaluates_channel_ref_present() {
+        let vals = channels(&[("a", Q3232::from_num(5_i32))]);
+        let out = eval_expression(&Expr::ChannelRef("a".into()), &vals);
+        assert_eq!(out, Q3232::from_num(5_i32));
+    }
+
+    #[test]
+    fn evaluates_channel_ref_missing_as_zero() {
+        let vals = BTreeMap::new();
+        let out = eval_expression(&Expr::ChannelRef("missing".into()), &vals);
+        assert_eq!(out, Q3232::ZERO);
+    }
+
+    #[test]
+    fn roundtrip_parse_then_evaluate() {
+        let reg = registry_with(&["a", "b"]);
+        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
+        let vals = channels(&[
+            ("a", Q3232::from_num(0.5_f64)),
+            ("b", Q3232::from_num(2_i32)),
+        ]);
+        // 0.5 * 8 + 2 = 6
+        let out = eval_expression(&expr, &vals);
+        assert_eq!(out, Q3232::from_num(6_i32));
+    }
+
+    #[test]
+    fn roundtrip_same_input_yields_same_output_twice() {
+        let reg = registry_with(&["a", "b"]);
+        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
+        let vals = channels(&[
+            ("a", Q3232::from_num(0.25_f64)),
+            ("b", Q3232::from_num(1_i32)),
+        ]);
+        let first = eval_expression(&expr, &vals);
+        let second = eval_expression(&expr, &vals);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn saturating_addition_clamps() {
+        let vals = BTreeMap::new();
+        let expr = Expr::Add(
+            Box::new(Expr::Literal(Q3232::MAX)),
+            Box::new(Expr::Literal(Q3232::ONE)),
+        );
+        assert_eq!(eval_expression(&expr, &vals), Q3232::MAX);
+    }
+
+    #[test]
+    fn collect_channel_refs_returns_sorted_unique_ids() {
+        let reg = registry_with(&["alpha", "beta"]);
+        let expr = parse_expression("ch[beta] + ch[alpha] * 2 + ch[beta]", &reg).unwrap();
+        let refs = collect_channel_refs(&expr);
+        assert_eq!(refs, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    // ------- proptest: evaluator purity -----------------------------------
+
+    /// Sample a small, balanced `Expr` AST. We intentionally keep the channel
+    /// alphabet small so the "missing channel → zero" path is exercised.
+    fn arb_expr() -> impl Strategy<Value = Expr> {
+        let leaf = prop_oneof![
+            (-100_000_i64..=100_000_i64).prop_map(|n| Expr::Literal(Q3232::from_num(n))),
+            prop::sample::select(vec!["a", "b", "c", "d", "missing"])
+                .prop_map(|s| Expr::ChannelRef(s.to_string())),
+        ];
+        leaf.prop_recursive(4, 16, 2, |inner| {
+            prop_oneof![
+                (inner.clone(), inner.clone())
+                    .prop_map(|(l, r)| Expr::Add(Box::new(l), Box::new(r))),
+                (inner.clone(), inner).prop_map(|(l, r)| Expr::Mul(Box::new(l), Box::new(r))),
+            ]
+        })
+    }
+
+    proptest! {
+        /// `eval_expression` is a pure function of `(expr, channel_values)`:
+        /// calling it twice on the same inputs always yields the same output.
+        /// Required by INVARIANTS §1 (determinism).
+        #[test]
+        fn eval_is_pure_and_deterministic(
+            expr in arb_expr(),
+            bits_a in any::<i64>(),
+            bits_b in any::<i64>(),
+            bits_c in any::<i64>(),
+            bits_d in any::<i64>(),
+        ) {
+            let vals = channels(&[
+                ("a", Q3232::from_bits(bits_a)),
+                ("b", Q3232::from_bits(bits_b)),
+                ("c", Q3232::from_bits(bits_c)),
+                ("d", Q3232::from_bits(bits_d)),
+            ]);
+            let first = eval_expression(&expr, &vals);
+            let second = eval_expression(&expr, &vals);
+            prop_assert_eq!(first, second);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Stage 2 parameter-expression parsing and `PrimitiveEffect` emission per `documentation/systems/11_phenotype_interpreter.md` §6.2 and §6.2B.

- **`parameter_map.rs`** — recursive-descent parser + evaluator for the minimal operator set (per sprint plan Q3): `ch[<symbol>]`, Q32.32 literal, `+`, `*`, parentheses. Channel symbols resolved to ids at parse time (Q4); unknown symbols fail at load with `UnknownChannelSymbol`. Missing channels at eval time propagate `Q3232::ZERO` (§6.2 "dormant channels propagate zero").
- **`emission.rs`** — `emit_primitives(fired_hooks, phenotype, registry, emitter) -> Result<Vec<PrimitiveEffect>>`. For each fired hook × `EmitSpec`, evaluates the parameter expressions, looks up the primitive manifest, computes cost via `beast_primitives::evaluate_cost`, and produces a `PrimitiveEffect`. Dedups by `primitive_id` and merges per-parameter (max default, sum on the activation-cost sentinel). Output sorted by `primitive_id`.

Extended ops (`sqrt`, ranges, clamp, `-`, `/`) tracked in **#61**.

## Design decisions flagged for follow-up

Three worth tracker issues (I'll open them after merge):

1. **`_activation_cost` sentinel parameter**. `PrimitiveEffect` has no dedicated cost field, so the computed cost rides in `parameters` under the key `_activation_cost` with a `sum` merge strategy. Right place to fix this is #67 (the body-site schema extension is already touching `PrimitiveEffect`).
2. **Hard-coded default merge strategy = `max`**. `PrimitiveManifest` doesn't yet carry a typed `merge_strategy` field; the spec calls for one (§6.2B lines 802–868). Default `max` matches the doc's implicit default.
3. **`FiredHook.channel_ids` is a superset**. Currently `source_channels` on the emitted effect is reconstructed from parameter-expression channel refs only; gate-only hook channels (referenced by thresholds but not parameters) don't appear. Extending `FiredHook` would fix this.

## Tests (37 new / 69 total workspace-wide)

**parameter_map.rs** (22 unit + 1 proptest): integer / fractional / `_`-separated literals; channel ref with registry check; `*` > `+` precedence; parentheses; whitespace tolerance; unknown-channel / trailing garbage / unbalanced paren / empty / malformed `ch[` all error; literal / channel-ref / missing-channel → zero eval; round-trip parse→eval; same-input-twice determinism; saturating add; `collect_channel_refs` sort+dedup; proptest `eval_is_pure_and_deterministic`.

**emission.rs** (8 unit): effect construction; `UnknownPrimitive` error; cost scales with parameter (epsilon-tolerant due to `q_pow` via `exp`/`ln`); two-hook merge (max + cost sum); sorted-by-primitive-id output; `source_channels` sorted+deduped; dormant channel → zero without error; empty input → empty output; full-pipeline determinism.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p beast-interpreter --all-targets` — 69/69 pass
- [x] `cargo test -p beast-interpreter --doc` — 2/2 pass

Closes #58 · Follow-ups: #67 (PrimitiveEffect shape), deferred ops #61 · Epic: #16