### PR TITLE
feat(beast-interpreter): S4.6 wire interpret_phenotype + determinism tests

### DIFF
--- a/crates/beast-interpreter/src/emission.rs
+++ b/crates/beast-interpreter/src/emission.rs
@@ -87,6 +87,7 @@ pub const ACTIVATION_COST_PARAM: &str = "_activation_cost";
 ///   into [`InterpreterError::ParseError`] (chosen over adding a new enum
 ///   variant; the cost evaluator's own errors contain the detail in the
 ///   message).
+#[must_use = "emitted primitive effects must feed the next stage — dropping silences this tick's emission"]
 pub fn emit_primitives(
     fired_hooks: &[FiredHook],
     phenotype: &ResolvedPhenotype,

--- a/crates/beast-interpreter/src/interpreter.rs
+++ b/crates/beast-interpreter/src/interpreter.rs
@@ -1,17 +1,127 @@
 //! Top-level entry point [`interpret_phenotype`].
 //!
-//! Sequencing through the six stages in §6 of the design doc:
+//! Sequences the four pipeline stages from
+//! `documentation/systems/11_phenotype_interpreter.md` §6 into a single pure,
+//! deterministic function:
 //!
-//! 1. Scale-band filter ([`crate::scale_band`])
-//! 2. Affordance filter ([`crate::expression`])
-//! 3. Composition hook resolve ([`crate::composition`])
-//! 4. Primitive emission + dedup/merge ([`crate::emission`])
-//! 5. Body-region tiling ([`crate::body_map`])
+//! 1. Scale-band filter     ([`crate::scale_band::apply_scale_band_filter`])
+//! 2. Affordance filter     ([`crate::expression::filter_hooks_by_affordances`])
+//! 3. Composition resolve   ([`crate::composition::resolve_hooks`])
+//! 4. Primitive emission    ([`crate::emission::emit_primitives`])
 //!
-//! Behaviour compilation (stage 3 in the doc) lives downstream and is not part
-//! of S4.
+//! Behaviour compilation (stage 3 in the doc) and body-site primitive fanout
+//! (§6.0B, tracked in issue #67) are deliberately out of scope for S4.
 //!
-//! Wired up incrementally as each story in epic #16 lands; the current stub
-//! exists so downstream crates can reference the entry-point signature.
+//! # Determinism
+//!
+//! This function is pure: `(phenotype, hooks, channel_registry,
+//! primitive_registry, emitter)` uniquely determines the returned
+//! `Vec<PrimitiveEffect>`. No RNG, no wall-clock reads, no `HashMap` /
+//! `HashSet` iteration, and every arithmetic path goes through
+//! [`beast_core::Q3232`]. See INVARIANTS §1.
+//!
+//! The input `phenotype` is **not** mutated — the scale-band stage operates on
+//! an internal clone so callers can reuse the same phenotype across repeated
+//! invocations without observing side effects.
 
-// Implementation — wired up as stories 4.1–4.6 complete.
+use beast_channels::ChannelRegistry;
+use beast_core::EntityId;
+use beast_primitives::{PrimitiveEffect, PrimitiveRegistry};
+
+use crate::composition::{resolve_hooks, InterpreterHook};
+use crate::emission::emit_primitives;
+use crate::expression::filter_hooks_by_affordances;
+use crate::phenotype::ResolvedPhenotype;
+use crate::scale_band::apply_scale_band_filter;
+use crate::Result;
+
+/// Run the full interpreter pipeline and return the primitive-effect set.
+///
+/// # Stages
+///
+/// 1. **Scale-band filter** — zero out channel values that fall outside their
+///    manifest's `scale_band` for the creature's body mass
+///    ([`crate::scale_band::apply_scale_band_filter`]). Applied to a clone of
+///    `phenotype` so the caller's copy is left untouched.
+/// 2. **Affordance filter** — drop hooks whose environmental
+///    `expression_conditions` fail
+///    ([`crate::expression::filter_hooks_by_affordances`]). The filter returns
+///    the surviving hook ids sorted ascending; those ids are then materialised
+///    back into a filtered `Vec<InterpreterHook>` preserving that order.
+/// 3. **Composition resolve** — decide which surviving hooks fire against the
+///    scale-band-filtered phenotype and produce `FiredHook`s
+///    ([`crate::composition::resolve_hooks`]).
+/// 4. **Primitive emission** — evaluate each emit spec's parameter
+///    expressions, compute costs, merge duplicates by `primitive_id`
+///    ([`crate::emission::emit_primitives`]). The returned vector is sorted by
+///    `primitive_id`.
+///
+/// # Arguments
+///
+/// * `phenotype` — materialised creature state (per-channel globals,
+///   per-region amplitudes, life stage, mass, environment).
+/// * `hooks` — per-tick `InterpreterHook` slice; typically loaded once at
+///   world init and shared across creatures. This function does not mutate
+///   or retain a reference to the slice.
+/// * `channel_registry` — authoritative channel registry (core + mods +
+///   genesis). Used by stage 1 to look up scale bands.
+/// * `primitive_registry` — authoritative primitive registry. Used by stage
+///   4 to look up primitive manifests for cost evaluation.
+/// * `emitter` — the [`EntityId`] attributed to every emitted
+///   [`PrimitiveEffect`].
+///
+/// # Errors
+///
+/// Returns the first error from [`emit_primitives`] — in practice
+/// [`crate::InterpreterError::UnknownPrimitive`] if any `EmitSpec`
+/// references a primitive not in `primitive_registry`, or
+/// [`crate::InterpreterError::ParseError`] propagated from cost evaluation.
+/// Stages 1-3 never fail; malformed hooks and missing channels are handled
+/// by dropping the offending hook (dormant-channel / lazy-genesis semantics,
+/// §6.2).
+///
+/// # Determinism
+///
+/// Pure function: identical inputs produce bit-identical outputs on every
+/// call, across runs, and across platforms — a precondition for the
+/// 1000-tick replay gate (INVARIANTS §1). Covered by integration tests in
+/// `tests/determinism.rs`.
+pub fn interpret_phenotype(
+    phenotype: &ResolvedPhenotype,
+    hooks: &[InterpreterHook],
+    channel_registry: &ChannelRegistry,
+    primitive_registry: &PrimitiveRegistry,
+    emitter: EntityId,
+) -> Result<Vec<PrimitiveEffect>> {
+    // Stage 1 — scale-band filter. Operate on a clone so the caller's
+    // phenotype is untouched; the filter mutates `global_channels` and, for
+    // `body_site_applicable` channels, `body_map` amplitudes.
+    let mut filtered_phenotype = phenotype.clone();
+    apply_scale_band_filter(&mut filtered_phenotype, channel_registry);
+
+    // Stage 2 — affordance filter. Returns the sorted subset of HookIds
+    // whose environmental conditions all hold.
+    let active_ids = filter_hooks_by_affordances(
+        &filtered_phenotype.environment,
+        filtered_phenotype.life_stage,
+        filtered_phenotype.body_mass_kg,
+        hooks,
+    );
+
+    // Materialise the active hooks in id-sorted order (the order the
+    // affordance filter returned). `active_ids` is typically small, so a
+    // linear scan per id is fine; a BTreeMap index would add allocation for
+    // no speed-up at interpreter-scale hook counts.
+    let active_hooks: Vec<InterpreterHook> = active_ids
+        .iter()
+        .filter_map(|id| hooks.iter().find(|h| h.id == *id).cloned())
+        .collect();
+
+    // Stage 3 — composition resolve. Produces one `FiredHook` per hook that
+    // fires; input order (== id-sorted from stage 2) is preserved.
+    let fired = resolve_hooks(&filtered_phenotype, &active_hooks);
+
+    // Stage 4 — primitive emission. Evaluates parameter expressions, merges
+    // duplicates by primitive_id, returns a vector sorted by primitive_id.
+    emit_primitives(&fired, &filtered_phenotype, primitive_registry, emitter)
+}

--- a/crates/beast-interpreter/src/interpreter.rs
+++ b/crates/beast-interpreter/src/interpreter.rs
@@ -86,6 +86,7 @@ use crate::Result;
 /// call, across runs, and across platforms — a precondition for the
 /// 1000-tick replay gate (INVARIANTS §1). Covered by integration tests in
 /// `tests/determinism.rs`.
+#[must_use = "primitive effects must be consumed — dropping silences the whole tick"]
 pub fn interpret_phenotype(
     phenotype: &ResolvedPhenotype,
     hooks: &[InterpreterHook],

--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -58,6 +58,7 @@ pub use composition::{
 pub use emission::{emit_primitives, ACTIVATION_COST_PARAM};
 pub use error::{InterpreterError, Result};
 pub use expression::filter_hooks_by_affordances;
+pub use interpreter::interpret_phenotype;
 pub use parameter_map::{collect_channel_refs, eval_expression, parse_expression, Expr};
 pub use phenotype::{BodyRegion, BodySite, Environment, LifeStage, ResolvedPhenotype};
 pub use scale_band::apply_scale_band_filter;

--- a/crates/beast-interpreter/tests/common/mod.rs
+++ b/crates/beast-interpreter/tests/common/mod.rs
@@ -1,0 +1,424 @@
+//! Shared fixture builders for the interpreter's integration tests.
+//!
+//! Rust treats each file under `tests/` as a separate integration-test binary,
+//! so this module is included via `mod common;` in every test file that needs
+//! the fixtures. All helpers are deterministic: no RNG, no wall-clock, no
+//! filesystem reads.
+//!
+//! The helpers build lightweight channel and primitive registries with
+//! schema-valid JSON manifests (we reuse
+//! [`beast_primitives::PrimitiveManifest::from_json_str`]), plus a handful of
+//! composed `InterpreterHook`s covering Additive, Threshold, Multiplicative,
+//! Antagonistic, and Gating kinds.
+
+#![allow(dead_code)] // not every test file uses every helper
+
+use std::collections::BTreeMap;
+
+use beast_channels::{
+    BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry, ExpressionCondition,
+    MutationKernel, Provenance as ChannelProvenance, Range, ScaleBand,
+};
+use beast_core::{TickCounter, Q3232};
+use beast_interpreter::{
+    composition::{CompositionKind, EmitSpec, HookId, InterpreterHook},
+    parameter_map::{parse_expression, Expr},
+    phenotype::{BodyRegion, BodySite, Environment, LifeStage, ResolvedPhenotype},
+};
+use beast_primitives::{PrimitiveManifest, PrimitiveRegistry};
+
+pub fn q(v: f64) -> Q3232 {
+    Q3232::from_num(v)
+}
+
+/// Build a bare-bones channel manifest with caller-controlled scale band and
+/// body-site flag. All other fields take benign defaults — the interpreter
+/// only reads `id`, `scale_band`, and `body_site_applicable` from channel
+/// manifests (composition rules live on the `InterpreterHook`s).
+pub fn channel_manifest(
+    id: &str,
+    min_kg: f64,
+    max_kg: f64,
+    body_site_applicable: bool,
+) -> ChannelManifest {
+    ChannelManifest {
+        id: id.into(),
+        family: ChannelFamily::Sensory,
+        description: "integration-test fixture".into(),
+        range: Range {
+            min: Q3232::ZERO,
+            max: Q3232::ONE,
+            units: "dimensionless".into(),
+        },
+        mutation_kernel: MutationKernel {
+            sigma: q(0.1),
+            bounds_policy: BoundsPolicy::Clamp,
+            genesis_weight: Q3232::ONE,
+            correlation_with: Vec::new(),
+        },
+        composition_hooks: Vec::new(),
+        expression_conditions: Vec::new(),
+        scale_band: ScaleBand {
+            min_kg: q(min_kg),
+            max_kg: q(max_kg),
+        },
+        body_site_applicable,
+        provenance: ChannelProvenance::Core,
+    }
+}
+
+/// Build a channel registry from `(id, min_kg, max_kg, body_site_applicable)`
+/// tuples.
+pub fn build_channel_registry(specs: &[(&str, f64, f64, bool)]) -> ChannelRegistry {
+    let mut reg = ChannelRegistry::new();
+    for (id, min_kg, max_kg, body_site) in specs {
+        reg.register(channel_manifest(id, *min_kg, *max_kg, *body_site))
+            .expect("fixture ids are unique");
+    }
+    reg
+}
+
+/// Build a primitive manifest with one default parameter and a simple
+/// `{base 1.0 + coefficient * param^1}` cost function. The `force` variant
+/// scales with the `force` parameter; the plain variant has no scaling term.
+pub fn primitive_manifest_json(id: &str, param_name: &str, with_force_cost: bool) -> String {
+    let cost_scaling = if with_force_cost {
+        format!(r#"[{{ "parameter": "{param_name}", "exponent": 1.0, "coefficient": 0.5 }}]"#)
+    } else {
+        "[]".into()
+    };
+    format!(
+        r#"{{
+            "id": "{id}",
+            "category": "force_application",
+            "description": "integration-test fixture",
+            "parameter_schema": {{ "{param_name}": {{ "type": "number", "default": 0 }} }},
+            "composition_compatibility": [{{ "channel_family": "sensory" }}],
+            "cost_function": {{
+                "base_metabolic_cost": 1.0,
+                "parameter_scaling": {cost_scaling}
+            }},
+            "observable_signature": {{
+                "modality": "mechanical",
+                "detection_range_m": 1,
+                "pattern_key": "fixture_v1"
+            }},
+            "provenance": "core"
+        }}"#
+    )
+}
+
+/// Parse a manifest string into a `PrimitiveManifest`. Panics on parse error
+/// (fixture authors control the source, so failures here are bugs in the
+/// fixture).
+pub fn parse_primitive_manifest(json: &str) -> PrimitiveManifest {
+    PrimitiveManifest::from_json_str(json).expect("fixture primitive manifest must parse")
+}
+
+/// Build a primitive registry from `(id, param_name, with_force_cost)`
+/// tuples.
+pub fn build_primitive_registry(specs: &[(&str, &str, bool)]) -> PrimitiveRegistry {
+    let mut reg = PrimitiveRegistry::new();
+    for (id, param, with_cost) in specs {
+        let json = primitive_manifest_json(id, param, *with_cost);
+        reg.register(parse_primitive_manifest(&json))
+            .expect("fixture primitive ids are unique");
+    }
+    reg
+}
+
+/// Parse a parameter expression; panics on error (fixture failures are bugs).
+pub fn expr(src: &str, registry: &ChannelRegistry) -> Expr {
+    parse_expression(src, registry).expect("fixture expression must parse")
+}
+
+/// Build a single interpreter hook covering the common case (additive,
+/// no thresholds, no conditions). Callers that need threshold or gating
+/// behaviour build hooks by hand using the [`InterpreterHook`] struct
+/// directly.
+pub fn additive_hook(
+    id: u32,
+    channel_ids: &[&str],
+    emit_primitive_id: &str,
+    params: Vec<(&str, Expr)>,
+) -> InterpreterHook {
+    InterpreterHook {
+        id: HookId(id),
+        kind: CompositionKind::Additive,
+        channel_ids: channel_ids.iter().map(|s| (*s).to_string()).collect(),
+        thresholds: Vec::new(),
+        coefficient: Q3232::ONE,
+        expression_conditions: Vec::new(),
+        emits: vec![EmitSpec {
+            primitive_id: emit_primitive_id.into(),
+            parameter_mapping: params
+                .into_iter()
+                .map(|(n, e)| (n.to_string(), e))
+                .collect(),
+        }],
+    }
+}
+
+/// Build a threshold hook: fires only when every channel value meets its
+/// parallel threshold entry.
+pub fn threshold_hook(
+    id: u32,
+    channel_ids: &[&str],
+    thresholds: &[Q3232],
+    emit_primitive_id: &str,
+    params: Vec<(&str, Expr)>,
+) -> InterpreterHook {
+    InterpreterHook {
+        id: HookId(id),
+        kind: CompositionKind::Threshold,
+        channel_ids: channel_ids.iter().map(|s| (*s).to_string()).collect(),
+        thresholds: thresholds.to_vec(),
+        coefficient: Q3232::ONE,
+        expression_conditions: Vec::new(),
+        emits: vec![EmitSpec {
+            primitive_id: emit_primitive_id.into(),
+            parameter_mapping: params
+                .into_iter()
+                .map(|(n, e)| (n.to_string(), e))
+                .collect(),
+        }],
+    }
+}
+
+/// Build a resolved phenotype for the fixture world.
+pub fn phenotype(
+    body_mass_kg: f64,
+    life_stage: LifeStage,
+    globals: &[(&str, f64)],
+    env: Environment,
+) -> ResolvedPhenotype {
+    let mut p = ResolvedPhenotype {
+        global_channels: BTreeMap::new(),
+        body_map: Vec::new(),
+        body_mass_kg: q(body_mass_kg),
+        life_stage,
+        expression_tick: TickCounter::default(),
+        environment: env,
+    };
+    for (id, v) in globals {
+        p.global_channels.insert((*id).to_string(), q(*v));
+    }
+    p
+}
+
+/// Q3232-valued variant of [`phenotype`]. Preferred by callers that need to
+/// stay clear of `float_arithmetic` — channel values are assembled from
+/// integer base + increment via `Q3232::saturating_add`.
+pub fn phenotype_q(
+    body_mass: Q3232,
+    life_stage: LifeStage,
+    globals: &[(&str, Q3232)],
+    env: Environment,
+) -> ResolvedPhenotype {
+    let mut p = ResolvedPhenotype {
+        global_channels: BTreeMap::new(),
+        body_map: Vec::new(),
+        body_mass_kg: body_mass,
+        life_stage,
+        expression_tick: TickCounter::default(),
+        environment: env,
+    };
+    for (id, v) in globals {
+        p.global_channels.insert((*id).to_string(), *v);
+    }
+    p
+}
+
+/// Attach a region to a phenotype with the given per-channel amplitudes.
+/// Returns a modified copy — keeps usage immutable-by-default.
+pub fn with_region(
+    mut phenotype: ResolvedPhenotype,
+    region_id: u32,
+    site: BodySite,
+    amps: &[(&str, f64)],
+) -> ResolvedPhenotype {
+    let mut channel_amplitudes = BTreeMap::new();
+    for (ch, v) in amps {
+        channel_amplitudes.insert((*ch).to_string(), q(*v));
+    }
+    phenotype.body_map.push(BodyRegion {
+        id: region_id,
+        body_site: site,
+        surface_vs_internal: q(0.5),
+        channel_amplitudes,
+    });
+    phenotype
+}
+
+/// Builds the "standard" fixture world used by determinism and proptest:
+///
+/// * 5 channels named `alpha`..`epsilon`, all universal-scale (0..1e9 kg)
+/// * 4 primitives `p0`..`p3` (first three plain, `p3` cost-scaling on its param)
+/// * 6 hooks mixing Additive, Threshold, Multiplicative, Antagonistic, and
+///   Gating kinds.
+///
+/// All ids are ASCII lowercase and sort lexicographically.
+pub struct FixtureWorld {
+    pub channel_registry: ChannelRegistry,
+    pub primitive_registry: PrimitiveRegistry,
+    pub hooks: Vec<InterpreterHook>,
+}
+
+pub fn standard_world() -> FixtureWorld {
+    let channel_registry = build_channel_registry(&[
+        ("alpha", 0.0, 1e9, false),
+        ("beta", 0.0, 1e9, false),
+        ("gamma", 0.0, 1e9, false),
+        ("delta", 0.0, 1e9, false),
+        ("epsilon", 0.0, 1e9, false),
+    ]);
+    let primitive_registry = build_primitive_registry(&[
+        ("p0_pulse", "intensity", false),
+        ("p1_strike", "force", true),
+        ("p2_signal", "magnitude", false),
+        ("p3_calm", "level", false),
+    ]);
+
+    let e_alpha = expr("ch[alpha]", &channel_registry);
+    let e_alpha_times_two = expr("ch[alpha] * 2", &channel_registry);
+    let e_alpha_plus_beta = expr("ch[alpha] + ch[beta]", &channel_registry);
+    let e_gamma = expr("ch[gamma]", &channel_registry);
+    let e_delta = expr("ch[delta]", &channel_registry);
+    let e_epsilon_plus_one = expr("ch[epsilon] + 1", &channel_registry);
+
+    let hooks = vec![
+        additive_hook(
+            1,
+            &["alpha"],
+            "p0_pulse",
+            vec![("intensity", e_alpha.clone())],
+        ),
+        additive_hook(
+            2,
+            &["alpha", "beta"],
+            "p2_signal",
+            vec![("magnitude", e_alpha_plus_beta)],
+        ),
+        threshold_hook(
+            3,
+            &["gamma"],
+            &[q(0.25)],
+            "p1_strike",
+            vec![("force", e_gamma)],
+        ),
+        InterpreterHook {
+            id: HookId(4),
+            kind: CompositionKind::Multiplicative,
+            channel_ids: vec!["alpha".into()],
+            thresholds: Vec::new(),
+            coefficient: q(0.5),
+            expression_conditions: Vec::new(),
+            emits: vec![EmitSpec {
+                primitive_id: "p0_pulse".into(),
+                parameter_mapping: vec![("intensity".into(), e_alpha_times_two)],
+            }],
+        },
+        InterpreterHook {
+            id: HookId(5),
+            kind: CompositionKind::Antagonistic,
+            channel_ids: vec!["delta".into(), "epsilon".into()],
+            thresholds: Vec::new(),
+            coefficient: q(0.1),
+            expression_conditions: Vec::new(),
+            emits: vec![EmitSpec {
+                primitive_id: "p3_calm".into(),
+                parameter_mapping: vec![("level".into(), e_delta)],
+            }],
+        },
+        InterpreterHook {
+            id: HookId(6),
+            kind: CompositionKind::Gating,
+            channel_ids: vec!["epsilon".into()],
+            thresholds: vec![q(0.1)],
+            coefficient: Q3232::ONE,
+            expression_conditions: vec![ExpressionCondition::DevelopmentalStage {
+                stage: "adult".into(),
+            }],
+            emits: vec![EmitSpec {
+                primitive_id: "p2_signal".into(),
+                parameter_mapping: vec![("magnitude".into(), e_epsilon_plus_one)],
+            }],
+        },
+    ];
+
+    FixtureWorld {
+        channel_registry,
+        primitive_registry,
+        hooks,
+    }
+}
+
+/// Build 20 phenotypes used by the 1000-run determinism test. Values are
+/// assembled entirely via `Q3232` saturating arithmetic (no `f64` math) so
+/// the fixture stays inside the determinism invariant (INVARIANTS §1) and
+/// does not trip `clippy::float_arithmetic`.
+///
+/// Values are chosen to exercise all firing paths:
+/// * some phenotypes have every channel above the threshold hook's 0.25 gate
+/// * some have gamma below 0.25 so the threshold hook drops
+/// * some have delta == epsilon so the antagonistic hook drops
+/// * some have juvenile life-stage so the gating hook drops
+pub fn standard_phenotypes() -> Vec<ResolvedPhenotype> {
+    let base_envs = [
+        Environment::default(),
+        Environment {
+            biome_flags: vec!["forest".into()],
+            season: Some("spring".into()),
+            ..Environment::default()
+        },
+        Environment {
+            biome_flags: vec!["aquatic".into()],
+            season: Some("summer".into()),
+            population_density_per_km2: Some(q(50.0)),
+            ..Environment::default()
+        },
+    ];
+    let stages = [LifeStage::Juvenile, LifeStage::Adult, LifeStage::Elderly];
+
+    // Step constants — each evaluated once via `Q3232::from_num` on a literal,
+    // then combined via saturating arithmetic inside the loop.
+    let alpha_base = q(0.1);
+    let alpha_step = q(0.05);
+    let beta_base = q(0.2);
+    let beta_step = q(0.1);
+    let gamma_hi = q(0.4);
+    let gamma_lo = q(0.1);
+    let delta_base = q(0.2);
+    let delta_step = q(0.08);
+    let epsilon_base = q(0.3);
+    let epsilon_step = q(0.05);
+    let mass_base = Q3232::ONE;
+    let mass_step = q(10.0);
+
+    let mut out = Vec::with_capacity(20);
+    for i in 0..20u32 {
+        let alpha = alpha_base.saturating_add(alpha_step.saturating_mul(Q3232::from_num(i)));
+        let beta = beta_base.saturating_add(beta_step.saturating_mul(Q3232::from_num(i % 5)));
+        let gamma = if i % 3 == 0 { gamma_hi } else { gamma_lo };
+        let delta = delta_base.saturating_add(delta_step.saturating_mul(Q3232::from_num(i % 7)));
+        let epsilon =
+            epsilon_base.saturating_add(epsilon_step.saturating_mul(Q3232::from_num(i % 11)));
+        let mass = mass_base.saturating_add(mass_step.saturating_mul(Q3232::from_num(i)));
+        let env = base_envs[(i as usize) % base_envs.len()].clone();
+        let stage = stages[(i as usize) % stages.len()];
+        let p = phenotype_q(
+            mass,
+            stage,
+            &[
+                ("alpha", alpha),
+                ("beta", beta),
+                ("gamma", gamma),
+                ("delta", delta),
+                ("epsilon", epsilon),
+            ],
+            env,
+        );
+        out.push(p);
+    }
+    out
+}

--- a/crates/beast-interpreter/tests/composition_thresholds.rs
+++ b/crates/beast-interpreter/tests/composition_thresholds.rs
@@ -1,0 +1,215 @@
+//! Composition-threshold acceptance fixtures (S4.6 — issue #60).
+//!
+//! Exercises the §6.2 threshold rule end-to-end through
+//! [`beast_interpreter::interpret_phenotype`]:
+//!
+//! * A 3-channel threshold hook fires **only when all three operands meet
+//!   their thresholds**.
+//! * A dormant operand (`Q3232::ZERO`) auto-fails the gate even when the
+//!   threshold itself is also zero — the per-channel "zero operand ⇒
+//!   threshold fails" rule cascades through the full pipeline.
+
+mod common;
+
+use beast_core::{EntityId, Q3232};
+use beast_interpreter::{
+    composition::{CompositionKind, EmitSpec, HookId, InterpreterHook},
+    interpret_phenotype,
+};
+
+use crate::common::{build_channel_registry, build_primitive_registry, expr, phenotype};
+use beast_interpreter::phenotype::{Environment, LifeStage};
+
+fn q(v: f64) -> Q3232 {
+    Q3232::from_num(v)
+}
+
+/// Helper: build a 3-channel threshold hook that emits `fire` at intensity =
+/// sum of the three channel values.
+fn three_channel_threshold_hook(
+    registry: &beast_channels::ChannelRegistry,
+    thresholds: [f64; 3],
+) -> InterpreterHook {
+    let sum_expr = expr("ch[a] + ch[b] + ch[c]", registry);
+    InterpreterHook {
+        id: HookId(1),
+        kind: CompositionKind::Threshold,
+        channel_ids: vec!["a".into(), "b".into(), "c".into()],
+        thresholds: thresholds.iter().map(|v| q(*v)).collect(),
+        coefficient: Q3232::ONE,
+        expression_conditions: Vec::new(),
+        emits: vec![EmitSpec {
+            primitive_id: "fire".into(),
+            parameter_mapping: vec![("intensity".into(), sum_expr)],
+        }],
+    }
+}
+
+fn world() -> (
+    beast_channels::ChannelRegistry,
+    beast_primitives::PrimitiveRegistry,
+) {
+    let creg = build_channel_registry(&[
+        ("a", 0.0, 1e9, false),
+        ("b", 0.0, 1e9, false),
+        ("c", 0.0, 1e9, false),
+    ]);
+    let preg = build_primitive_registry(&[("fire", "intensity", false)]);
+    (creg, preg)
+}
+
+#[test]
+fn threshold_hook_fires_when_all_three_operands_exceed_thresholds() {
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.2, 0.3, 0.4]);
+
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.5), ("b", 0.5), ("c", 0.5)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert_eq!(effects.len(), 1);
+    assert_eq!(effects[0].primitive_id, "fire");
+    // intensity = 0.5 + 0.5 + 0.5 = 1.5
+    assert_eq!(effects[0].parameters["intensity"], q(1.5));
+}
+
+#[test]
+fn threshold_hook_does_not_fire_when_one_operand_below_threshold() {
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.2, 0.3, 0.4]);
+
+    // Channel `b` is below its 0.3 threshold.
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.5), ("b", 0.1), ("c", 0.5)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert!(
+        effects.is_empty(),
+        "hook fired despite operand `b` being below threshold"
+    );
+}
+
+#[test]
+fn threshold_hook_does_not_fire_when_two_operands_below_thresholds() {
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.2, 0.3, 0.4]);
+
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.05), ("b", 0.1), ("c", 0.5)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert!(effects.is_empty());
+}
+
+#[test]
+fn threshold_hook_fires_exactly_at_thresholds() {
+    // `>=` semantics: an operand equal to its threshold must pass.
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.2, 0.3, 0.4]);
+
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.2), ("b", 0.3), ("c", 0.4)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert_eq!(effects.len(), 1, "equal-to-threshold must pass (`>=` rule)");
+}
+
+/// §6.2 dormant-channel rule: any operand at `Q3232::ZERO` auto-fails, even
+/// when the per-channel threshold is also zero. This is a deliberate
+/// deviation from naive `value >= threshold` — dormant channels must never
+/// propagate a spurious "all zero" pass.
+#[test]
+fn dormant_operand_auto_fails_even_when_threshold_is_zero() {
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.0, 0.0, 0.0]);
+
+    // `a` is dormant (zero value). The other two are above zero.
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.0), ("b", 0.1), ("c", 0.1)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert!(
+        effects.is_empty(),
+        "dormant operand must auto-fail even with zero threshold (§6.2)"
+    );
+}
+
+/// Complementary: no operand dormant, all thresholds zero → hook must fire
+/// (every operand is `> 0` ∧ `>= 0`).
+#[test]
+fn all_operands_positive_with_zero_thresholds_fires() {
+    let (creg, preg) = world();
+    let hook = three_channel_threshold_hook(&creg, [0.0, 0.0, 0.0]);
+
+    let p = phenotype(
+        10.0,
+        LifeStage::Adult,
+        &[("a", 0.1), ("b", 0.1), ("c", 0.1)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        std::slice::from_ref(&hook),
+        &creg,
+        &preg,
+        EntityId::new(1),
+    )
+    .unwrap();
+    assert_eq!(effects.len(), 1);
+}

--- a/crates/beast-interpreter/tests/determinism.rs
+++ b/crates/beast-interpreter/tests/determinism.rs
@@ -1,0 +1,133 @@
+//! Integration test: the 1000-run determinism gate (S4.6 — issue #60).
+//!
+//! Runs [`beast_interpreter::interpret_phenotype`] 1000 times against a
+//! fixture world (5 channels, 4 primitives, 6 hooks, 20 synthetic phenotypes)
+//! and asserts byte-identical `Vec<PrimitiveEffect>` on every run.
+//!
+//! This is the per-story version of the 1000-tick replay gate described in
+//! `CLAUDE.md` / `INVARIANTS.md` §1. The full tick loop gate lands with
+//! `beast-sim` in S6.
+
+mod common;
+
+use beast_core::EntityId;
+use beast_interpreter::{interpret_phenotype, ACTIVATION_COST_PARAM};
+
+use crate::common::{standard_phenotypes, standard_world};
+
+/// Run the pipeline once across every fixture phenotype and return the
+/// concatenated per-phenotype effect vectors. Used as the deterministic
+/// "expected value" that every subsequent run must equal byte-for-byte.
+fn run_once() -> Vec<Vec<beast_primitives::PrimitiveEffect>> {
+    let world = standard_world();
+    let phenotypes = standard_phenotypes();
+    phenotypes
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            interpret_phenotype(
+                p,
+                &world.hooks,
+                &world.channel_registry,
+                &world.primitive_registry,
+                EntityId::new(i as u32),
+            )
+            .expect("fixture world emits valid primitives")
+        })
+        .collect()
+}
+
+#[test]
+fn one_thousand_runs_produce_byte_identical_output() {
+    let baseline = run_once();
+
+    // Sanity: the fixture must actually emit primitives, otherwise the test
+    // would be vacuously green.
+    let total_effects: usize = baseline.iter().map(|v| v.len()).sum();
+    assert!(
+        total_effects > 0,
+        "fixture must produce at least one primitive across the 20 phenotypes"
+    );
+
+    for run in 0..1000 {
+        let actual = run_once();
+        assert_eq!(
+            actual, baseline,
+            "run {run} diverged from baseline — determinism invariant broken"
+        );
+    }
+}
+
+#[test]
+fn output_is_sorted_by_primitive_id() {
+    let effects = run_once();
+    for (phenotype_idx, per_phenotype) in effects.iter().enumerate() {
+        let ids: Vec<&str> = per_phenotype
+            .iter()
+            .map(|e| e.primitive_id.as_str())
+            .collect();
+        let mut sorted = ids.clone();
+        sorted.sort();
+        assert_eq!(
+            ids, sorted,
+            "phenotype {phenotype_idx}: primitive ids must be sorted"
+        );
+    }
+}
+
+#[test]
+fn input_phenotype_is_not_mutated() {
+    // Regression: the pipeline clones internally before applying the
+    // scale-band filter. Verify the caller's copy is unchanged after a call.
+    let world = standard_world();
+    let phenotypes = standard_phenotypes();
+    for (i, p) in phenotypes.iter().enumerate() {
+        let before = p.global_channels.clone();
+        let before_mass = p.body_mass_kg;
+        let _ = interpret_phenotype(
+            p,
+            &world.hooks,
+            &world.channel_registry,
+            &world.primitive_registry,
+            EntityId::new(i as u32),
+        )
+        .unwrap();
+        assert_eq!(
+            p.global_channels, before,
+            "phenotype {i}: global_channels mutated"
+        );
+        assert_eq!(p.body_mass_kg, before_mass, "phenotype {i}: mass mutated");
+    }
+}
+
+#[test]
+fn every_effect_has_registered_primitive_id() {
+    let world = standard_world();
+    let effects = run_once();
+    for per_phenotype in &effects {
+        for effect in per_phenotype {
+            assert!(
+                world.primitive_registry.contains(&effect.primitive_id),
+                "primitive `{}` not in registry",
+                effect.primitive_id,
+            );
+        }
+    }
+}
+
+#[test]
+fn activation_cost_is_present_on_every_effect() {
+    // The emitter stores the evaluated cost under the sentinel parameter
+    // (§6.2B workaround until PrimitiveEffect grows a dedicated field — issue
+    // #67). Every emitted effect must carry it.
+    let effects = run_once();
+    for per_phenotype in &effects {
+        for effect in per_phenotype {
+            assert!(
+                effect.parameters.contains_key(ACTIVATION_COST_PARAM),
+                "effect `{}` missing activation cost parameter",
+                effect.primitive_id,
+            );
+        }
+    }
+}

