### PR TITLE
chore: gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Cargo.lock.bak
 
 # Claude Code local state (per-machine)
 .claude/*.local.json
+.claude/worktrees
 
 # IDE
 .idea/


### PR DESCRIPTION
Adds `.claude/worktrees` to `.gitignore` so agent subagent worktrees never appear as untracked state in the main tree between cleanup cycles. One-line change; no functional impact.