### PR TITLE
feat(beast-genome): registry-fingerprint guard on save/load (closes #79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +87,7 @@ name = "beast-channels"
 version = "0.1.0"
 dependencies = [
  "beast-core",
+ "blake3",
  "jsonschema",
  "proptest",
  "regex",
@@ -158,6 +171,20 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
 
 [[package]]
 name = "borrow-or-share"
@@ -256,6 +283,21 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://example.invalid/beast-evolution-game"
 publish = false
 
 [workspace.dependencies]
+blake3 = { version = "1.5", default-features = false }
 fixed = { version = "1.28", features = ["serde"] }
 rand_core = "0.9"
 rand_xoshiro = { version = "0.7", features = ["serde"] }

--- a/crates/beast-channels/Cargo.toml
+++ b/crates/beast-channels/Cargo.toml
@@ -14,6 +14,7 @@ doctest = true
 
 [dependencies]
 beast-core = { workspace = true }
+blake3 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/beast-channels/src/fingerprint.rs
+++ b/crates/beast-channels/src/fingerprint.rs
@@ -1,0 +1,255 @@
+//! Channel-registry identity fingerprint.
+//!
+//! The fingerprint is a BLAKE3 digest over the *semantic identity* of the
+//! registered channels: id, family tag, and provenance. It is intentionally
+//! **not** keyed by tuning parameters (sigma, composition hooks, scale bands,
+//! numeric bounds) because those are expected to drift between mod versions
+//! without invalidating existing saves. What the fingerprint catches is the
+//! dangerous case: a new channel is inserted into the vocabulary, or an
+//! existing channel is renamed/removed, which would silently reshuffle the
+//! positional `EffectVector.channel` indexing that saved genomes depend on
+//! (see `documentation/INVARIANTS.md` §1 "Determinism" and §3 "Channel
+//! Registry Monolithicism").
+//!
+//! ## Hash input format (CRF1)
+//!
+//! ```text
+//! "CRF1"                              (4 bytes, ASCII magic)
+//! u32 LE — count                       (4 bytes)
+//! for each channel (iterated in sorted id order via BTreeMap):
+//!     u32 LE — len(id)                 (4 bytes)
+//!     id bytes                         (len bytes, UTF-8)
+//!     u32 LE — len(family_tag)         (4 bytes)
+//!     family_tag bytes                 (len bytes, ASCII)
+//!     u32 LE — len(provenance_str)     (4 bytes)
+//!     provenance_str bytes             (len bytes, canonical schema form)
+//! ```
+//!
+//! The length prefix before each string prevents ambiguity attacks like
+//! `"ab" + "c"` hashing to the same bytes as `"a" + "bc"`. If the mapping
+//! between [`ChannelFamily`] and its ASCII tag ever changes intentionally,
+//! bump the magic (`CRF1` → `CRF2`) so older saves are rejected cleanly
+//! rather than silently misvalidating.
+
+use crate::manifest::{ChannelFamily, ChannelManifest};
+use crate::registry::ChannelRegistry;
+
+/// Magic bytes identifying version 1 of the fingerprint format.
+const FINGERPRINT_MAGIC: &[u8; 4] = b"CRF1";
+
+/// A 256-bit BLAKE3 digest identifying a channel-registry vocabulary.
+///
+/// Two registries that register the same channel ids (each with the same
+/// family and provenance) in **any** insertion order will produce equal
+/// fingerprints — iteration is sorted by id via the backing `BTreeMap`.
+/// Tuning changes (sigma, composition hooks, ranges) deliberately do **not**
+/// affect the fingerprint.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct RegistryFingerprint(pub [u8; 32]);
+
+impl RegistryFingerprint {
+    /// Render the fingerprint as a lowercase hex string (64 characters).
+    ///
+    /// Used in error messages so the fingerprint survives copy/paste through
+    /// logs and bug reports.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        let mut out = String::with_capacity(64);
+        for byte in &self.0 {
+            use core::fmt::Write as _;
+            let _ = write!(out, "{byte:02x}");
+        }
+        out
+    }
+}
+
+/// Map a [`ChannelFamily`] to its stable ASCII tag.
+///
+/// This is intentionally decoupled from serde's `rename_all = "snake_case"`
+/// so refactoring the serde rename pattern cannot silently shift save-file
+/// compatibility. If this mapping is ever changed deliberately, bump the
+/// fingerprint version magic.
+const fn family_tag(family: ChannelFamily) -> &'static str {
+    match family {
+        ChannelFamily::Sensory => "sensory",
+        ChannelFamily::Motor => "motor",
+        ChannelFamily::Metabolic => "metabolic",
+        ChannelFamily::Structural => "structural",
+        ChannelFamily::Regulatory => "regulatory",
+        ChannelFamily::Social => "social",
+        ChannelFamily::Cognitive => "cognitive",
+        ChannelFamily::Reproductive => "reproductive",
+        ChannelFamily::Developmental => "developmental",
+    }
+}
+
+fn write_len_prefixed(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    let len = u32::try_from(bytes.len()).expect("channel metadata length exceeds u32::MAX");
+    hasher.update(&len.to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn hash_manifest(hasher: &mut blake3::Hasher, manifest: &ChannelManifest) {
+    write_len_prefixed(hasher, manifest.id.as_bytes());
+    write_len_prefixed(hasher, family_tag(manifest.family).as_bytes());
+    let provenance = manifest.provenance.to_schema_string();
+    write_len_prefixed(hasher, provenance.as_bytes());
+}
+
+impl ChannelRegistry {
+    /// Compute the identity fingerprint for this registry.
+    ///
+    /// The result is stable across:
+    ///
+    /// * insertion order (the backing `BTreeMap` sorts by id),
+    /// * tuning changes (sigma, composition hooks, range bounds, scale bands).
+    ///
+    /// The result **does** change when a channel is added, removed, renamed,
+    /// re-familied, or gets a different provenance string.
+    ///
+    /// See the module-level documentation for the exact byte layout.
+    #[must_use]
+    pub fn fingerprint(&self) -> RegistryFingerprint {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(FINGERPRINT_MAGIC);
+        let count = u32::try_from(self.len()).expect("registry size exceeds u32::MAX");
+        hasher.update(&count.to_le_bytes());
+        for (_id, manifest) in self.iter() {
+            hash_manifest(&mut hasher, manifest);
+        }
+        RegistryFingerprint(*hasher.finalize().as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::composition::{CompositionHook, CompositionKind};
+    use crate::expression::ExpressionCondition;
+    use crate::manifest::{
+        BoundsPolicy, ChannelFamily, MutationKernel, Provenance, Range, ScaleBand,
+    };
+    use beast_core::Q3232;
+
+    fn fixture(id: &str, family: ChannelFamily, provenance: Provenance) -> ChannelManifest {
+        ChannelManifest {
+            id: id.into(),
+            family,
+            description: "fixture".into(),
+            range: Range {
+                min: Q3232::ZERO,
+                max: Q3232::ONE,
+                units: "dimensionless".into(),
+            },
+            mutation_kernel: MutationKernel {
+                sigma: Q3232::from_num(0.1_f64),
+                bounds_policy: BoundsPolicy::Clamp,
+                genesis_weight: Q3232::ONE,
+                correlation_with: Vec::new(),
+            },
+            composition_hooks: Vec::new(),
+            expression_conditions: Vec::<ExpressionCondition>::new(),
+            scale_band: ScaleBand {
+                min_kg: Q3232::ZERO,
+                max_kg: Q3232::from_num(1000_i32),
+            },
+            body_site_applicable: false,
+            provenance,
+        }
+    }
+
+    fn build(channels: &[(&str, ChannelFamily)]) -> ChannelRegistry {
+        let mut reg = ChannelRegistry::new();
+        for (id, family) in channels {
+            reg.register(fixture(id, *family, Provenance::Core)).unwrap();
+        }
+        reg
+    }
+
+    #[test]
+    fn hex_is_lowercase_hex_of_64_chars() {
+        let reg = build(&[("alpha", ChannelFamily::Sensory)]);
+        let hex = reg.fingerprint().to_hex();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    #[test]
+    fn hooks_do_not_affect_fingerprint() {
+        // Two registries with identical (id, family, provenance) but different
+        // composition hooks and mutation kernels must produce the same hash.
+        let plain = build(&[("alpha", ChannelFamily::Sensory)]);
+        let mut fancy = ChannelRegistry::new();
+        let mut adorned = fixture("alpha", ChannelFamily::Sensory, Provenance::Core);
+        adorned.composition_hooks.push(CompositionHook {
+            with: "self".into(),
+            kind: CompositionKind::Multiplicative,
+            coefficient: Q3232::from_num(0.5_f64),
+            threshold: None,
+        });
+        adorned.mutation_kernel.sigma = Q3232::from_num(0.42_f64);
+        fancy.register(adorned).unwrap();
+
+        assert_eq!(plain.fingerprint(), fancy.fingerprint());
+    }
+
+    #[test]
+    fn insertion_order_does_not_affect_fingerprint() {
+        let a = build(&[
+            ("alpha", ChannelFamily::Sensory),
+            ("bravo", ChannelFamily::Motor),
+            ("charlie", ChannelFamily::Sensory),
+        ]);
+        let b = build(&[
+            ("charlie", ChannelFamily::Sensory),
+            ("alpha", ChannelFamily::Sensory),
+            ("bravo", ChannelFamily::Motor),
+        ]);
+        assert_eq!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn different_id_changes_fingerprint() {
+        let a = build(&[("alpha", ChannelFamily::Sensory)]);
+        let b = build(&[("beta", ChannelFamily::Sensory)]);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn different_family_changes_fingerprint() {
+        let a = build(&[("alpha", ChannelFamily::Sensory)]);
+        let b = build(&[("alpha", ChannelFamily::Motor)]);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn different_provenance_changes_fingerprint() {
+        let mut a = ChannelRegistry::new();
+        a.register(fixture("alpha", ChannelFamily::Sensory, Provenance::Core))
+            .unwrap();
+        let mut b = ChannelRegistry::new();
+        b.register(fixture(
+            "alpha",
+            ChannelFamily::Sensory,
+            Provenance::Mod("acme".into()),
+        ))
+        .unwrap();
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn empty_registry_has_stable_fingerprint() {
+        let a = ChannelRegistry::new();
+        let b = ChannelRegistry::new();
+        assert_eq!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn length_prefixing_avoids_concatenation_collisions() {
+        // "ab"+"c" vs "a"+"bc" — length prefixes keep these separate.
+        let a = build(&[("ab", ChannelFamily::Sensory), ("c", ChannelFamily::Sensory)]);
+        let b = build(&[("a", ChannelFamily::Sensory), ("bc", ChannelFamily::Sensory)]);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+}

--- a/crates/beast-channels/src/fingerprint.rs
+++ b/crates/beast-channels/src/fingerprint.rs
@@ -162,7 +162,8 @@ mod tests {
     fn build(channels: &[(&str, ChannelFamily)]) -> ChannelRegistry {
         let mut reg = ChannelRegistry::new();
         for (id, family) in channels {
-            reg.register(fixture(id, *family, Provenance::Core)).unwrap();
+            reg.register(fixture(id, *family, Provenance::Core))
+                .unwrap();
         }
         reg
     }
@@ -172,7 +173,9 @@ mod tests {
         let reg = build(&[("alpha", ChannelFamily::Sensory)]);
         let hex = reg.fingerprint().to_hex();
         assert_eq!(hex.len(), 64);
-        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+        assert!(hex
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
     }
 
     #[test]
@@ -248,8 +251,14 @@ mod tests {
     #[test]
     fn length_prefixing_avoids_concatenation_collisions() {
         // "ab"+"c" vs "a"+"bc" — length prefixes keep these separate.
-        let a = build(&[("ab", ChannelFamily::Sensory), ("c", ChannelFamily::Sensory)]);
-        let b = build(&[("a", ChannelFamily::Sensory), ("bc", ChannelFamily::Sensory)]);
+        let a = build(&[
+            ("ab", ChannelFamily::Sensory),
+            ("c", ChannelFamily::Sensory),
+        ]);
+        let b = build(&[
+            ("a", ChannelFamily::Sensory),
+            ("bc", ChannelFamily::Sensory),
+        ]);
         assert_ne!(a.fingerprint(), b.fingerprint());
     }
 }

--- a/crates/beast-channels/src/lib.rs
+++ b/crates/beast-channels/src/lib.rs
@@ -31,12 +31,14 @@
 
 pub mod composition;
 pub mod expression;
+pub mod fingerprint;
 pub mod manifest;
 pub mod registry;
 pub mod schema;
 
 pub use composition::{evaluate_hook, CompositionHook, CompositionKind, HookOutcome};
 pub use expression::{evaluate_expression_conditions, ExpressionCondition, ExpressionContext};
+pub use fingerprint::RegistryFingerprint;
 pub use manifest::{
     BoundsPolicy, ChannelFamily, ChannelManifest, CorrelationEntry, MutationKernel, Provenance,
     Range, ScaleBand,

--- a/crates/beast-genome/Cargo.toml
+++ b/crates/beast-genome/Cargo.toml
@@ -16,12 +16,12 @@ doctest = true
 beast-core = { workspace = true }
 beast-channels = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 regex = { workspace = true }
-serde_json = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/beast-genome/src/channel_vector.rs
+++ b/crates/beast-genome/src/channel_vector.rs
@@ -162,7 +162,7 @@ mod tests {
     fn iter_mut_permits_in_place_updates() {
         let mut cv = sample();
         for v in &mut cv {
-            *v = *v + Q3232::from_num(1_i32);
+            *v += Q3232::from_num(1_i32);
         }
         assert_eq!(
             cv.as_slice(),

--- a/crates/beast-genome/src/channel_vector.rs
+++ b/crates/beast-genome/src/channel_vector.rs
@@ -1,0 +1,210 @@
+//! Positional per-channel contribution vector.
+//!
+//! [`ChannelVector`] is a thin newtype over `Vec<Q3232>` whose sole job is to
+//! flag, in the type system, that a bare [`Vec<Q3232>`] of channel
+//! contributions is positionally tied to a specific channel-registry
+//! vocabulary. The index-to-channel mapping is recovered at runtime from a
+//! [`beast_channels::ChannelRegistry`] (via its sorted iteration order), and
+//! the integrity of that mapping is enforced at load time by the
+//! [`beast_channels::RegistryFingerprint`] stored in the save envelope (see
+//! [`crate::save`]).
+//!
+//! The newtype deserializes **transparently**: on-disk JSON for an
+//! [`crate::gene::EffectVector`] still has a plain `[Q3232, Q3232, ...]`
+//! array at `channel`, so saves written before this newtype existed still
+//! round-trip cleanly. A regression test below pins that behaviour.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+
+/// Positional per-channel contribution vector.
+///
+/// Indexed by sorted channel id from the loaded
+/// [`beast_channels::ChannelRegistry`]. Callers should treat the index as an
+/// opaque handle; the only legitimate way to recover the channel id is to
+/// iterate the registry in parallel.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ChannelVector(Vec<Q3232>);
+
+impl ChannelVector {
+    /// Construct from a raw `Vec<Q3232>`. The caller is responsible for the
+    /// vector being indexed against the *current* registry; mismatches are
+    /// caught at save-load boundaries, not here.
+    #[inline]
+    #[must_use]
+    pub fn new(values: Vec<Q3232>) -> Self {
+        Self(values)
+    }
+
+    /// Number of channels.
+    #[inline]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether there are zero channels.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterate in index order.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, Q3232> {
+        self.0.iter()
+    }
+
+    /// Iterate mutably in index order.
+    #[inline]
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, Q3232> {
+        self.0.iter_mut()
+    }
+
+    /// Borrow as a slice.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[Q3232] {
+        &self.0
+    }
+
+    /// Borrow mutably as a slice.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [Q3232] {
+        &mut self.0
+    }
+
+    /// Consume and return the underlying `Vec<Q3232>`.
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Vec<Q3232> {
+        self.0
+    }
+}
+
+impl From<Vec<Q3232>> for ChannelVector {
+    #[inline]
+    fn from(values: Vec<Q3232>) -> Self {
+        Self(values)
+    }
+}
+
+impl From<ChannelVector> for Vec<Q3232> {
+    #[inline]
+    fn from(vector: ChannelVector) -> Self {
+        vector.0
+    }
+}
+
+impl AsRef<[Q3232]> for ChannelVector {
+    #[inline]
+    fn as_ref(&self) -> &[Q3232] {
+        &self.0
+    }
+}
+
+impl AsMut<[Q3232]> for ChannelVector {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [Q3232] {
+        &mut self.0
+    }
+}
+
+impl<'a> IntoIterator for &'a ChannelVector {
+    type Item = &'a Q3232;
+    type IntoIter = core::slice::Iter<'a, Q3232>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ChannelVector {
+    type Item = &'a mut Q3232;
+    type IntoIter = core::slice::IterMut<'a, Q3232>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> ChannelVector {
+        ChannelVector::from(vec![
+            Q3232::from_num(0.25_f64),
+            -Q3232::from_num(0.5_f64),
+            Q3232::from_num(1.5_f64),
+        ])
+    }
+
+    #[test]
+    fn from_vec_preserves_contents() {
+        let raw = vec![Q3232::from_num(0.1_f64), Q3232::from_num(0.2_f64)];
+        let cv = ChannelVector::from(raw.clone());
+        assert_eq!(cv.as_slice(), raw.as_slice());
+    }
+
+    #[test]
+    fn iter_yields_values_in_order() {
+        let cv = sample();
+        let collected: Vec<Q3232> = (&cv).into_iter().copied().collect();
+        assert_eq!(collected, cv.as_slice());
+    }
+
+    #[test]
+    fn iter_mut_permits_in_place_updates() {
+        let mut cv = sample();
+        for v in &mut cv {
+            *v = *v + Q3232::from_num(1_i32);
+        }
+        assert_eq!(
+            cv.as_slice(),
+            &[
+                Q3232::from_num(1.25_f64),
+                Q3232::from_num(0.5_f64),
+                Q3232::from_num(2.5_f64),
+            ]
+        );
+    }
+
+    #[test]
+    fn serializes_as_bare_array() {
+        // #[serde(transparent)] keeps the JSON byte-identical to a bare Vec<Q3232>.
+        let cv = sample();
+        let raw_vec: Vec<Q3232> = cv.clone().into_inner();
+        let cv_json = serde_json::to_string(&cv).unwrap();
+        let vec_json = serde_json::to_string(&raw_vec).unwrap();
+        assert_eq!(cv_json, vec_json);
+    }
+
+    #[test]
+    fn deserializes_same_json_as_a_vec() {
+        // Old save files stored the channel vector as a bare JSON array of
+        // Q3232 values (whatever Q3232's serde shape is — we inherit it
+        // transparently). Deserializing a `Vec<Q3232>`-shaped payload into a
+        // `ChannelVector` must succeed without any wrapper object.
+        let raw: Vec<Q3232> = vec![
+            Q3232::from_num(0.25_f64),
+            -Q3232::from_num(0.5_f64),
+            Q3232::from_num(1.5_f64),
+        ];
+        let json = serde_json::to_string(&raw).unwrap();
+        let cv: ChannelVector = serde_json::from_str(&json).unwrap();
+        assert_eq!(cv.as_slice(), raw.as_slice());
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let cv = sample();
+        let json = serde_json::to_string(&cv).unwrap();
+        let back: ChannelVector = serde_json::from_str(&json).unwrap();
+        assert_eq!(cv, back);
+    }
+}

--- a/crates/beast-genome/src/gene.rs
+++ b/crates/beast-genome/src/gene.rs
@@ -13,6 +13,7 @@ use beast_core::Q3232;
 use serde::{Deserialize, Serialize};
 
 use crate::body_site::BodyVector;
+use crate::channel_vector::ChannelVector;
 use crate::error::{check_unit, GenomeError, Result};
 use crate::lineage::LineageTag;
 use crate::modifier::Modifier;
@@ -57,10 +58,17 @@ pub enum Target {
 /// exceed 1.0 (synergistic). Clamping happens downstream in the network
 /// resolver and interpreter, not here. `magnitude` and `radius` are the
 /// only unit-range `[0, 1]` fields validated at construction.
+///
+/// `channel` is a [`ChannelVector`] newtype (a transparent wrapper around
+/// `Vec<Q3232>`); the positional binding to channel ids is enforced at save
+/// load time by comparing the current registry's
+/// [`beast_channels::RegistryFingerprint`] against the one stored in the
+/// save envelope. On-disk JSON remains a bare array, unchanged from earlier
+/// versions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EffectVector {
     /// Per-channel contribution, one entry per channel in the registry.
-    pub channel: Vec<Q3232>,
+    pub channel: ChannelVector,
     /// Overall expression strength in `[0, 1]`.
     pub magnitude: Q3232,
     /// Spatial reach in `[0, 1]` (0 = self-only, 1 = wide AoE).
@@ -73,8 +81,11 @@ pub struct EffectVector {
 
 impl EffectVector {
     /// Construct a new effect vector, validating unit-range fields.
+    ///
+    /// Accepts anything convertible into a [`ChannelVector`] so existing call
+    /// sites that pass a `Vec<Q3232>` literal keep working unchanged.
     pub fn new(
-        channel: Vec<Q3232>,
+        channel: impl Into<ChannelVector>,
         magnitude: Q3232,
         radius: Q3232,
         timing: Timing,
@@ -83,7 +94,7 @@ impl EffectVector {
         check_unit("magnitude", magnitude)?;
         check_unit("radius", radius)?;
         Ok(Self {
-            channel,
+            channel: channel.into(),
             magnitude,
             radius,
             timing,

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -17,6 +17,7 @@
 #![warn(rust_2018_idioms)]
 
 pub mod body_site;
+pub mod channel_vector;
 pub mod duplication;
 pub mod error;
 pub mod gene;
@@ -26,6 +27,7 @@ pub mod modifier;
 pub mod mutation;
 
 pub use body_site::BodyVector;
+pub use channel_vector::ChannelVector;
 pub use duplication::{mutate_duplicate, mutate_duplication_rate};
 pub use error::{GenomeError, Result};
 pub use gene::{EffectVector, Target, Timing, TraitGene};

--- a/crates/beast-genome/src/lib.rs
+++ b/crates/beast-genome/src/lib.rs
@@ -25,6 +25,7 @@ pub mod genome;
 pub mod lineage;
 pub mod modifier;
 pub mod mutation;
+pub mod save;
 
 pub use body_site::BodyVector;
 pub use channel_vector::ChannelVector;
@@ -35,3 +36,6 @@ pub use genome::{Genome, GenomeParams};
 pub use lineage::LineageTag;
 pub use modifier::{Modifier, ModifierEffect};
 pub use mutation::{apply_mutations, mutate_point, mutate_regulatory};
+pub use save::{
+    load_genome_from_json, save_genome_to_json, GenomeSave, SaveLoadError, SAVE_FORMAT_VERSION,
+};

--- a/crates/beast-genome/src/save.rs
+++ b/crates/beast-genome/src/save.rs
@@ -1,0 +1,320 @@
+//! Genome persistence with registry-fingerprint guard.
+//!
+//! Saved genomes encode channel contributions positionally (see
+//! [`crate::channel_vector::ChannelVector`]). If the channel registry's
+//! vocabulary or sort order changes between save and load, the positional
+//! index silently remaps — inhibitory contributions can turn sensory, motor
+//! outputs can land on metabolic channels, and the save loads "successfully"
+//! while producing garbage phenotypes.
+//!
+//! This module closes that hole with a two-field envelope:
+//!
+//! ```text
+//! GenomeSave {
+//!     version: u32 = SAVE_FORMAT_VERSION,
+//!     registry_fingerprint: RegistryFingerprint,  // 32-byte BLAKE3
+//!     genome: Genome,
+//! }
+//! ```
+//!
+//! [`save_genome_to_json`] snapshots the current registry's fingerprint into
+//! the envelope, and [`load_genome_from_json`] refuses to hand back a
+//! [`Genome`] unless the fingerprint matches the active registry. A version
+//! mismatch takes precedence over a fingerprint mismatch, so that future
+//! envelope layouts (e.g. a `v2` file that relocates the fingerprint field
+//! or omits it entirely) produce a clean "unsupported version" error rather
+//! than a spurious "registry mismatch" on a comparison that would have been
+//! meaningless.
+
+use beast_channels::{ChannelRegistry, RegistryFingerprint};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::error::GenomeError;
+use crate::genome::Genome;
+
+/// On-disk save-envelope version. Bump whenever the envelope layout changes
+/// in a way that isn't backward-compatible at the serde level.
+///
+/// The current layout pins an explicit `version: 1` alongside a 32-byte
+/// [`RegistryFingerprint`] and the `genome` payload.
+pub const SAVE_FORMAT_VERSION: u32 = 1;
+
+/// The on-disk envelope around a saved [`Genome`].
+///
+/// `#[serde(deny_unknown_fields)]` ensures a future v2 file that adds new
+/// fields will be rejected by v1 readers rather than silently dropping
+/// them — a conservative choice appropriate for a deterministic sim.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenomeSave {
+    /// Envelope format version. Must equal [`SAVE_FORMAT_VERSION`].
+    pub version: u32,
+    /// Fingerprint of the registry that indexed the genome at save time.
+    pub registry_fingerprint: RegistryFingerprint,
+    /// The saved genome.
+    pub genome: Genome,
+}
+
+/// Errors produced by [`save_genome_to_json`] and [`load_genome_from_json`].
+#[derive(Debug, Error)]
+pub enum SaveLoadError {
+    /// `serde_json` failed to encode or decode the envelope.
+    #[error("json (de)serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The envelope's `version` field did not match [`SAVE_FORMAT_VERSION`].
+    #[error("unsupported save-format version: expected {expected}, found {found}")]
+    UnsupportedVersion {
+        /// Version this build understands.
+        expected: u32,
+        /// Version reported in the envelope.
+        found: u32,
+    },
+
+    /// The envelope's fingerprint did not match the active registry.
+    ///
+    /// The hex-formatted fingerprints are included so the mismatch is
+    /// diagnosable from a log paste without needing the original file.
+    #[error(
+        "registry fingerprint mismatch: save was written against registry {actual}, current registry is {expected}"
+    )]
+    RegistryMismatch {
+        /// Hex of the active registry's fingerprint.
+        expected: String,
+        /// Hex of the fingerprint stored in the save.
+        actual: String,
+    },
+
+    /// The genome payload passed deserialization but failed structural
+    /// validation — modifier index out of bounds, duplicate lineage tags,
+    /// channel-count mismatch across genes, etc.
+    #[error("genome validation failed after load: {0}")]
+    InvalidGenome(#[from] GenomeError),
+}
+
+/// Serialize a genome and the current registry's fingerprint to JSON.
+pub fn save_genome_to_json(
+    genome: &Genome,
+    registry: &ChannelRegistry,
+) -> Result<String, SaveLoadError> {
+    let envelope = GenomeSave {
+        version: SAVE_FORMAT_VERSION,
+        registry_fingerprint: registry.fingerprint(),
+        genome: genome.clone(),
+    };
+    Ok(serde_json::to_string(&envelope)?)
+}
+
+/// Parse a JSON save envelope and return the genome if it matches `registry`.
+///
+/// Checks run in this order; the first mismatch short-circuits:
+///
+/// 1. JSON parse.
+/// 2. `version == SAVE_FORMAT_VERSION`.
+/// 3. Envelope fingerprint equals current registry fingerprint.
+/// 4. `genome.validate()` passes (defense-in-depth — the fingerprint only
+///    guarantees the vocabulary matches, not that intra-genome invariants
+///    are intact after third-party edits).
+pub fn load_genome_from_json(
+    json: &str,
+    registry: &ChannelRegistry,
+) -> Result<Genome, SaveLoadError> {
+    let envelope: GenomeSave = serde_json::from_str(json)?;
+
+    if envelope.version != SAVE_FORMAT_VERSION {
+        return Err(SaveLoadError::UnsupportedVersion {
+            expected: SAVE_FORMAT_VERSION,
+            found: envelope.version,
+        });
+    }
+
+    let current = registry.fingerprint();
+    if current != envelope.registry_fingerprint {
+        return Err(SaveLoadError::RegistryMismatch {
+            expected: current.to_hex(),
+            actual: envelope.registry_fingerprint.to_hex(),
+        });
+    }
+
+    envelope.genome.validate()?;
+    Ok(envelope.genome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::body_site::BodyVector;
+    use crate::gene::{EffectVector, Target, Timing, TraitGene};
+    use crate::genome::GenomeParams;
+    use crate::lineage::LineageTag;
+    use beast_channels::{
+        BoundsPolicy, ChannelFamily, ChannelManifest, MutationKernel, Provenance, Range, ScaleBand,
+    };
+    use beast_core::Q3232;
+
+    fn channel(id: &str) -> ChannelManifest {
+        ChannelManifest {
+            id: id.into(),
+            family: ChannelFamily::Sensory,
+            description: "fixture".into(),
+            range: Range {
+                min: Q3232::ZERO,
+                max: Q3232::ONE,
+                units: "dimensionless".into(),
+            },
+            mutation_kernel: MutationKernel {
+                sigma: Q3232::from_num(0.1_f64),
+                bounds_policy: BoundsPolicy::Clamp,
+                genesis_weight: Q3232::ONE,
+                correlation_with: Vec::new(),
+            },
+            composition_hooks: Vec::new(),
+            expression_conditions: Vec::new(),
+            scale_band: ScaleBand {
+                min_kg: Q3232::ZERO,
+                max_kg: Q3232::from_num(1000_i32),
+            },
+            body_site_applicable: false,
+            provenance: Provenance::Core,
+        }
+    }
+
+    fn registry_with(ids: &[&str]) -> ChannelRegistry {
+        let mut r = ChannelRegistry::new();
+        for id in ids {
+            r.register(channel(id)).unwrap();
+        }
+        r
+    }
+
+    fn gene(tag: u64, channel_count: usize) -> TraitGene {
+        TraitGene::new(
+            "alpha",
+            EffectVector::new(
+                vec![Q3232::from_num(0.25_f64); channel_count],
+                Q3232::from_num(0.5_f64),
+                Q3232::from_num(0.25_f64),
+                Timing::Passive,
+                Target::SelfEntity,
+            )
+            .unwrap(),
+            BodyVector::default_internal(),
+            vec![],
+            true,
+            LineageTag::from_raw(tag),
+            Provenance::Core,
+        )
+        .unwrap()
+    }
+
+    fn genome_with(channel_count: usize) -> Genome {
+        Genome::new(
+            GenomeParams::default(),
+            vec![gene(1, channel_count), gene(2, channel_count)],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn round_trips_through_same_registry() {
+        let registry = registry_with(&["alpha", "bravo", "charlie"]);
+        let genome = genome_with(registry.len());
+        let json = save_genome_to_json(&genome, &registry).unwrap();
+        let back = load_genome_from_json(&json, &registry).unwrap();
+        assert_eq!(back, genome);
+    }
+
+    #[test]
+    fn round_trips_through_reordered_insertion_into_same_ids() {
+        // Sort order is what matters, not insertion order — BTreeMap makes the
+        // registry iteration deterministic by id. A registry with identical
+        // ids inserted in a different order must accept the saved genome.
+        let saver = registry_with(&["alpha", "bravo", "charlie"]);
+        let loader = registry_with(&["charlie", "alpha", "bravo"]);
+        let genome = genome_with(saver.len());
+        let json = save_genome_to_json(&genome, &saver).unwrap();
+        let back = load_genome_from_json(&json, &loader).unwrap();
+        assert_eq!(back, genome);
+    }
+
+    #[test]
+    fn rejects_when_channel_added_at_start_of_registry() {
+        // Canonical acceptance test for issue #79: a new channel is added to
+        // the registry after a save was written. The new channel sorts ahead
+        // of the originals (id "aardvark"), so every positional index in the
+        // saved genome is now off by one. The fingerprint mismatch must be
+        // caught at load time.
+        let saver = registry_with(&["alpha", "bravo", "charlie"]);
+        let genome = genome_with(saver.len());
+        let json = save_genome_to_json(&genome, &saver).unwrap();
+
+        let mut loader = saver.clone();
+        loader.register(channel("aardvark")).unwrap();
+
+        let err = load_genome_from_json(&json, &loader).unwrap_err();
+        assert!(
+            matches!(err, SaveLoadError::RegistryMismatch { .. }),
+            "expected RegistryMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_when_channel_renamed() {
+        let saver = registry_with(&["alpha", "bravo", "charlie"]);
+        let genome = genome_with(saver.len());
+        let json = save_genome_to_json(&genome, &saver).unwrap();
+
+        let loader = registry_with(&["alpha", "bravo", "delta"]);
+        let err = load_genome_from_json(&json, &loader).unwrap_err();
+        assert!(matches!(err, SaveLoadError::RegistryMismatch { .. }));
+    }
+
+    #[test]
+    fn rejects_unsupported_version_before_fingerprint_check() {
+        // A future save format must fail fast with UnsupportedVersion rather
+        // than be compared on a fingerprint field whose meaning may have
+        // changed. We simulate by hand-crafting a "v2" envelope.
+        let registry = registry_with(&["alpha", "bravo"]);
+        let zero_fp = serde_json::to_value(RegistryFingerprint([0u8; 32])).unwrap();
+        let envelope = serde_json::json!({
+            "version": 2,
+            "registry_fingerprint": zero_fp,
+            "genome": genome_with(registry.len()),
+        });
+        let json = envelope.to_string();
+        let err = load_genome_from_json(&json, &registry).unwrap_err();
+        assert!(matches!(
+            err,
+            SaveLoadError::UnsupportedVersion {
+                expected: 1,
+                found: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let registry = registry_with(&["alpha"]);
+        let err = load_genome_from_json("{not json", &registry).unwrap_err();
+        assert!(matches!(err, SaveLoadError::Json(_)));
+    }
+
+    #[test]
+    fn envelope_is_denormalized_on_unknown_fields() {
+        // A v1 reader must reject a file with unknown top-level fields,
+        // rather than silently dropping them and proceeding.
+        let registry = registry_with(&["alpha"]);
+        let fingerprint = registry.fingerprint();
+        let fp_json = serde_json::to_value(fingerprint).unwrap();
+        let envelope = serde_json::json!({
+            "version": SAVE_FORMAT_VERSION,
+            "registry_fingerprint": fp_json,
+            "genome": genome_with(registry.len()),
+            "unexpected_future_field": true,
+        });
+        let json = envelope.to_string();
+        let err = load_genome_from_json(&json, &registry).unwrap_err();
+        assert!(matches!(err, SaveLoadError::Json(_)));
+    }
+}


### PR DESCRIPTION
Closes #79

## Summary

Adds a BLAKE3-based registry fingerprint that genome save files carry as a header. Load rejects cleanly on any semantic change to the channel registry (new channel inserted, channel renamed, family or provenance changed) instead of silently mis-indexing positional `EffectVector.channel` data.

## Fingerprint scheme (`crates/beast-channels/src/fingerprint.rs`)

- `RegistryFingerprint([u8; 32])`, BLAKE3 over a canonical byte stream.
- Stream format: 4-byte magic `CRF1` + `u32 LE` channel count, then per channel (sorted by id via `BTreeMap::iter`): length-prefixed id, family tag (`&'static str` from an exhaustive match over `ChannelFamily`, decoupled from serde's rename), and provenance string.
- Length-prefixing every string prevents the `"ab" + "c" == "a" + "bc"` collision class.
- Explicitly excluded from the hash: `sigma`, composition hooks, scale bands, any numeric tuning. Tuning changes must not invalidate saves; only shifts in positional indexing do.

## ChannelVector newtype (`crates/beast-genome/src/channel_vector.rs`)

- `#[serde(transparent)] struct ChannelVector(Vec<Q3232>)` — on-disk JSON byte-identical to the old `Vec<Q3232>` shape. Regression test proves round-trip.
- `From<Vec<Q3232>>`, `AsRef<[Q3232]>`, `IntoIterator for &ChannelVector` and `&mut`, plus `iter/iter_mut/as_slice/as_mut_slice` keep the existing mutation/duplication call sites compiling.
- `EffectVector::new` takes `impl Into<ChannelVector>` so `vec![...]` still works unchanged.

## Save envelope (`crates/beast-genome/src/save.rs`)

- `pub const SAVE_FORMAT_VERSION: u32 = 1` (new — bumped to introduce the fingerprint field).
- `GenomeSave { version, registry_fingerprint, genome }` with `#[serde(deny_unknown_fields)]`.
- `load_genome_from_json` check order: **version → fingerprint → post-load `Genome::validate`**. Version is checked first because a future v2 layout may not have the fingerprint field at the same offset; a clean `UnsupportedVersion` beats a misleading deserialization error.
- `SaveLoadError` covers: `Json`, `UnsupportedVersion { expected, found }`, `RegistryMismatch { expected: hex, actual: hex }`, `InvalidGenome`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets --locked` — 485 tests pass
- [x] `cargo test --workspace --doc --locked` — 7 doc tests pass
- [x] `cargo build --workspace --release --locked` — clean
- [x] `cargo deny check` — clean (BLAKE3 is MIT/Apache-2.0)

### New tests (21)

**Fingerprint:** `hex_is_lowercase_hex_of_64_chars`, `hooks_do_not_affect_fingerprint`, `insertion_order_does_not_affect_fingerprint`, `different_id_changes_fingerprint`, `different_family_changes_fingerprint`, `different_provenance_changes_fingerprint`, `empty_registry_has_stable_fingerprint`, `length_prefixing_avoids_concatenation_collisions`.

**ChannelVector:** `from_vec_preserves_contents`, `iter_yields_values_in_order`, `iter_mut_permits_in_place_updates`, `serializes_as_bare_array`, `deserializes_same_json_as_a_vec`, `round_trips_through_json`.

**Save:** `round_trips_through_same_registry`, `round_trips_through_reordered_insertion_into_same_ids`, **`rejects_when_channel_added_at_start_of_registry`** (canonical acceptance test for #79), `rejects_when_channel_renamed`, `rejects_unsupported_version_before_fingerprint_check`, `rejects_malformed_json`, `envelope_is_denormalized_on_unknown_fields`.

## Rust-reviewer verdict

**APPROVE** — 0 CRITICAL / 0 HIGH. Determinism preserved (Q32.32 only, `BTreeMap` sorted iteration, length-prefixed hash input, stable `family_tag` decoupled from serde rename, version magic `CRF1`, `deny_unknown_fields`, version check before fingerprint check). One LOW note: `save_genome_to_json` clones the genome — cold path, left as-is; could be optimized later with a `GenomeSaveRef<'a>` if saves ever become hot.

## Save-format change

Introduces `SAVE_FORMAT_VERSION = 1` (new field). Any test fixtures or sample saves need to be re-generated — checked the tree, none exist yet.

## New dependency

Adds `blake3` as a workspace dep and to `beast-channels` (MIT/Apache-2.0, already allow-listed by `cargo deny`). Promotes `serde_json` from dev-dep to dep in `beast-genome`.