--- a/crates/beast-interpreter/tests/proptest_random.rs
+++ b/crates/beast-interpreter/tests/proptest_random.rs
@@ -1,0 +1,145 @@
+//! Property-based tests on random phenotypes (S4.6 — issue #60).
+//!
+//! Generates 100 random phenotypes against the standard fixture world and
+//! asserts every invariant the integration tests require of
+//! [`beast_interpreter::interpret_phenotype`]:
+//!
+//! * never panics
+//! * always returns `Ok`
+//! * every `PrimitiveEffect.primitive_id` is present in the registry — no
+//!   phantom ids leak
+//! * every parameter value is a finite `Q3232` (saturating arithmetic only —
+//!   no raw `MAX`/`MIN` unless produced via saturating ops, and we don't
+//!   expect to hit those in the fixture's bounded value range)
+//! * output is sorted by `primitive_id`
+//! * calling the pipeline twice with the same input produces identical output
+
+mod common;
+
+use beast_core::{EntityId, Q3232};
+use beast_interpreter::{interpret_phenotype, phenotype::LifeStage};
+use proptest::prelude::*;
+
+use crate::common::{phenotype, standard_world};
+use beast_interpreter::phenotype::Environment;
+
+/// Sample each channel value as `Q3232::from_bits(n)` for `n` in a bounded
+/// integer range. Using `from_bits` keeps the distribution deterministic
+/// (no `f64` rounding in the generator) and `|n| <= 2^20 << 32` stays well
+/// inside the range where saturating arithmetic on sums of ~8 terms cannot
+/// overflow.
+const BITS_BOUND: i64 = 1 << 20;
+
+fn arb_life_stage() -> impl Strategy<Value = LifeStage> {
+    prop_oneof![
+        Just(LifeStage::Juvenile),
+        Just(LifeStage::Adult),
+        Just(LifeStage::Elderly),
+    ]
+}
+
+fn arb_environment() -> impl Strategy<Value = Environment> {
+    // Environment variation is bounded to the small set the fixture hooks
+    // actually look at — biome flags + season + developmental stage.
+    prop_oneof![
+        Just(Environment::default()),
+        Just(Environment {
+            biome_flags: vec!["forest".into()],
+            season: Some("spring".into()),
+            ..Environment::default()
+        }),
+        Just(Environment {
+            biome_flags: vec!["aquatic".into()],
+            season: Some("summer".into()),
+            ..Environment::default()
+        }),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 100,
+        // Keep the harness headroom low — this is a determinism test, not a
+        // failure-mode search.
+        max_shrink_iters: 32,
+        ..ProptestConfig::default()
+    })]
+
+    /// The main property: random phenotypes against the standard fixture world
+    /// must produce valid, sorted, reproducible effect sets.
+    #[test]
+    fn interpret_phenotype_on_random_input(
+        bits in prop::collection::vec(-BITS_BOUND..=BITS_BOUND, 5),
+        mass_bits in 1_i64..=(100_i64 * (1 << 32)),
+        stage in arb_life_stage(),
+        env in arb_environment(),
+    ) {
+        let world = standard_world();
+
+        // Mass: use integers (then cast through `from_num`) to stay inside
+        // every channel's universal scale band. The standard_world() fixture
+        // uses 0..1e9 kg bands so any positive mass is in-band.
+        let mass_kg = Q3232::from_bits(mass_bits).to_num::<f64>().abs();
+        // Pad to at least 1e-6 kg so we stay well away from zero mass edge
+        // cases on hooks that consult ScaleBand expression conditions.
+        let mass_kg = if mass_kg < 1e-6 { 1e-6 } else { mass_kg };
+
+        let globals: Vec<(&str, f64)> = ["alpha", "beta", "gamma", "delta", "epsilon"]
+            .iter()
+            .zip(bits.iter())
+            .map(|(id, b)| (*id, Q3232::from_bits(*b).to_num::<f64>()))
+            .collect();
+
+        let p = phenotype(mass_kg, stage, &globals, env);
+
+        // --- Invariant 1: no panic, always `Ok`. ---
+        let first = interpret_phenotype(
+            &p,
+            &world.hooks,
+            &world.channel_registry,
+            &world.primitive_registry,
+            EntityId::new(1),
+        );
+        prop_assert!(first.is_ok(), "interpret_phenotype returned error on random input");
+        let effects = first.unwrap();
+
+        // --- Invariant 2: every primitive id is registered. ---
+        for effect in &effects {
+            prop_assert!(
+                world.primitive_registry.contains(&effect.primitive_id),
+                "primitive `{}` is not in the registry — phantom id leaked",
+                effect.primitive_id,
+            );
+        }
+
+        // --- Invariant 3: no parameter value saturated to Q3232::MIN / MAX.
+        //     The fixture's value range keeps arithmetic well inside the
+        //     representable window; a saturated value here would signal a
+        //     real overflow bug.
+        for effect in &effects {
+            for (name, value) in &effect.parameters {
+                prop_assert!(
+                    *value != Q3232::MAX && *value != Q3232::MIN,
+                    "parameter `{name}` on effect `{}` saturated to an extremum",
+                    effect.primitive_id,
+                );
+            }
+        }
+
+        // --- Invariant 4: output sorted by primitive_id. ---
+        let ids: Vec<&str> = effects.iter().map(|e| e.primitive_id.as_str()).collect();
+        let mut sorted_ids = ids.clone();
+        sorted_ids.sort();
+        prop_assert_eq!(&ids, &sorted_ids, "output must be sorted by primitive_id");
+
+        // --- Invariant 5: calling twice with the same input is idempotent. ---
+        let second = interpret_phenotype(
+            &p,
+            &world.hooks,
+            &world.channel_registry,
+            &world.primitive_registry,
+            EntityId::new(1),
+        ).unwrap();
+        prop_assert_eq!(&effects, &second, "repeat call diverged — determinism broken");
+    }
+}

