### PR TITLE
fix(ci): lizard exclusion glob never matched — drop stale ./ prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,20 +163,20 @@ jobs:
         run: |
           set +e
           python -m lizard -l rust -C"${QUALITY_MAX_CCN}" -L"${QUALITY_MAX_LENGTH}" \
-            -x "./crates/*/tests/*" \
-            -x "./crates/*/benches/*" \
+            -x "*/tests/*" \
+            -x "*/benches/*" \
             -W ".github/qa/whitelizard.txt" \
             crates > quality-lizard.txt
           complexity_status=$?
           python -m lizard --csv -l rust -C"${QUALITY_MAX_CCN}" -L"${QUALITY_MAX_LENGTH}" \
-            -x "./crates/*/tests/*" \
-            -x "./crates/*/benches/*" \
+            -x "*/tests/*" \
+            -x "*/benches/*" \
             -W ".github/qa/whitelizard.txt" \
             crates > quality-functions.csv
           functions_status=$?
           python -m lizard -l rust -Eduplicate \
-            -x "./crates/*/tests/*" \
-            -x "./crates/*/benches/*" \
+            -x "*/tests/*" \
+            -x "*/benches/*" \
             crates > quality-duplicates.txt
           duplicates_status=$?
           python .github/scripts/quality_metrics.py \


### PR DESCRIPTION
## Summary

The quality-metrics step in `.github/workflows/ci.yml` passed `./crates/*/tests/*` and `./crates/*/benches/*` to lizard's `-x` flag. Python's `fnmatch` compares those patterns literally against the paths lizard emits, which don't carry a leading `./` on either Windows or Linux. Net effect: **the exclusions have been silently non-functional since the workflow was written** — all test and bench code has been analyzed against the production thresholds the whole time.

## Why it didn't trip before

No test function has crossed the 80-line threshold until now. S4.6's `standard_world()` test fixture is 88 lines of straight-line setup (CCN 1), which surfaced the broken exclusion on [run 24700958778](https://github.com/BemusedVermin/evolution-simulation/actions/runs/24700958778/job/72243933965):

```
standard_world@267-354@crates/beast-interpreter/tests/common/mod.rs
length 88 > 80
```

## Proof of the root cause

```python
import fnmatch
fnmatch.fnmatch('crates/beast-interpreter/tests/common/mod.rs', './crates/*/tests/*')
# False          ← current pattern never matches
fnmatch.fnmatch('crates/beast-interpreter/tests/common/mod.rs', '*/tests/*')
# True           ← fixed pattern
```

## Fix

Drop the `./` prefix from the three pairs of `-x` patterns. Keep the semantics (exclude test and bench code from production complexity thresholds).

## Test plan

Locally reproduced the CI step with the fix applied:

- [x] `python -m lizard ... -x "*/tests/*" -x "*/benches/*" ...` → `complexity_status=0`
- [x] same, CSV variant → `functions_status=0`
- [x] `python -m lizard ... -Eduplicate ... -x "*/tests/*"` → `duplicates_status=0`
- [x] `python .github/scripts/quality_metrics.py ...` → `summary_status=0`

No changes to `standard_world()` itself — it's a legitimate test fixture and shouldn't be forced to split just because of a broken glob. If we later decide production code deliberately needs the length cap to apply to test fixtures too, that's a separate policy conversation.

Closes the failure on run 24700958778.