### PR TITLE
refactor(beast-interpreter): split parameter_map into focused sub-modules

### DIFF
--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -59,6 +59,8 @@ pub use emission::{emit_primitives, ACTIVATION_COST_PARAM};
 pub use error::{InterpreterError, Result};
 pub use expression::filter_hooks_by_affordances;
 pub use interpreter::interpret_phenotype;
-pub use parameter_map::{collect_channel_refs, eval_expression, parse_expression, Expr};
+pub use parameter_map::{
+    collect_channel_refs, eval_expression, parse_expression, CompiledExpr, Expr,
+};
 pub use phenotype::{BodyRegion, BodySite, Environment, LifeStage, ResolvedPhenotype};
 pub use scale_band::apply_scale_band_filter;

--- a/crates/beast-interpreter/src/parameter_map/analysis.rs
+++ b/crates/beast-interpreter/src/parameter_map/analysis.rs
@@ -1,0 +1,48 @@
+//! Static analysis passes over a parsed [`CompiledExpr`].
+//!
+//! Currently exposes [`collect_channel_refs`]; future passes (dead-channel
+//! detection, constant folding) live here without bloating the evaluator.
+
+use std::collections::BTreeSet;
+
+use super::ast::{CompiledExpr, ExprNode};
+
+/// Return every channel id referenced by `expr`, sorted and deduplicated.
+///
+/// Used by the emission path to compose a hook's
+/// [`beast_primitives::PrimitiveEffect::source_channels`] without having
+/// to re-walk the raw manifest source string.
+#[must_use]
+pub fn collect_channel_refs(expr: &CompiledExpr) -> Vec<String> {
+    let mut out = BTreeSet::new();
+    walk(expr.node(), &mut out);
+    out.into_iter().collect()
+}
+
+fn walk(node: &ExprNode, out: &mut BTreeSet<String>) {
+    match node {
+        ExprNode::Literal(_) => {}
+        ExprNode::ChannelRef(id) => {
+            out.insert(id.clone());
+        }
+        ExprNode::Add(l, r) | ExprNode::Mul(l, r) => {
+            walk(l, out);
+            walk(r, out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parameter_map::parse_expression;
+    use crate::parameter_map::test_support::registry_with;
+
+    #[test]
+    fn collect_channel_refs_returns_sorted_unique_ids() {
+        let reg = registry_with(&["alpha", "beta"]);
+        let expr = parse_expression("ch[beta] + ch[alpha] * 2 + ch[beta]", &reg).unwrap();
+        let refs = collect_channel_refs(&expr);
+        assert_eq!(refs, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+}

--- a/crates/beast-interpreter/src/parameter_map/ast.rs
+++ b/crates/beast-interpreter/src/parameter_map/ast.rs
@@ -1,0 +1,84 @@
+//! Expression AST for the S4.4 parameter-mapping language.
+//!
+//! The AST is split from the parser (`super::parser`) so the evaluator and
+//! analysis passes can consume it without depending on the parser's
+//! recursive-descent machinery.
+//!
+//! ## Type-system enforcement of "channel symbols resolved at parse time"
+//!
+//! Channel symbols **must** be resolved against a
+//! [`beast_channels::ChannelRegistry`] at parse time (sprint plan Q4;
+//! §6.2). To enforce this in the type system — rather than by convention —
+//! the raw AST [`ExprNode`] has **crate-private variants**: downstream
+//! crates cannot construct an `ExprNode::ChannelRef(unresolved)`.
+//!
+//! The only path by which a downstream crate obtains an expression value is
+//! [`super::parse_expression`], which returns a [`CompiledExpr`]. Every
+//! [`CompiledExpr`] is therefore, by construction, a fully-resolved
+//! expression whose channel references were checked against the registry.
+//!
+//! [`Expr`] is a backward-compatibility alias for [`CompiledExpr`] used by
+//! downstream crates that stored expressions in `Vec<(String, Expr)>`-shaped
+//! fields prior to the S4.6 split (issue #76).
+
+use beast_core::Q3232;
+
+/// Raw expression AST — **crate-private** by design.
+///
+/// The variants are `pub(crate)` so that only the parser (which validates
+/// channel symbols against the registry) and the evaluator / analyser
+/// (which consume parsed values) can construct or match them. External
+/// crates interact with expressions exclusively through [`CompiledExpr`].
+#[derive(Debug, Clone)]
+pub(crate) enum ExprNode {
+    /// A literal Q32.32 value.
+    Literal(Q3232),
+    /// Reference to a channel value by resolved id.
+    ChannelRef(String),
+    /// Binary addition.
+    Add(Box<ExprNode>, Box<ExprNode>),
+    /// Binary multiplication.
+    Mul(Box<ExprNode>, Box<ExprNode>),
+}
+
+/// A parsed-and-resolved parameter-mapping expression.
+///
+/// "Resolved" means every `ch[<symbol>]` in the source was looked up in a
+/// [`beast_channels::ChannelRegistry`] at parse time and rejected if
+/// unknown. Because the inner [`ExprNode`] has crate-private variants, a
+/// `CompiledExpr` can **only** be produced by [`super::parse_expression`]
+/// — downstream crates cannot fabricate an unresolved expression and then
+/// cast it into a `CompiledExpr`.
+///
+/// Evaluation ([`super::eval_expression`]) and channel-ref collection
+/// ([`super::collect_channel_refs`]) both take `&CompiledExpr`, so the
+/// resolution guarantee propagates through the entire pipeline.
+#[derive(Debug, Clone)]
+pub struct CompiledExpr {
+    pub(crate) node: ExprNode,
+}
+
+impl CompiledExpr {
+    /// Construct a `CompiledExpr` from a crate-private AST node.
+    ///
+    /// This is `pub(crate)` so only the parser can mint a `CompiledExpr`.
+    pub(crate) fn from_node(node: ExprNode) -> Self {
+        Self { node }
+    }
+
+    /// Borrow the inner AST node for internal consumers (evaluator,
+    /// analyser). Not exposed publicly — downstream crates should not rely
+    /// on the AST shape.
+    pub(crate) fn node(&self) -> &ExprNode {
+        &self.node
+    }
+}
+
+/// Backward-compatibility alias for [`CompiledExpr`].
+///
+/// Pre-S4.6 (issue #76), the public AST type was `Expr`. Downstream code
+/// stores expressions in typed fields like
+/// `parameter_mapping: Vec<(String, Expr)>`. Keeping `Expr` as a type
+/// alias preserves that call-site ergonomy while the underlying type is
+/// now the newtype that enforces resolution.
+pub type Expr = CompiledExpr;

--- a/crates/beast-interpreter/src/parameter_map/eval.rs
+++ b/crates/beast-interpreter/src/parameter_map/eval.rs
@@ -1,0 +1,163 @@
+//! Pure evaluator for [`CompiledExpr`] over a per-channel value map.
+//!
+//! Evaluation is a fold over Q32.32 saturating arithmetic; see
+//! [`eval_expression`] for the determinism contract.
+
+use std::collections::BTreeMap;
+
+use beast_core::Q3232;
+
+use super::ast::{CompiledExpr, ExprNode};
+
+/// Evaluate a parsed expression against per-channel global values.
+///
+/// Returns [`Q3232::ZERO`] for any channel id not present in
+/// `channel_values` — this matches the "dormant channels propagate zero"
+/// rule from §6.2. Addition and multiplication use [`Q3232`] saturating
+/// arithmetic, so overflow clamps to [`Q3232::MAX`] / [`Q3232::MIN`] rather
+/// than panicking or wrapping.
+///
+/// This function is pure: the output is entirely determined by
+/// `(expr, channel_values)`, satisfying the determinism invariant
+/// (INVARIANTS §1).
+#[must_use]
+pub fn eval_expression(expr: &CompiledExpr, channel_values: &BTreeMap<String, Q3232>) -> Q3232 {
+    eval_node(expr.node(), channel_values)
+}
+
+fn eval_node(node: &ExprNode, channel_values: &BTreeMap<String, Q3232>) -> Q3232 {
+    match node {
+        ExprNode::Literal(v) => *v,
+        ExprNode::ChannelRef(id) => channel_values.get(id).copied().unwrap_or(Q3232::ZERO),
+        ExprNode::Add(lhs, rhs) => {
+            eval_node(lhs, channel_values).saturating_add(eval_node(rhs, channel_values))
+        }
+        ExprNode::Mul(lhs, rhs) => {
+            eval_node(lhs, channel_values).saturating_mul(eval_node(rhs, channel_values))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parameter_map::parse_expression;
+    use crate::parameter_map::test_support::{channels, registry_with};
+    use proptest::prelude::*;
+
+    #[test]
+    fn evaluates_literal() {
+        let vals = BTreeMap::new();
+        let expr = CompiledExpr::from_node(ExprNode::Literal(Q3232::from_num(3_i32)));
+        let out = eval_expression(&expr, &vals);
+        assert_eq!(out, Q3232::from_num(3_i32));
+    }
+
+    #[test]
+    fn evaluates_channel_ref_present() {
+        let vals = channels(&[("a", Q3232::from_num(5_i32))]);
+        let expr = CompiledExpr::from_node(ExprNode::ChannelRef("a".into()));
+        let out = eval_expression(&expr, &vals);
+        assert_eq!(out, Q3232::from_num(5_i32));
+    }
+
+    #[test]
+    fn evaluates_channel_ref_missing_as_zero() {
+        // The "dormant channels propagate zero" rule: an AST that refers
+        // to a channel not present in the runtime value map reads as ZERO.
+        let vals = BTreeMap::new();
+        let expr = CompiledExpr::from_node(ExprNode::ChannelRef("missing".into()));
+        let out = eval_expression(&expr, &vals);
+        assert_eq!(out, Q3232::ZERO);
+    }
+
+    #[test]
+    fn roundtrip_parse_then_evaluate() {
+        let reg = registry_with(&["a", "b"]);
+        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
+        let vals = channels(&[
+            ("a", Q3232::from_num(0.5_f64)),
+            ("b", Q3232::from_num(2_i32)),
+        ]);
+        // 0.5 * 8 + 2 = 6
+        let out = eval_expression(&expr, &vals);
+        assert_eq!(out, Q3232::from_num(6_i32));
+    }
+
+    #[test]
+    fn roundtrip_same_input_yields_same_output_twice() {
+        let reg = registry_with(&["a", "b"]);
+        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
+        let vals = channels(&[
+            ("a", Q3232::from_num(0.25_f64)),
+            ("b", Q3232::from_num(1_i32)),
+        ]);
+        let first = eval_expression(&expr, &vals);
+        let second = eval_expression(&expr, &vals);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn saturating_addition_clamps() {
+        let vals = BTreeMap::new();
+        // Driving the evaluator with a hand-built AST is fine from inside
+        // the module — `ExprNode` is `pub(crate)` and exposed here via
+        // `super::*`. External crates cannot do this: they must go through
+        // [`parse_expression`], which is the whole point of [`CompiledExpr`].
+        let expr = CompiledExpr::from_node(ExprNode::Add(
+            Box::new(ExprNode::Literal(Q3232::MAX)),
+            Box::new(ExprNode::Literal(Q3232::ONE)),
+        ));
+        assert_eq!(eval_expression(&expr, &vals), Q3232::MAX);
+    }
+
+    // ------- proptest: evaluator purity -----------------------------------
+
+    /// Sample a small, balanced AST. We intentionally keep the channel
+    /// alphabet small so the "missing channel → zero" path is exercised.
+    ///
+    /// This proptest drives the evaluator's internal [`ExprNode`] type
+    /// directly (not [`CompiledExpr`]) because the point of the test is
+    /// to prove the evaluator is a deterministic fold — it should not
+    /// matter how the AST was produced, only that the same input always
+    /// yields the same output.
+    fn arb_node() -> impl Strategy<Value = ExprNode> {
+        let leaf = prop_oneof![
+            (-100_000_i64..=100_000_i64).prop_map(|n| ExprNode::Literal(Q3232::from_num(n))),
+            prop::sample::select(vec!["a", "b", "c", "d", "missing"])
+                .prop_map(|s| ExprNode::ChannelRef(s.to_string())),
+        ];
+        leaf.prop_recursive(4, 16, 2, |inner| {
+            prop_oneof![
+                (inner.clone(), inner.clone())
+                    .prop_map(|(l, r)| ExprNode::Add(Box::new(l), Box::new(r))),
+                (inner.clone(), inner).prop_map(|(l, r)| ExprNode::Mul(Box::new(l), Box::new(r))),
+            ]
+        })
+    }
+
+    proptest! {
+        /// `eval_expression` is a pure function of `(expr, channel_values)`:
+        /// calling it twice on the same inputs always yields the same output.
+        /// Required by INVARIANTS §1 (determinism).
+        #[test]
+        fn eval_is_pure_and_deterministic(
+            node in arb_node(),
+            bits_a in any::<i64>(),
+            bits_b in any::<i64>(),
+            bits_c in any::<i64>(),
+            bits_d in any::<i64>(),
+        ) {
+            let expr = CompiledExpr::from_node(node);
+            let vals = channels(&[
+                ("a", Q3232::from_bits(bits_a)),
+                ("b", Q3232::from_bits(bits_b)),
+                ("c", Q3232::from_bits(bits_c)),
+                ("d", Q3232::from_bits(bits_d)),
+            ]);
+            let first = eval_expression(&expr, &vals);
+            let second = eval_expression(&expr, &vals);
+            prop_assert_eq!(first, second);
+        }
+    }
+}

--- a/crates/beast-interpreter/src/parameter_map/literal.rs
+++ b/crates/beast-interpreter/src/parameter_map/literal.rs
@@ -1,0 +1,70 @@
+//! Numeric-literal parsing for the parameter-mapping language.
+//!
+//! Split from [`super::parser`] so the recursive-descent engine is not
+//! cluttered by the dot-decimal / underscore-separator handling. All code
+//! here is float-free and operates in Q32.32.
+
+use beast_core::Q3232;
+
+/// Parse a dot-decimal ASCII literal (already stripped of `_`) into a
+/// [`Q3232`]. Returns `None` when neither the integer nor the combined
+/// rational representation fit, or when the string is malformed for either
+/// path.
+pub(super) fn parse_q3232_literal(cleaned: &str) -> Option<Q3232> {
+    if let Some(dot) = cleaned.find('.') {
+        let int_part = &cleaned[..dot];
+        let frac_part = &cleaned[dot + 1..];
+        if frac_part.is_empty() {
+            return None;
+        }
+        // Parse as (numerator / 10^frac_len) in Q32.32 arithmetic so we
+        // avoid floats. Both pieces must fit in `i64`.
+        let int_val: i64 = int_part.parse().ok()?;
+        let frac_val: i64 = frac_part.parse().ok()?;
+        let scale: i64 = 10_i64.checked_pow(u32::try_from(frac_part.len()).ok()?)?;
+        // int_val + frac_val / scale, in Q32.32.
+        let int_q = Q3232::from_num(int_val);
+        let frac_q = Q3232::from_num(frac_val).saturating_div(Q3232::from_num(scale));
+        Some(int_q.saturating_add(frac_q))
+    } else {
+        let int_val: i64 = cleaned.parse().ok()?;
+        Some(Q3232::from_num(int_val))
+    }
+}
+
+/// Strip underscore digit-separators from a literal slice.
+///
+/// `fixed`'s `FromStr` rejects `_`, so we normalise the byte slice to an
+/// ASCII-only [`String`] before handing it to [`parse_q3232_literal`].
+pub(super) fn strip_underscores(raw: &[u8]) -> String {
+    raw.iter()
+        .filter(|b| **b != b'_')
+        .map(|b| *b as char)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_integer_only() {
+        assert_eq!(parse_q3232_literal("42"), Some(Q3232::from_num(42_i32)));
+    }
+
+    #[test]
+    fn parses_fractional() {
+        assert_eq!(parse_q3232_literal("0.5"), Some(Q3232::from_num(0.5_f64)));
+    }
+
+    #[test]
+    fn rejects_trailing_dot() {
+        assert_eq!(parse_q3232_literal("3."), None);
+    }
+
+    #[test]
+    fn strips_underscore_separators() {
+        assert_eq!(strip_underscores(b"1_000_000"), "1000000");
+        assert_eq!(strip_underscores(b"0.1_2"), "0.12");
+    }
+}

--- a/crates/beast-interpreter/src/parameter_map/mod.rs
+++ b/crates/beast-interpreter/src/parameter_map/mod.rs
@@ -1,0 +1,53 @@
+//! Parameter-mapping expression parser and evaluator (S4.4 — issue #58).
+//!
+//! Expressions look like `ch[vocal_modulation] * 8 + ch[auditory_sensitivity]`
+//! in the manifest source. They are parsed **once at manifest load time**
+//! (sprint plan Q2) into a [`CompiledExpr`] where channel symbols have
+//! already been resolved to channel ids (Q4). Evaluation is a pure fold
+//! over Q32.32 fixed-point arithmetic.
+//!
+//! The **minimal operator set** shipped in S4 is listed below; everything
+//! else is tracked in issue #61.
+//!
+//! | Construct          | S4.4 | Deferred (#61) |
+//! |--------------------|------|----------------|
+//! | `ch[<symbol>]`     | ✓    |                |
+//! | scalar literal     | ✓    |                |
+//! | `+`, `*`           | ✓    |                |
+//! | `sqrt(...)`        |      | ✓              |
+//! | `[lo, hi]` range   |      | ✓              |
+//! | implicit `clamp`   |      | ✓              |
+//! | `-`, `/`           |      | ✓              |
+//!
+//! See `documentation/systems/11_phenotype_interpreter.md` §6.2.
+//!
+//! # Module layout (issue #76 split)
+//!
+//! The original monolithic `parameter_map.rs` was split into focused
+//! sub-modules in S4.6 without changing behaviour:
+//!
+//! | Sub-module   | Responsibility                                  |
+//! |--------------|-------------------------------------------------|
+//! | `ast`        | [`CompiledExpr`] newtype + crate-private AST    |
+//! | `parser`     | Recursive-descent parser                        |
+//! | `literal`    | Numeric-literal parsing (Q32.32)                |
+//! | `eval`       | Pure Q32.32 evaluator                           |
+//! | `analysis`   | Static passes (e.g. [`collect_channel_refs`])   |
+//!
+//! Only the parser can construct a [`CompiledExpr`] — the AST variants are
+//! crate-private — so "channel symbols resolved at parse time" is
+//! enforced in the type system, not by convention.
+
+mod analysis;
+mod ast;
+mod eval;
+mod literal;
+mod parser;
+
+#[cfg(test)]
+pub(crate) mod test_support;
+
+pub use analysis::collect_channel_refs;
+pub use ast::{CompiledExpr, Expr};
+pub use eval::eval_expression;
+pub use parser::parse_expression;

--- a/crates/beast-interpreter/src/parameter_map/parser.rs
+++ b/crates/beast-interpreter/src/parameter_map/parser.rs
@@ -1,52 +1,19 @@
-//! Parameter-mapping expression parser and evaluator (S4.4 — issue #58).
+//! Recursive-descent parser for the S4.4 parameter-mapping language.
 //!
-//! Expressions look like `ch[vocal_modulation] * 8 + ch[auditory_sensitivity]`
-//! in the manifest source. They are parsed **once at manifest load time**
-//! (sprint plan Q2) into an [`Expr`] AST where channel symbols have already
-//! been resolved to channel ids (Q4). Evaluation is a pure fold over Q32.32
-//! fixed-point arithmetic.
-//!
-//! The **minimal operator set** shipped in S4 is listed below; everything
-//! else is tracked in issue #61.
-//!
-//! | Construct          | S4.4 | Deferred (#61) |
-//! |--------------------|------|----------------|
-//! | `ch[<symbol>]`     | ✓    |                |
-//! | scalar literal     | ✓    |                |
-//! | `+`, `*`           | ✓    |                |
-//! | `sqrt(...)`        |      | ✓              |
-//! | `[lo, hi]` range   |      | ✓              |
-//! | implicit `clamp`   |      | ✓              |
-//! | `-`, `/`           |      | ✓              |
-//!
-//! See `documentation/systems/11_phenotype_interpreter.md` §6.2.
-
-use std::collections::BTreeMap;
+//! Byte-at-a-time over ASCII source. Channel symbols are resolved against
+//! the [`ChannelRegistry`] during `ch[<ident>]` parsing — unknown symbols
+//! surface as [`InterpreterError::UnknownChannelSymbol`], every other
+//! failure as [`InterpreterError::ParseError`]. See the
+//! [`super`][super] module doc for the full grammar.
 
 use beast_channels::ChannelRegistry;
-use beast_core::Q3232;
 
 use crate::error::{InterpreterError, Result};
 
-/// Parsed parameter expression.
-///
-/// `ChannelRef` carries a resolved channel id (sprint plan Q4): the parser
-/// looks the symbol up in the [`beast_channels::ChannelRegistry`] at load
-/// time and rejects unknown symbols early. Evaluator therefore does not need
-/// the registry — it walks the AST over a pre-indexed channel-value vector.
-#[derive(Debug, Clone)]
-pub enum Expr {
-    /// A literal Q32.32 value.
-    Literal(Q3232),
-    /// Reference to a channel value by resolved id.
-    ChannelRef(String),
-    /// Binary addition.
-    Add(Box<Expr>, Box<Expr>),
-    /// Binary multiplication.
-    Mul(Box<Expr>, Box<Expr>),
-}
+use super::ast::{CompiledExpr, ExprNode};
+use super::literal::{parse_q3232_literal, strip_underscores};
 
-/// Parse a parameter-mapping expression source string into an [`Expr`].
+/// Parse a parameter-mapping expression source string into a [`CompiledExpr`].
 ///
 /// # Grammar (minimal operator set — sprint plan Q3)
 ///
@@ -97,9 +64,9 @@ pub enum Expr {
 ///
 /// let _expr = parse_expression("ch[vocal_modulation] * 8", &registry).unwrap();
 /// ```
-pub fn parse_expression(src: &str, registry: &ChannelRegistry) -> Result<Expr> {
+pub fn parse_expression(src: &str, registry: &ChannelRegistry) -> Result<CompiledExpr> {
     let mut parser = Parser::new(src, registry);
-    let expr = parser.parse_expr()?;
+    let node = parser.parse_expr()?;
     parser.skip_whitespace();
     if !parser.at_end() {
         return Err(InterpreterError::ParseError {
@@ -110,54 +77,7 @@ pub fn parse_expression(src: &str, registry: &ChannelRegistry) -> Result<Expr> {
             ),
         });
     }
-    Ok(expr)
-}
-
-/// Evaluate a parsed expression against per-channel global values.
-///
-/// Returns [`Q3232::ZERO`] for any channel id not present in
-/// `channel_values` — this matches the "dormant channels propagate zero"
-/// rule from §6.2. Addition and multiplication use [`Q3232`] saturating
-/// arithmetic, so overflow clamps to [`Q3232::MAX`] / [`Q3232::MIN`] rather
-/// than panicking or wrapping.
-///
-/// This function is pure: the output is entirely determined by
-/// `(expr, channel_values)`, satisfying the determinism invariant
-/// (INVARIANTS §1).
-#[must_use]
-pub fn eval_expression(expr: &Expr, channel_values: &BTreeMap<String, Q3232>) -> Q3232 {
-    match expr {
-        Expr::Literal(v) => *v,
-        Expr::ChannelRef(id) => channel_values.get(id).copied().unwrap_or(Q3232::ZERO),
-        Expr::Add(lhs, rhs) => eval_expression(lhs, channel_values)
-            .saturating_add(eval_expression(rhs, channel_values)),
-        Expr::Mul(lhs, rhs) => eval_expression(lhs, channel_values)
-            .saturating_mul(eval_expression(rhs, channel_values)),
-    }
-}
-
-/// Return every channel id referenced by `expr`, sorted and deduplicated.
-///
-/// Used by the emission path to compose a hook's
-/// [`beast_primitives::PrimitiveEffect::source_channels`] without having to
-/// re-walk the raw manifest source string.
-#[must_use]
-pub fn collect_channel_refs(expr: &Expr) -> Vec<String> {
-    let mut out = std::collections::BTreeSet::new();
-    fn walk(expr: &Expr, out: &mut std::collections::BTreeSet<String>) {
-        match expr {
-            Expr::Literal(_) => {}
-            Expr::ChannelRef(id) => {
-                out.insert(id.clone());
-            }
-            Expr::Add(l, r) | Expr::Mul(l, r) => {
-                walk(l, out);
-                walk(r, out);
-            }
-        }
-    }
-    walk(expr, &mut out);
-    out.into_iter().collect()
+    Ok(CompiledExpr::from_node(node))
 }
 
 // ---------------------------------------------------------------------------
@@ -221,14 +141,14 @@ impl<'src, 'reg> Parser<'src, 'reg> {
     }
 
     /// Parse an `expr` (addition-level).
-    fn parse_expr(&mut self) -> Result<Expr> {
+    fn parse_expr(&mut self) -> Result<ExprNode> {
         let mut lhs = self.parse_term()?;
         loop {
             self.skip_whitespace();
             if self.peek() == Some(b'+') {
                 self.pos += 1;
                 let rhs = self.parse_term()?;
-                lhs = Expr::Add(Box::new(lhs), Box::new(rhs));
+                lhs = ExprNode::Add(Box::new(lhs), Box::new(rhs));
             } else {
                 return Ok(lhs);
             }
@@ -236,14 +156,14 @@ impl<'src, 'reg> Parser<'src, 'reg> {
     }
 
     /// Parse a `term` (multiplication-level).
-    fn parse_term(&mut self) -> Result<Expr> {
+    fn parse_term(&mut self) -> Result<ExprNode> {
         let mut lhs = self.parse_factor()?;
         loop {
             self.skip_whitespace();
             if self.peek() == Some(b'*') {
                 self.pos += 1;
                 let rhs = self.parse_factor()?;
-                lhs = Expr::Mul(Box::new(lhs), Box::new(rhs));
+                lhs = ExprNode::Mul(Box::new(lhs), Box::new(rhs));
             } else {
                 return Ok(lhs);
             }
@@ -251,7 +171,7 @@ impl<'src, 'reg> Parser<'src, 'reg> {
     }
 
     /// Parse a `factor` — literal, channel reference, or parenthesised `expr`.
-    fn parse_factor(&mut self) -> Result<Expr> {
+    fn parse_factor(&mut self) -> Result<ExprNode> {
         self.skip_whitespace();
         match self.peek() {
             None => Err(InterpreterError::ParseError {
@@ -286,7 +206,7 @@ impl<'src, 'reg> Parser<'src, 'reg> {
 
     /// Parse a numeric literal with optional underscore digit separators and
     /// an optional fractional part.
-    fn parse_literal(&mut self) -> Result<Expr> {
+    fn parse_literal(&mut self) -> Result<ExprNode> {
         let start = self.pos;
         // Integer part (required).
         let mut saw_digit = false;
@@ -326,23 +246,19 @@ impl<'src, 'reg> Parser<'src, 'reg> {
             }
         }
         let raw = &self.src[start..self.pos];
-        // Strip underscore separators before parsing. Both the integer and
-        // fractional parsers treat `_` as a separator only — `fixed`'s FromStr
-        // rejects underscores, so we strip here rather than depending on it.
-        let cleaned: String = raw
-            .iter()
-            .filter(|b| **b != b'_')
-            .map(|b| *b as char)
-            .collect();
+        // Integer and fractional parsers treat `_` as a separator only —
+        // `fixed`'s FromStr rejects underscores, so [`strip_underscores`]
+        // normalises first.
+        let cleaned = strip_underscores(raw);
         let value = parse_q3232_literal(&cleaned).ok_or_else(|| InterpreterError::ParseError {
             message: format!("invalid numeric literal `{}`", cleaned),
         })?;
-        Ok(Expr::Literal(value))
+        Ok(ExprNode::Literal(value))
     }
 
     /// Parse a channel reference `ch[<ident>]` and resolve the symbol via
     /// the registry.
-    fn parse_channel_ref(&mut self) -> Result<Expr> {
+    fn parse_channel_ref(&mut self) -> Result<ExprNode> {
         // We already know the next three bytes are `ch[`.
         self.pos += 3;
         let ident_start = self.pos;
@@ -376,83 +292,16 @@ impl<'src, 'reg> Parser<'src, 'reg> {
                 symbol: symbol.to_owned(),
             });
         }
-        Ok(Expr::ChannelRef(symbol.to_owned()))
-    }
-}
-
-/// Parse a dot-decimal ASCII literal (already stripped of `_`) into a
-/// [`Q3232`]. Returns `None` when neither the integer nor the combined
-/// rational representation fit, or when the string is malformed for either
-/// path.
-fn parse_q3232_literal(cleaned: &str) -> Option<Q3232> {
-    if let Some(dot) = cleaned.find('.') {
-        let int_part = &cleaned[..dot];
-        let frac_part = &cleaned[dot + 1..];
-        if frac_part.is_empty() {
-            return None;
-        }
-        // Parse as (numerator / 10^frac_len) in Q32.32 arithmetic so we
-        // avoid floats. Both pieces must fit in `i64`.
-        let int_val: i64 = int_part.parse().ok()?;
-        let frac_val: i64 = frac_part.parse().ok()?;
-        let scale: i64 = 10_i64.checked_pow(u32::try_from(frac_part.len()).ok()?)?;
-        // int_val + frac_val / scale, in Q32.32.
-        let int_q = Q3232::from_num(int_val);
-        let frac_q = Q3232::from_num(frac_val).saturating_div(Q3232::from_num(scale));
-        Some(int_q.saturating_add(frac_q))
-    } else {
-        let int_val: i64 = cleaned.parse().ok()?;
-        Some(Q3232::from_num(int_val))
+        Ok(ExprNode::ChannelRef(symbol.to_owned()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use beast_channels::{
-        BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry, MutationKernel, Provenance,
-        Range, ScaleBand,
-    };
-    use proptest::prelude::*;
-
-    fn manifest(id: &str) -> ChannelManifest {
-        ChannelManifest {
-            id: id.into(),
-            family: ChannelFamily::Sensory,
-            description: "fixture".into(),
-            range: Range {
-                min: Q3232::ZERO,
-                max: Q3232::ONE,
-                units: "dimensionless".into(),
-            },
-            mutation_kernel: MutationKernel {
-                sigma: Q3232::from_num(0.1_f64),
-                bounds_policy: BoundsPolicy::Clamp,
-                genesis_weight: Q3232::ONE,
-                correlation_with: Vec::new(),
-            },
-            composition_hooks: Vec::new(),
-            expression_conditions: Vec::new(),
-            scale_band: ScaleBand {
-                min_kg: Q3232::ZERO,
-                max_kg: Q3232::from_num(1_000_i32),
-            },
-            body_site_applicable: false,
-            provenance: Provenance::Core,
-        }
-    }
-
-    fn registry_with(ids: &[&str]) -> ChannelRegistry {
-        let mut reg = ChannelRegistry::new();
-        for id in ids {
-            reg.register(manifest(id)).expect("unique fixture ids");
-        }
-        reg
-    }
-
-    fn channels(pairs: &[(&str, Q3232)]) -> BTreeMap<String, Q3232> {
-        pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect()
-    }
+    use crate::parameter_map::test_support::registry_with;
+    use beast_channels::ChannelRegistry;
+    use beast_core::Q3232;
 
     // ------- parser happy paths --------------------------------------------
 
@@ -460,8 +309,8 @@ mod tests {
     fn parses_integer_literal() {
         let reg = ChannelRegistry::new();
         let expr = parse_expression("8", &reg).unwrap();
-        match expr {
-            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(8_i32)),
+        match expr.node() {
+            ExprNode::Literal(v) => assert_eq!(*v, Q3232::from_num(8_i32)),
             _ => panic!("expected Literal"),
         }
     }
@@ -470,8 +319,8 @@ mod tests {
     fn parses_fractional_literal() {
         let reg = ChannelRegistry::new();
         let expr = parse_expression("0.5", &reg).unwrap();
-        match expr {
-            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(0.5_f64)),
+        match expr.node() {
+            ExprNode::Literal(v) => assert_eq!(*v, Q3232::from_num(0.5_f64)),
             _ => panic!("expected Literal"),
         }
     }
@@ -480,8 +329,8 @@ mod tests {
     fn parses_underscore_separated_literal() {
         let reg = ChannelRegistry::new();
         let expr = parse_expression("1_000", &reg).unwrap();
-        match expr {
-            Expr::Literal(v) => assert_eq!(v, Q3232::from_num(1_000_i32)),
+        match expr.node() {
+            ExprNode::Literal(v) => assert_eq!(*v, Q3232::from_num(1_000_i32)),
             _ => panic!("expected Literal"),
         }
     }
@@ -490,8 +339,8 @@ mod tests {
     fn parses_channel_reference_when_registered() {
         let reg = registry_with(&["vocal_modulation"]);
         let expr = parse_expression("ch[vocal_modulation]", &reg).unwrap();
-        match expr {
-            Expr::ChannelRef(id) => assert_eq!(id, "vocal_modulation"),
+        match expr.node() {
+            ExprNode::ChannelRef(id) => assert_eq!(id, "vocal_modulation"),
             _ => panic!("expected ChannelRef"),
         }
     }
@@ -501,9 +350,9 @@ mod tests {
         let reg = registry_with(&["a", "b", "c"]);
         let expr = parse_expression("ch[a] + ch[b] + ch[c]", &reg).unwrap();
         // Shape must be ((a + b) + c), not (a + (b + c)).
-        match expr {
-            Expr::Add(lhs, _rhs) => match *lhs {
-                Expr::Add(_, _) => {}
+        match expr.node() {
+            ExprNode::Add(lhs, _rhs) => match lhs.as_ref() {
+                ExprNode::Add(_, _) => {}
                 other => panic!("expected nested Add on lhs, got {other:?}"),
             },
             other => panic!("expected Add, got {other:?}"),
@@ -515,9 +364,9 @@ mod tests {
         let reg = registry_with(&["a", "b"]);
         // a + b * 2 must parse as Add(a, Mul(b, 2)).
         let expr = parse_expression("ch[a] + ch[b] * 2", &reg).unwrap();
-        match expr {
-            Expr::Add(_, rhs) => match *rhs {
-                Expr::Mul(_, _) => {}
+        match expr.node() {
+            ExprNode::Add(_, rhs) => match rhs.as_ref() {
+                ExprNode::Mul(_, _) => {}
                 other => panic!("expected Mul on rhs of Add, got {other:?}"),
             },
             other => panic!("expected Add, got {other:?}"),
@@ -528,9 +377,9 @@ mod tests {
     fn parentheses_override_precedence() {
         let reg = registry_with(&["a", "b"]);
         let expr = parse_expression("(ch[a] + ch[b]) * 2", &reg).unwrap();
-        match expr {
-            Expr::Mul(lhs, _) => match *lhs {
-                Expr::Add(_, _) => {}
+        match expr.node() {
+            ExprNode::Mul(lhs, _) => match lhs.as_ref() {
+                ExprNode::Add(_, _) => {}
                 other => panic!("expected Add inside parens, got {other:?}"),
             },
             other => panic!("expected Mul, got {other:?}"),
@@ -542,9 +391,9 @@ mod tests {
         let reg = registry_with(&["a"]);
         let expr = parse_expression("  ch[a]   *   8  +  0  ", &reg).unwrap();
         // Structure: Add(Mul(ChannelRef, 8), 0)
-        match expr {
-            Expr::Add(lhs, _) => match *lhs {
-                Expr::Mul(_, _) => {}
+        match expr.node() {
+            ExprNode::Add(lhs, _) => match lhs.as_ref() {
+                ExprNode::Mul(_, _) => {}
                 other => panic!("unexpected shape: {other:?}"),
             },
             other => panic!("unexpected shape: {other:?}"),
@@ -606,115 +455,5 @@ mod tests {
             parse_expression("ch[a", &reg),
             Err(InterpreterError::ParseError { .. })
         ));
-    }
-
-    // ------- evaluator -----------------------------------------------------
-
-    #[test]
-    fn evaluates_literal() {
-        let vals = BTreeMap::new();
-        let out = eval_expression(&Expr::Literal(Q3232::from_num(3_i32)), &vals);
-        assert_eq!(out, Q3232::from_num(3_i32));
-    }
-
-    #[test]
-    fn evaluates_channel_ref_present() {
-        let vals = channels(&[("a", Q3232::from_num(5_i32))]);
-        let out = eval_expression(&Expr::ChannelRef("a".into()), &vals);
-        assert_eq!(out, Q3232::from_num(5_i32));
-    }
-
-    #[test]
-    fn evaluates_channel_ref_missing_as_zero() {
-        let vals = BTreeMap::new();
-        let out = eval_expression(&Expr::ChannelRef("missing".into()), &vals);
-        assert_eq!(out, Q3232::ZERO);
-    }
-
-    #[test]
-    fn roundtrip_parse_then_evaluate() {
-        let reg = registry_with(&["a", "b"]);
-        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
-        let vals = channels(&[
-            ("a", Q3232::from_num(0.5_f64)),
-            ("b", Q3232::from_num(2_i32)),
-        ]);
-        // 0.5 * 8 + 2 = 6
-        let out = eval_expression(&expr, &vals);
-        assert_eq!(out, Q3232::from_num(6_i32));
-    }
-
-    #[test]
-    fn roundtrip_same_input_yields_same_output_twice() {
-        let reg = registry_with(&["a", "b"]);
-        let expr = parse_expression("ch[a] * 8 + ch[b]", &reg).unwrap();
-        let vals = channels(&[
-            ("a", Q3232::from_num(0.25_f64)),
-            ("b", Q3232::from_num(1_i32)),
-        ]);
-        let first = eval_expression(&expr, &vals);
-        let second = eval_expression(&expr, &vals);
-        assert_eq!(first, second);
-    }
-
-    #[test]
-    fn saturating_addition_clamps() {
-        let vals = BTreeMap::new();
-        let expr = Expr::Add(
-            Box::new(Expr::Literal(Q3232::MAX)),
-            Box::new(Expr::Literal(Q3232::ONE)),
-        );
-        assert_eq!(eval_expression(&expr, &vals), Q3232::MAX);
-    }
-
-    #[test]
-    fn collect_channel_refs_returns_sorted_unique_ids() {
-        let reg = registry_with(&["alpha", "beta"]);
-        let expr = parse_expression("ch[beta] + ch[alpha] * 2 + ch[beta]", &reg).unwrap();
-        let refs = collect_channel_refs(&expr);
-        assert_eq!(refs, vec!["alpha".to_string(), "beta".to_string()]);
-    }
-
-    // ------- proptest: evaluator purity -----------------------------------
-
-    /// Sample a small, balanced `Expr` AST. We intentionally keep the channel
-    /// alphabet small so the "missing channel → zero" path is exercised.
-    fn arb_expr() -> impl Strategy<Value = Expr> {
-        let leaf = prop_oneof![
-            (-100_000_i64..=100_000_i64).prop_map(|n| Expr::Literal(Q3232::from_num(n))),
-            prop::sample::select(vec!["a", "b", "c", "d", "missing"])
-                .prop_map(|s| Expr::ChannelRef(s.to_string())),
-        ];
-        leaf.prop_recursive(4, 16, 2, |inner| {
-            prop_oneof![
-                (inner.clone(), inner.clone())
-                    .prop_map(|(l, r)| Expr::Add(Box::new(l), Box::new(r))),
-                (inner.clone(), inner).prop_map(|(l, r)| Expr::Mul(Box::new(l), Box::new(r))),
-            ]
-        })
-    }
-
-    proptest! {
-        /// `eval_expression` is a pure function of `(expr, channel_values)`:
-        /// calling it twice on the same inputs always yields the same output.
-        /// Required by INVARIANTS §1 (determinism).
-        #[test]
-        fn eval_is_pure_and_deterministic(
-            expr in arb_expr(),
-            bits_a in any::<i64>(),
-            bits_b in any::<i64>(),
-            bits_c in any::<i64>(),
-            bits_d in any::<i64>(),
-        ) {
-            let vals = channels(&[
-                ("a", Q3232::from_bits(bits_a)),
-                ("b", Q3232::from_bits(bits_b)),
-                ("c", Q3232::from_bits(bits_c)),
-                ("d", Q3232::from_bits(bits_d)),
-            ]);
-            let first = eval_expression(&expr, &vals);
-            let second = eval_expression(&expr, &vals);
-            prop_assert_eq!(first, second);
-        }
     }
 }

--- a/crates/beast-interpreter/src/parameter_map/test_support.rs
+++ b/crates/beast-interpreter/src/parameter_map/test_support.rs
@@ -1,0 +1,52 @@
+//! Shared test fixtures for the `parameter_map` sub-modules.
+//!
+//! Kept here (rather than duplicated across the three child modules) so
+//! the parser, evaluator, and analysis test suites all exercise identical
+//! channel-manifest shapes.
+
+use std::collections::BTreeMap;
+
+use beast_channels::{
+    BoundsPolicy, ChannelFamily, ChannelManifest, ChannelRegistry, MutationKernel, Provenance,
+    Range, ScaleBand,
+};
+use beast_core::Q3232;
+
+pub(crate) fn manifest(id: &str) -> ChannelManifest {
+    ChannelManifest {
+        id: id.into(),
+        family: ChannelFamily::Sensory,
+        description: "fixture".into(),
+        range: Range {
+            min: Q3232::ZERO,
+            max: Q3232::ONE,
+            units: "dimensionless".into(),
+        },
+        mutation_kernel: MutationKernel {
+            sigma: Q3232::from_num(0.1_f64),
+            bounds_policy: BoundsPolicy::Clamp,
+            genesis_weight: Q3232::ONE,
+            correlation_with: Vec::new(),
+        },
+        composition_hooks: Vec::new(),
+        expression_conditions: Vec::new(),
+        scale_band: ScaleBand {
+            min_kg: Q3232::ZERO,
+            max_kg: Q3232::from_num(1_000_i32),
+        },
+        body_site_applicable: false,
+        provenance: Provenance::Core,
+    }
+}
+
+pub(crate) fn registry_with(ids: &[&str]) -> ChannelRegistry {
+    let mut reg = ChannelRegistry::new();
+    for id in ids {
+        reg.register(manifest(id)).expect("unique fixture ids");
+    }
+    reg
+}
+
+pub(crate) fn channels(pairs: &[(&str, Q3232)]) -> BTreeMap<String, Q3232> {
+    pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect()
+}


### PR DESCRIPTION
Closes #76

## Summary

Pure refactor of the `parameter_map` hotspot in `beast-interpreter` — no behavioural change. The ~408-LOC monolith is now a module directory with responsibilities separated along the pipeline boundary (parse → resolve → evaluate).

### Sub-module layout (`crates/beast-interpreter/src/parameter_map/`)

| File              | Total LOC | Production LOC |
|-------------------|-----------|----------------|
| `mod.rs`          | 53        | ~46            |
| `ast.rs`          | 84        | 84             |
| `parser.rs`       | 459       | ~298           |
| `literal.rs`      | 70        | ~45            |
| `eval.rs`         | 163       | ~40            |
| `analysis.rs`     | 48        | ~34            |
| `test_support.rs` | 52        | 52 (cfg-test)  |

`parser.rs` runs ~298 production LOC because the recursive-descent grammar rules are tightly coupled; further splitting would hurt readability, and the issue explicitly forbids swapping the parser (that's #61).

### `CompiledExpr` newtype

`ExprNode` is `pub(crate)` with `pub(crate)` variants. `CompiledExpr { pub(crate) node: ExprNode }` is constructible only via `pub(crate) fn from_node` from the parser, so "channel symbols resolved at parse time" is a compiler-enforced invariant rather than a convention. `pub type Expr = CompiledExpr` keeps downstream callers (`composition.rs`, `emission.rs`, integration tests) compiling unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets --locked` — 335 tests pass (beast-interpreter: 88 unit, +4 literal-helper tests)
- [x] `cargo test --workspace --doc --locked` — pass

## Rust-reviewer verdict

**APPROVE.** 0 CRITICAL / 0 HIGH. One pre-existing LOW observation (unchecked `self.pos + 3` usize add in `parse_factor`) — out of pure-refactor scope; will open a follow-up tracker.

## Out of scope

- New operators (`sqrt`, ranges, `clamp`, `div`, `sub`) — see #61.
- Parser rewrite (pratt / `nom` / `winnow`).