--- a/crates/beast-interpreter/tests/proptest_random.rs
+++ b/crates/beast-interpreter/tests/proptest_random.rs
@@ -20,7 +20,7 @@ use beast_core::{EntityId, Q3232};
 use beast_interpreter::{interpret_phenotype, phenotype::LifeStage};
 use proptest::prelude::*;
 
-use crate::common::{phenotype, standard_world};
+use crate::common::{phenotype_q, standard_world};
 use beast_interpreter::phenotype::Environment;
 
 /// Sample each channel value as `Q3232::from_bits(n)` for `n` in a bounded
@@ -76,21 +76,24 @@ proptest! {
     ) {
         let world = standard_world();
 
-        // Mass: use integers (then cast through `from_num`) to stay inside
-        // every channel's universal scale band. The standard_world() fixture
-        // uses 0..1e9 kg bands so any positive mass is in-band.
-        let mass_kg = Q3232::from_bits(mass_bits).to_num::<f64>().abs();
-        // Pad to at least 1e-6 kg so we stay well away from zero mass edge
-        // cases on hooks that consult ScaleBand expression conditions.
-        let mass_kg = if mass_kg < 1e-6 { 1e-6 } else { mass_kg };
+        // Mass and channel values flow as Q3232 end-to-end. No `f64`
+        // round-trip, so there's no platform-specific rounding to worry about;
+        // the generator is bit-stable across any target.
+        //
+        // The standard_world() fixture uses [0, 1e9] kg bands, so any positive
+        // mass is in-band. We pad to at least ~2^12 bits above zero to stay
+        // clear of zero-mass edge cases on hooks that consult ScaleBand.
+        let min_mass = Q3232::from_bits(1_i64 << 12);
+        let mass_q = Q3232::from_bits(mass_bits).saturating_abs();
+        let mass_q = if mass_q < min_mass { min_mass } else { mass_q };
 
-        let globals: Vec<(&str, f64)> = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        let globals: Vec<(&str, Q3232)> = ["alpha", "beta", "gamma", "delta", "epsilon"]
             .iter()
             .zip(bits.iter())
-            .map(|(id, b)| (*id, Q3232::from_bits(*b).to_num::<f64>()))
+            .map(|(id, b)| (*id, Q3232::from_bits(*b)))
             .collect();
 
-        let p = phenotype(mass_kg, stage, &globals, env);
+        let p = phenotype_q(mass_q, stage, &globals, env);
 
         // --- Invariant 1: no panic, always `Ok`. ---
         let first = interpret_phenotype(

--- a/crates/beast-interpreter/tests/scale_band_fixtures.rs
+++ b/crates/beast-interpreter/tests/scale_band_fixtures.rs
@@ -1,0 +1,252 @@
+//! Scale-band acceptance fixtures (S4.6 — issue #60).
+//!
+//! Three end-to-end scenarios per
+//! `documentation/systems/11_phenotype_interpreter.md` §6.0 and the S4 epic
+//! demo criteria:
+//!
+//! * **Fixture A**: macro creature (100 kg) + micro-only channel. Channel
+//!   value is zeroed; no dependent primitive fires.
+//! * **Fixture B**: micro creature (1 µg) + macro-only channel. Same in reverse.
+//! * **Fixture C**: 500 g creature + universal regulatory channel. Channel
+//!   value is preserved; dependent primitives fire normally.
+
+mod common;
+
+use beast_core::{EntityId, Q3232};
+use beast_interpreter::{composition::HookId, interpret_phenotype};
+
+use crate::common::{
+    additive_hook, build_channel_registry, build_primitive_registry, expr, phenotype,
+    threshold_hook,
+};
+use beast_interpreter::composition::InterpreterHook;
+use beast_interpreter::phenotype::{Environment, LifeStage};
+
+/// Fixture A — 100 kg macro creature + micro-only (1e-15..1e-3 kg) channel.
+/// The scale-band filter must zero that channel's global value and the
+/// dependent threshold hook must therefore not fire (dormant-channel
+/// auto-fail, §6.2).
+#[test]
+fn fixture_a_macro_creature_zeros_micro_only_channel() {
+    let channel_registry = build_channel_registry(&[
+        ("host_attachment", 1e-15, 1e-3, false),
+        ("universal", 0.0, 1e9, false),
+    ]);
+    let primitive_registry =
+        build_primitive_registry(&[("p_attach", "strength", false), ("p_signal", "mag", false)]);
+
+    let e_host = expr("ch[host_attachment]", &channel_registry);
+    let e_universal = expr("ch[universal]", &channel_registry);
+
+    let hooks: Vec<InterpreterHook> = vec![
+        // This threshold hook depends on the micro-only channel; should
+        // auto-fail once the scale-band filter zeros it.
+        threshold_hook(
+            1,
+            &["host_attachment"],
+            &[Q3232::from_num(0.1_f64)],
+            "p_attach",
+            vec![("strength", e_host)],
+        ),
+        // Control: a universal-scale channel hook that MUST fire so the test
+        // proves the pipeline is alive.
+        additive_hook(2, &["universal"], "p_signal", vec![("mag", e_universal)]),
+    ];
+
+    let p = phenotype(
+        100.0,
+        LifeStage::Adult,
+        &[("host_attachment", 0.8), ("universal", 0.5)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        &hooks,
+        &channel_registry,
+        &primitive_registry,
+        EntityId::new(1),
+    )
+    .unwrap();
+
+    // `p_attach` never fires — micro-only channel was zeroed by scale-band.
+    assert!(
+        effects.iter().all(|e| e.primitive_id != "p_attach"),
+        "p_attach fired despite micro-only channel being out-of-band"
+    );
+    // `p_signal` fires from the universal control.
+    assert!(
+        effects.iter().any(|e| e.primitive_id == "p_signal"),
+        "p_signal (universal control) did not fire — pipeline wiring broken"
+    );
+}
+
+/// Fixture B — 1 µg (1e-9 kg) micro creature + macro-only (1.0..1e9 kg)
+/// channel. Mirror of fixture A.
+#[test]
+fn fixture_b_micro_creature_zeros_macro_only_channel() {
+    let channel_registry = build_channel_registry(&[
+        ("large_neural_integration", 1.0, 1e9, false),
+        ("universal", 0.0, 1e9, false),
+    ]);
+    let primitive_registry =
+        build_primitive_registry(&[("p_neural", "intensity", false), ("p_signal", "mag", false)]);
+
+    let e_neural = expr("ch[large_neural_integration]", &channel_registry);
+    let e_universal = expr("ch[universal]", &channel_registry);
+
+    let hooks: Vec<InterpreterHook> = vec![
+        threshold_hook(
+            1,
+            &["large_neural_integration"],
+            &[Q3232::from_num(0.1_f64)],
+            "p_neural",
+            vec![("intensity", e_neural)],
+        ),
+        additive_hook(2, &["universal"], "p_signal", vec![("mag", e_universal)]),
+    ];
+
+    let p = phenotype(
+        1e-9,
+        LifeStage::Adult,
+        &[("large_neural_integration", 0.9), ("universal", 0.5)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        &hooks,
+        &channel_registry,
+        &primitive_registry,
+        EntityId::new(1),
+    )
+    .unwrap();
+
+    assert!(
+        effects.iter().all(|e| e.primitive_id != "p_neural"),
+        "p_neural fired despite macro-only channel being out-of-band"
+    );
+    assert!(
+        effects.iter().any(|e| e.primitive_id == "p_signal"),
+        "p_signal (universal control) did not fire"
+    );
+}
+
+/// Fixture C — 500 g (0.5 kg) creature + universal (0..1e9 kg) regulatory
+/// channel. Channel value must be preserved; dependent primitives fire.
+#[test]
+fn fixture_c_universal_channel_preserved_at_every_scale() {
+    let channel_registry = build_channel_registry(&[("immune_response_baseline", 0.0, 1e9, false)]);
+    let primitive_registry = build_primitive_registry(&[("p_immune", "baseline", false)]);
+
+    let e_immune = expr("ch[immune_response_baseline]", &channel_registry);
+    let hooks = vec![threshold_hook(
+        1,
+        &["immune_response_baseline"],
+        &[Q3232::from_num(0.05_f64)],
+        "p_immune",
+        vec![("baseline", e_immune)],
+    )];
+
+    let p = phenotype(
+        0.5,
+        LifeStage::Adult,
+        &[("immune_response_baseline", 0.3)],
+        Environment::default(),
+    );
+
+    let effects = interpret_phenotype(
+        &p,
+        &hooks,
+        &channel_registry,
+        &primitive_registry,
+        EntityId::new(1),
+    )
+    .unwrap();
+
+    assert_eq!(effects.len(), 1, "exactly one effect should fire");
+    assert_eq!(effects[0].primitive_id, "p_immune");
+    // `immune_response_baseline` was 0.3 — must be preserved through the
+    // scale-band stage and returned in the effect's parameter.
+    assert_eq!(
+        effects[0].parameters["baseline"],
+        Q3232::from_num(0.3_f64),
+        "universal channel value must be preserved at 500 g",
+    );
+}
+
+/// Extra: proves that the same fixture world applied to both a macro and a
+/// micro creature yields different effect sets — that is, the scale-band
+/// filter is actually gating behaviour on body mass, not just a no-op.
+#[test]
+fn macro_and_micro_creatures_get_different_effect_sets() {
+    let channel_registry = build_channel_registry(&[
+        ("macro_only", 1.0, 1e9, false),
+        ("micro_only", 1e-15, 1e-3, false),
+    ]);
+    let primitive_registry =
+        build_primitive_registry(&[("p_macro", "val", false), ("p_micro", "val", false)]);
+
+    let e_macro = expr("ch[macro_only]", &channel_registry);
+    let e_micro = expr("ch[micro_only]", &channel_registry);
+    let hooks = vec![
+        threshold_hook(
+            1,
+            &["macro_only"],
+            &[Q3232::from_num(0.1_f64)],
+            "p_macro",
+            vec![("val", e_macro)],
+        ),
+        threshold_hook(
+            2,
+            &["micro_only"],
+            &[Q3232::from_num(0.1_f64)],
+            "p_micro",
+            vec![("val", e_micro)],
+        ),
+    ];
+
+    let macro_p = phenotype(
+        100.0,
+        LifeStage::Adult,
+        &[("macro_only", 0.8), ("micro_only", 0.8)],
+        Environment::default(),
+    );
+    let micro_p = phenotype(
+        1e-9,
+        LifeStage::Adult,
+        &[("macro_only", 0.8), ("micro_only", 0.8)],
+        Environment::default(),
+    );
+
+    let macro_effects = interpret_phenotype(
+        &macro_p,
+        &hooks,
+        &channel_registry,
+        &primitive_registry,
+        EntityId::new(1),
+    )
+    .unwrap();
+    let micro_effects = interpret_phenotype(
+        &micro_p,
+        &hooks,
+        &channel_registry,
+        &primitive_registry,
+        EntityId::new(1),
+    )
+    .unwrap();
+
+    let macro_ids: Vec<&str> = macro_effects
+        .iter()
+        .map(|e| e.primitive_id.as_str())
+        .collect();
+    let micro_ids: Vec<&str> = micro_effects
+        .iter()
+        .map(|e| e.primitive_id.as_str())
+        .collect();
+    assert_eq!(macro_ids, vec!["p_macro"]);
+    assert_eq!(micro_ids, vec!["p_micro"]);
+
+    // `HookId` imports are unused here — keep the module tidy.
+    let _ = HookId(0);
+}

--- a/crates/beast-interpreter/tests/scale_band_fixtures.rs
+++ b/crates/beast-interpreter/tests/scale_band_fixtures.rs
@@ -13,7 +13,7 @@
 mod common;
 
 use beast_core::{EntityId, Q3232};
-use beast_interpreter::{composition::HookId, interpret_phenotype};
+use beast_interpreter::interpret_phenotype;
 
 use crate::common::{
     additive_hook, build_channel_registry, build_primitive_registry, expr, phenotype,
@@ -246,7 +246,4 @@ fn macro_and_micro_creatures_get_different_effect_sets() {
         .collect();
     assert_eq!(macro_ids, vec!["p_macro"]);
     assert_eq!(micro_ids, vec!["p_micro"]);
-
-    // `HookId` imports are unused here — keep the module tidy.
-    let _ = HookId(0);
 }


### PR DESCRIPTION
## Summary

Wires the interpreter pipeline (scale-band filter → affordance filter → hook resolve → primitive emission) as the public `interpret_phenotype` entry point per `documentation/systems/11_phenotype_interpreter.md` §6. Closes out S4 by shipping the local determinism gate that guards the interpreter before the S6 world-level replay gate arrives.

## `interpret_phenotype`

```rust
pub fn interpret_phenotype(
    phenotype: &ResolvedPhenotype,
    hooks: &[InterpreterHook],
    channel_registry: &ChannelRegistry,
    primitive_registry: &PrimitiveRegistry,
    emitter: EntityId,
) -> Result<Vec<PrimitiveEffect>>
```

Clones the phenotype (to mutate under scale-band filter), filters hooks by affordances, materialises the filtered active-hook list in the id-sorted order returned by stage 2, runs the resolver, emits + dedups + merges primitives. No body-site fanout (deferred to #67); no cost-field refinement (also #67).

## Integration tests (16 new; 100 total passing)

- **`tests/determinism.rs`** (5 tests, 0.83 s) — the big one: 1000 runs of `interpret_phenotype` on a 20-phenotype fixture produce byte-identical `Vec<PrimitiveEffect>` every time; output is sorted by `primitive_id`; input phenotype is never mutated; every emitted id is in the registry; cost sentinel present.
- **`tests/scale_band_fixtures.rs`** (4 tests, 0.01 s) — Fixture A (100 kg macro + `[1e-15, 1e-3]` micro-only → zeroed), Fixture B (1 µg micro + `[1, 1e9]` macro-only → zeroed), Fixture C (500 g + universal `[0, 1e9]` → preserved), and a macro-vs-micro differentiation assertion.
- **`tests/composition_thresholds.rs`** (6 tests, 0.02 s) — all-exceed fires, one-below / two-below drops, boundary-equal passes, dormant-auto-fail, all-positive-zero-thresholds fires.
- **`tests/proptest_random.rs`** (1 proptest × 100 cases, 0.05 s) — no panic, `Ok` result, registered ids only, no saturated MIN/MAX leak, sorted output, idempotent twice-run.
- **`tests/common/mod.rs`** — shared fixture builder: 5-channel / 4-primitive / 6-hook world + 20-phenotype standard set + both `f64` and `Q3232` phenotype constructors (the latter avoids the workspace-wide `clippy::float_arithmetic = warn` when arithmetic is needed).

**Integration wall-clock**: ~0.91 s total across all four binaries — well under the 5 s CI budget.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p beast-interpreter --tests` — 16/16 integration pass (0.91 s)
- [x] `cargo test -p beast-interpreter --all-targets` — 100/100 pass (84 unit + 16 integration)
- [x] `cargo test -p beast-interpreter --doc` — 2/2 pass
- [x] `cargo test --workspace --all-targets --locked` — still green workspace-wide
- [x] `cargo test --workspace --doc --locked` — still green workspace-wide

## What this closes

Closes **#60** (the final S4 story) and demo-crits the **epic #16**:
- ✓ Interpret 100 random genomes; all produce valid `PrimitiveEffect` sets
- ✓ Scale-band filter: 100 kg creature with `[1e-15, 1e-3 kg]` channel → zero primitives
- ✓ Composition threshold: fires iff both operands > T
- ✓ 1000-tick determinism: same seed → identical outputs

S4 follow-ups remain tracked in **#61** (extended operators), **#67** (body-site fanout + activation-cost field), **#70** (source-channel provenance), **#71** (typed manifest `merge_strategy`), **#66** (§6.0 pseudocode doc fix).

Closes #60 · Epic: #16