### PR TITLE
refactor(beast-manifest): extract shared loader/schema/registry infra (#75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,10 +87,9 @@ name = "beast-channels"
 version = "0.1.0"
 dependencies = [
  "beast-core",
+ "beast-manifest",
  "blake3",
- "jsonschema",
  "proptest",
- "regex",
  "serde",
  "serde_json",
  "thiserror",
@@ -138,15 +137,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-manifest"
+version = "0.1.0"
+dependencies = [
+ "jsonschema",
+ "proptest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "beast-primitives"
 version = "0.1.0"
 dependencies = [
  "beast-channels",
  "beast-core",
+ "beast-manifest",
  "fixed",
- "jsonschema",
  "proptest",
- "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/beast-core",
+    "crates/beast-manifest",
     "crates/beast-channels",
     "crates/beast-primitives",
     "crates/beast-genome",
@@ -43,6 +44,7 @@ regex = "1"
 winnow = "0.7"
 
 beast-core = { path = "crates/beast-core" }
+beast-manifest = { path = "crates/beast-manifest" }
 beast-channels = { path = "crates/beast-channels" }
 beast-primitives = { path = "crates/beast-primitives" }
 beast-genome = { path = "crates/beast-genome" }

--- a/crates/beast-channels/src/manifest.rs
+++ b/crates/beast-channels/src/manifest.rs
@@ -16,6 +16,11 @@ use crate::composition::{CompositionHook, CompositionKind};
 use crate::expression::ExpressionCondition;
 use crate::schema::ChannelLoadError;
 
+/// Canonical provenance enum, re-exported from `beast-manifest` so
+/// downstream callers see the same type whether they came in via channels,
+/// primitives, or any future manifest kind.
+pub use beast_manifest::Provenance;
+
 /// Biological family of a channel.
 ///
 /// Determines typical mutation breadth, composition patterns, and expression
@@ -53,90 +58,6 @@ pub enum BoundsPolicy {
     Reflect,
     /// Wrap around the range (periodic).
     Wrap,
-}
-
-/// Origin of a channel. Mirrors the schema's `provenance` discriminated regex.
-///
-/// Serializes as the same canonical string form used in channel manifest
-/// JSON (`"core"`, `"mod:foo"`, `"genesis:foo:123"`). This keeps save files
-/// self-describing and round-trippable without needing a separate enum tag.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Provenance {
-    /// A canonical channel shipped by the core game.
-    Core,
-    /// Registered by a mod with the given snake_case id.
-    Mod(String),
-    /// Duplicated from a parent channel at generation `n`.
-    Genesis {
-        /// Parent channel id.
-        parent: String,
-        /// Generation at which the duplication occurred.
-        generation: u64,
-    },
-}
-
-impl Provenance {
-    /// Render back into the canonical schema string form.
-    #[must_use]
-    pub fn to_schema_string(&self) -> String {
-        match self {
-            Self::Core => "core".to_owned(),
-            Self::Mod(id) => format!("mod:{id}"),
-            Self::Genesis { parent, generation } => format!("genesis:{parent}:{generation}"),
-        }
-    }
-
-    /// Parse a provenance string in the canonical schema form.
-    ///
-    /// The schema's regex (`^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`)
-    /// is enforced by JSON Schema validation inside the manifest loader,
-    /// so this parser assumes the structural shape is well-formed and only
-    /// does the split.
-    pub fn parse(raw: &str) -> Result<Self, ChannelLoadError> {
-        if raw == "core" {
-            return Ok(Self::Core);
-        }
-        if let Some(rest) = raw.strip_prefix("mod:") {
-            return Ok(Self::Mod(rest.to_owned()));
-        }
-        if let Some(rest) = raw.strip_prefix("genesis:") {
-            // rest is `parent_id:generation`.
-            let mut parts = rest.rsplitn(2, ':');
-            let gen_str = parts
-                .next()
-                .ok_or_else(|| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
-            let parent = parts
-                .next()
-                .ok_or_else(|| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
-            let generation: u64 = gen_str
-                .parse()
-                .map_err(|_| ChannelLoadError::InvalidProvenance(raw.to_owned()))?;
-            return Ok(Self::Genesis {
-                parent: parent.to_owned(),
-                generation,
-            });
-        }
-        Err(ChannelLoadError::InvalidProvenance(raw.to_owned()))
-    }
-}
-
-impl Serialize for Provenance {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_schema_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for Provenance {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let raw = String::deserialize(deserializer)?;
-        Self::parse(&raw).map_err(serde::de::Error::custom)
-    }
 }
 
 /// Numeric range with physical units.

--- a/crates/beast-channels/src/registry.rs
+++ b/crates/beast-channels/src/registry.rs
@@ -6,9 +6,14 @@
 //! surface; nothing downstream hardcodes channel ids. The registry is backed
 //! by [`BTreeMap`] so iteration order is deterministic and independent of
 //! hash randomization — a requirement for deterministic replay.
+//!
+//! The deterministic index structure itself lives in
+//! [`beast_manifest::SortedRegistry`]; this type wraps it and layers on the
+//! channel-specific cross-reference validation.
+//!
+//! [`BTreeMap`]: std::collections::BTreeMap
 
-use std::collections::{BTreeMap, BTreeSet};
-
+use beast_manifest::{DuplicateId, SortedRegistry};
 use thiserror::Error;
 
 use crate::manifest::{ChannelFamily, ChannelManifest};
@@ -31,6 +36,22 @@ pub enum RegistryError {
     },
 }
 
+impl From<DuplicateId> for RegistryError {
+    fn from(e: DuplicateId) -> Self {
+        Self::DuplicateId(e.0)
+    }
+}
+
+impl beast_manifest::Manifest for ChannelManifest {
+    type Group = ChannelFamily;
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn group(&self) -> ChannelFamily {
+        self.family
+    }
+}
+
 /// An authoritative in-memory index of channel manifests.
 ///
 /// Clone is cheap-ish (shallow: `BTreeMap` clones are linear in key+value
@@ -40,12 +61,12 @@ pub enum RegistryError {
 /// stay consistent.
 #[derive(Debug, Clone, Default)]
 pub struct ChannelRegistry {
-    by_id: BTreeMap<String, ChannelManifest>,
-    by_family: BTreeMap<ChannelFamily, BTreeSet<String>>,
+    inner: SortedRegistry<ChannelManifest>,
 }
 
 impl ChannelRegistry {
     /// An empty registry.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -55,64 +76,54 @@ impl ChannelRegistry {
     /// Returns an error *before* inserting, so on error the registry is
     /// unchanged (strong exception safety).
     pub fn register(&mut self, manifest: ChannelManifest) -> Result<(), RegistryError> {
-        if self.by_id.contains_key(&manifest.id) {
-            return Err(RegistryError::DuplicateId(manifest.id));
-        }
-        self.by_family
-            .entry(manifest.family)
-            .or_default()
-            .insert(manifest.id.clone());
-        self.by_id.insert(manifest.id.clone(), manifest);
-        Ok(())
+        Ok(self.inner.insert(manifest)?)
     }
 
     /// Number of registered channels.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.by_id.len()
+        self.inner.len()
     }
 
     /// Whether no channels are registered.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.by_id.is_empty()
+        self.inner.is_empty()
     }
 
     /// Check whether the given id is registered.
     #[must_use]
     pub fn contains(&self, id: &str) -> bool {
-        self.by_id.contains_key(id)
+        self.inner.contains(id)
     }
 
     /// Look up a manifest by id.
     #[must_use]
     pub fn get(&self, id: &str) -> Option<&ChannelManifest> {
-        self.by_id.get(id)
+        self.inner.get(id)
     }
 
     /// Iterate manifests in `(id, manifest)` order. Iteration is deterministic
     /// because the backing storage is a [`BTreeMap`].
+    ///
+    /// [`BTreeMap`]: std::collections::BTreeMap
     pub fn iter(&self) -> impl Iterator<Item = (&str, &ChannelManifest)> {
-        self.by_id.iter().map(|(k, v)| (k.as_str(), v))
+        self.inner.iter()
     }
 
     /// Iterate channel ids in sorted order.
     pub fn ids(&self) -> impl Iterator<Item = &str> {
-        self.by_id.keys().map(String::as_str)
+        self.inner.ids()
     }
 
     /// All channel ids belonging to `family`, in sorted order.
     pub fn ids_by_family(&self, family: ChannelFamily) -> impl Iterator<Item = &str> {
-        self.by_family
-            .get(&family)
-            .into_iter()
-            .flat_map(|set| set.iter().map(String::as_str))
+        self.inner.ids_by_group(family)
     }
 
     /// All manifests belonging to `family`, in sorted id order.
     pub fn by_family(&self, family: ChannelFamily) -> impl Iterator<Item = &ChannelManifest> {
-        self.ids_by_family(family)
-            .filter_map(move |id| self.by_id.get(id))
+        self.inner.by_group(family)
     }
 
     /// Verify that every composition hook `with` reference and every
@@ -123,22 +134,22 @@ impl ChannelRegistry {
     /// channel ahead of its children — call this after all core/mod/genesis
     /// manifests are loaded.
     pub fn validate_cross_references(&self) -> Result<(), RegistryError> {
-        for (id, manifest) in &self.by_id {
+        for (id, manifest) in self.inner.iter() {
             for hook in &manifest.composition_hooks {
                 if hook.with == "self" {
                     continue;
                 }
-                if !self.by_id.contains_key(&hook.with) {
+                if !self.inner.contains(&hook.with) {
                     return Err(RegistryError::UnknownReference {
-                        source_id: id.clone(),
+                        source_id: id.to_owned(),
                         target: hook.with.clone(),
                     });
                 }
             }
             for corr in &manifest.mutation_kernel.correlation_with {
-                if !self.by_id.contains_key(&corr.channel) {
+                if !self.inner.contains(&corr.channel) {
                     return Err(RegistryError::UnknownReference {
-                        source_id: id.clone(),
+                        source_id: id.to_owned(),
                         target: corr.channel.clone(),
                     });
                 }

--- a/crates/beast-channels/src/schema.rs
+++ b/crates/beast-channels/src/schema.rs
@@ -9,10 +9,11 @@
 //! Validation is **two-stage**:
 //!
 //! 1. Parse the input as `serde_json::Value` and run the JSON Schema
-//!    validator. This catches shape errors (missing fields, wrong types,
-//!    pattern failures, conditional `if/then` requirements like
-//!    `threshold` being required for `kind ∈ {threshold, gating}`, etc.)
-//!    with well-formed pointer-style paths.
+//!    validator via [`beast_manifest::CompiledSchema`]. This catches shape
+//!    errors (missing fields, wrong types, pattern failures, conditional
+//!    `if/then` requirements like `threshold` being required for
+//!    `kind ∈ {threshold, gating}`, etc.) with well-formed pointer-style
+//!    paths.
 //! 2. Deserialize into [`crate::manifest::ChannelManifest`] and run
 //!    cross-field semantic checks (`range.min <= range.max`, unique
 //!    composition targets, provenance string decomposition).
@@ -23,11 +24,15 @@
 
 use std::sync::OnceLock;
 
-use jsonschema::Validator;
+use beast_manifest::{CompiledSchema, ProvenanceParseError, SchemaLoadError};
 use thiserror::Error;
 
 use crate::composition::CompositionKind;
 use crate::manifest::ChannelManifest;
+
+/// Re-export of the shared violation record — kept here so downstream
+/// callers can continue to `use beast_channels::SchemaViolation`.
+pub use beast_manifest::SchemaViolation;
 
 /// Raw JSON text of the channel manifest schema. Embedded at compile time so
 /// downstream crates need no runtime filesystem access to validate.
@@ -44,7 +49,7 @@ pub enum ChannelLoadError {
     /// JSON Schema validation produced one or more errors. Each entry carries
     /// the failing JSON Pointer path plus a human-readable message, which is
     /// enough to point a mod author at the exact field.
-    #[error("manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    #[error("manifest failed schema validation:\n{}", beast_manifest::format_schema_errors(.0))]
     SchemaViolation(Vec<SchemaViolation>),
 
     /// Deserialization into the typed manifest struct failed after schema
@@ -90,42 +95,24 @@ pub enum ChannelLoadError {
     },
 }
 
-/// A single JSON Schema validation error, flattened to a simple path+message
-/// pair so callers don't need to depend on `jsonschema` types.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SchemaViolation {
-    /// JSON Pointer path to the failing node (e.g. `/composition_hooks/0/threshold`).
-    pub pointer: String,
-    /// Human-readable message from the validator.
-    pub message: String,
-}
-
-fn format_schema_errors(errors: &[SchemaViolation]) -> String {
-    let mut out = String::new();
-    for e in errors {
-        out.push_str("  at ");
-        out.push_str(if e.pointer.is_empty() {
-            "<root>"
-        } else {
-            e.pointer.as_str()
-        });
-        out.push_str(": ");
-        out.push_str(&e.message);
-        out.push('\n');
+impl From<SchemaLoadError> for ChannelLoadError {
+    fn from(e: SchemaLoadError) -> Self {
+        match e {
+            SchemaLoadError::InvalidJson(s) => Self::InvalidJson(s),
+            SchemaLoadError::SchemaViolation(v) => Self::SchemaViolation(v),
+        }
     }
-    out
 }
 
-fn compiled_schema() -> &'static Validator {
-    static SCHEMA: OnceLock<Validator> = OnceLock::new();
-    SCHEMA.get_or_init(|| {
-        let raw: serde_json::Value = serde_json::from_str(CHANNEL_MANIFEST_SCHEMA)
-            .expect("embedded channel manifest schema is valid JSON");
-        // `jsonschema::validator_for` auto-selects the draft from the schema's
-        // `$schema` URI — our files declare Draft 2020-12, which this crate
-        // natively supports.
-        jsonschema::validator_for(&raw).expect("embedded channel manifest schema compiles")
-    })
+impl From<ProvenanceParseError> for ChannelLoadError {
+    fn from(e: ProvenanceParseError) -> Self {
+        Self::InvalidProvenance(e.0)
+    }
+}
+
+fn compiled_schema() -> &'static CompiledSchema {
+    static SCHEMA: OnceLock<CompiledSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| CompiledSchema::compile(CHANNEL_MANIFEST_SCHEMA))
 }
 
 /// Load and fully validate a channel manifest from its JSON source.
@@ -133,21 +120,7 @@ fn compiled_schema() -> &'static Validator {
 /// See [`crate::manifest::ChannelManifest::from_json_str`] for the public
 /// entry point — it forwards here.
 pub fn load_channel_manifest(source: &str) -> Result<ChannelManifest, ChannelLoadError> {
-    let value: serde_json::Value =
-        serde_json::from_str(source).map_err(|e| ChannelLoadError::InvalidJson(e.to_string()))?;
-
-    let schema = compiled_schema();
-    let violations: Vec<SchemaViolation> = schema
-        .iter_errors(&value)
-        .map(|e| SchemaViolation {
-            pointer: e.instance_path().to_string(),
-            message: e.to_string(),
-        })
-        .collect();
-    if !violations.is_empty() {
-        return Err(ChannelLoadError::SchemaViolation(violations));
-    }
-
+    let value = compiled_schema().load(source)?;
     ChannelManifest::from_validated_value(&value)
 }
 

--- a/crates/beast-manifest/Cargo.toml
+++ b/crates/beast-manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "beast-channels"
-description = "Channel registry, manifest loading, composition hooks, and expression conditions for the Beast Evolution Game."
+name = "beast-manifest"
+description = "Shared manifest-loading infrastructure (JSON Schema validation, provenance parsing, deterministic registries) for the Beast Evolution Game."
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -13,9 +13,7 @@ publish.workspace = true
 doctest = true
 
 [dependencies]
-beast-core = { workspace = true }
-beast-manifest = { workspace = true }
-blake3 = { workspace = true }
+jsonschema = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -25,6 +23,3 @@ proptest = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"
-
-[lints.clippy]
-float_arithmetic = "warn"

--- a/crates/beast-manifest/src/lib.rs
+++ b/crates/beast-manifest/src/lib.rs
@@ -1,0 +1,35 @@
+//! Beast Evolution Game — shared manifest-loading infrastructure (L1).
+//!
+//! Both [`beast-channels`] and [`beast-primitives`] load JSON manifests with
+//! the same two-stage pipeline (JSON Schema validation, then semantic parse
+//! into strong types) and expose the same three supporting primitives:
+//!
+//! * a flattened [`schema::SchemaViolation`] error shape so downstream callers
+//!   don't depend on the `jsonschema` types directly,
+//! * a canonical [`provenance::Provenance`] enum matching the schemas'
+//!   `core | mod:<id> | genesis:<parent>:<n>` discriminator,
+//! * a [`BTreeMap`]-backed [`registry::SortedRegistry`] with a secondary
+//!   index by a domain-specific grouping key.
+//!
+//! Before this crate existed each loader was duplicated verbatim; adding a
+//! new manifest kind meant editing two parallel pipelines. Keeping the shared
+//! infrastructure here removes the change-amplification tax without folding
+//! the domain-specific semantic validation (range-ordering, compatibility
+//! checks, etc.) into a common place — those still live in the consumer
+//! crates.
+//!
+//! [`beast-channels`]: https://docs.rs/beast-channels
+//! [`beast-primitives`]: https://docs.rs/beast-primitives
+//! [`BTreeMap`]: std::collections::BTreeMap
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod provenance;
+pub mod registry;
+pub mod schema;
+
+pub use provenance::{Provenance, ProvenanceParseError};
+pub use registry::{DuplicateId, Manifest, SortedRegistry};
+pub use schema::{format_schema_errors, CompiledSchema, SchemaLoadError, SchemaViolation};

--- a/crates/beast-manifest/src/provenance.rs
+++ b/crates/beast-manifest/src/provenance.rs
@@ -1,0 +1,218 @@
+//! Canonical manifest provenance enum.
+//!
+//! Every manifest JSON document carries a `provenance` field constrained by
+//! the schema regex
+//! `^(core|mod:[a-z_][a-z0-9_]*|genesis:[a-z_][a-z0-9_]*:[0-9]+)$`. The
+//! JSON Schema validator enforces the string shape; this parser assumes a
+//! well-formed input and only does the structural split, so the two checks
+//! stay aligned without re-implementing the regex.
+//!
+//! The enum is used by both `beast-channels` and `beast-primitives`; they
+//! re-export it so downstream crates see a single type regardless of which
+//! manifest they came from.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Error returned by [`Provenance::parse`] when the input does not match one
+/// of the three recognised shapes.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("invalid provenance string: {0}")]
+pub struct ProvenanceParseError(pub String);
+
+/// Origin of a manifest entry. Mirrors the schema's `provenance` regex
+/// discriminator.
+///
+/// Serializes as the canonical string form used in manifest JSON (`"core"`,
+/// `"mod:foo"`, `"genesis:foo:123"`). Keeping the string form canonical
+/// means save files are self-describing and round-trippable without a
+/// separate enum tag.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Provenance {
+    /// A canonical entry shipped by the core game.
+    Core,
+    /// Registered by a mod with the given snake_case id.
+    Mod(String),
+    /// Duplicated / derived from a parent entry at simulation generation
+    /// `generation`.
+    Genesis {
+        /// Parent entry id.
+        parent: String,
+        /// Generation at which the duplication occurred.
+        generation: u64,
+    },
+}
+
+impl Provenance {
+    /// Render back into the canonical schema string form.
+    #[must_use]
+    pub fn to_schema_string(&self) -> String {
+        match self {
+            Self::Core => "core".to_owned(),
+            Self::Mod(id) => format!("mod:{id}"),
+            Self::Genesis { parent, generation } => format!("genesis:{parent}:{generation}"),
+        }
+    }
+
+    /// Parse a provenance string in the canonical schema form.
+    ///
+    /// The schema's regex is enforced by the JSON Schema validator upstream
+    /// of this parser; here we only split the already-structurally-valid
+    /// input. If you call this on an arbitrary string (e.g. from a
+    /// non-schema-validated source), malformed inputs produce
+    /// [`ProvenanceParseError`] rather than silently accepting garbage.
+    pub fn parse(raw: &str) -> Result<Self, ProvenanceParseError> {
+        if raw == "core" {
+            return Ok(Self::Core);
+        }
+        if let Some(rest) = raw.strip_prefix("mod:") {
+            return Ok(Self::Mod(rest.to_owned()));
+        }
+        if let Some(rest) = raw.strip_prefix("genesis:") {
+            // rest is `parent_id:generation` — split from the right because
+            // parent ids themselves are snake_case with no colons.
+            let mut parts = rest.rsplitn(2, ':');
+            let gen_str = parts
+                .next()
+                .ok_or_else(|| ProvenanceParseError(raw.to_owned()))?;
+            let parent = parts
+                .next()
+                .ok_or_else(|| ProvenanceParseError(raw.to_owned()))?;
+            let generation: u64 = gen_str
+                .parse()
+                .map_err(|_| ProvenanceParseError(raw.to_owned()))?;
+            return Ok(Self::Genesis {
+                parent: parent.to_owned(),
+                generation,
+            });
+        }
+        Err(ProvenanceParseError(raw.to_owned()))
+    }
+}
+
+impl Serialize for Provenance {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_schema_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Provenance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn core_parses() {
+        assert_eq!(Provenance::parse("core").unwrap(), Provenance::Core);
+    }
+
+    #[test]
+    fn mod_parses() {
+        assert_eq!(
+            Provenance::parse("mod:my_mod").unwrap(),
+            Provenance::Mod("my_mod".to_owned())
+        );
+    }
+
+    #[test]
+    fn genesis_parses() {
+        assert_eq!(
+            Provenance::parse("genesis:parent_id:12").unwrap(),
+            Provenance::Genesis {
+                parent: "parent_id".to_owned(),
+                generation: 12,
+            }
+        );
+    }
+
+    #[test]
+    fn genesis_missing_generation_rejected() {
+        assert!(Provenance::parse("genesis:parent").is_err());
+    }
+
+    #[test]
+    fn genesis_bad_generation_rejected() {
+        assert!(Provenance::parse("genesis:parent:not_a_number").is_err());
+    }
+
+    #[test]
+    fn unknown_prefix_rejected() {
+        assert!(Provenance::parse("unknown:foo").is_err());
+    }
+
+    #[test]
+    fn schema_string_round_trip_core() {
+        assert_eq!(Provenance::Core.to_schema_string(), "core");
+    }
+
+    #[test]
+    fn schema_string_round_trip_mod() {
+        let p = Provenance::Mod("m".to_owned());
+        assert_eq!(Provenance::parse(&p.to_schema_string()).unwrap(), p);
+    }
+
+    #[test]
+    fn schema_string_round_trip_genesis() {
+        let p = Provenance::Genesis {
+            parent: "parent_x".to_owned(),
+            generation: 4242,
+        };
+        assert_eq!(Provenance::parse(&p.to_schema_string()).unwrap(), p);
+    }
+
+    #[test]
+    fn serde_round_trip_via_json() {
+        for p in [
+            Provenance::Core,
+            Provenance::Mod("m".to_owned()),
+            Provenance::Genesis {
+                parent: "p".to_owned(),
+                generation: 7,
+            },
+        ] {
+            let s = serde_json::to_string(&p).unwrap();
+            let back: Provenance = serde_json::from_str(&s).unwrap();
+            assert_eq!(back, p);
+        }
+    }
+
+    #[test]
+    fn serde_rejects_invalid() {
+        let result: Result<Provenance, _> = serde_json::from_str(r#""bogus""#);
+        assert!(result.is_err());
+    }
+
+    proptest! {
+        // Any schema-conformant `mod:<id>` round-trips through parse.
+        #[test]
+        fn mod_round_trip(id in "[a-z_][a-z0-9_]{0,15}") {
+            let s = format!("mod:{id}");
+            let parsed = Provenance::parse(&s).unwrap();
+            prop_assert_eq!(parsed.to_schema_string(), s);
+        }
+
+        // Any schema-conformant `genesis:<parent>:<n>` round-trips.
+        #[test]
+        fn genesis_round_trip(
+            parent in "[a-z_][a-z0-9_]{0,15}",
+            generation in 0u64..=u64::MAX
+        ) {
+            let s = format!("genesis:{parent}:{generation}");
+            let parsed = Provenance::parse(&s).unwrap();
+            prop_assert_eq!(parsed.to_schema_string(), s);
+        }
+    }
+}

--- a/crates/beast-manifest/src/registry.rs
+++ b/crates/beast-manifest/src/registry.rs
@@ -1,0 +1,233 @@
+//! Deterministic, [`BTreeMap`]-backed registry helpers.
+//!
+//! Channel and primitive registries each expose a primary lookup by id and
+//! a secondary index by a domain-specific grouping key (channel family /
+//! primitive category). The shared [`SortedRegistry`] captures both indices
+//! with iteration that is deterministic by construction — a load-bearing
+//! invariant for replay (`documentation/INVARIANTS.md` §1).
+//!
+//! Domain crates wrap [`SortedRegistry`] rather than re-export it: they keep
+//! their own public type name and add semantic-validation methods that
+//! consult other registries (e.g. primitives validating channel references).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+/// Error returned when [`SortedRegistry::insert`] sees an id already present.
+///
+/// Domain crates wrap this in their own `RegistryError` enum so the public
+/// API can carry additional variants (unknown-reference checks, etc.).
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("duplicate id: {0}")]
+pub struct DuplicateId(pub String);
+
+/// Trait marking a value that can be stored in [`SortedRegistry`].
+///
+/// Implementors expose a unique id and a grouping key used for the
+/// secondary index. [`Self::Group`] must be `Ord + Copy` so the registry
+/// can BTreeMap-index it.
+pub trait Manifest {
+    /// Type of the grouping key (e.g. `ChannelFamily`, `PrimitiveCategory`).
+    type Group: Ord + Copy;
+
+    /// Unique snake_case id used for the primary index.
+    fn id(&self) -> &str;
+
+    /// Grouping key used for the secondary index.
+    fn group(&self) -> Self::Group;
+}
+
+/// A [`BTreeMap`]-backed registry with a primary `id → manifest` index and
+/// a secondary `group → ids` index.
+///
+/// * Iteration is deterministic because `BTreeMap` iterates in sort order
+///   of keys — iteration never depends on hash randomisation.
+/// * [`Self::insert`] is strongly exception-safe: on error the registry is
+///   unchanged.
+/// * Clone is cheap-ish (shallow; scales linearly with count).
+#[derive(Debug, Clone)]
+pub struct SortedRegistry<M: Manifest> {
+    by_id: BTreeMap<String, M>,
+    by_group: BTreeMap<M::Group, BTreeSet<String>>,
+}
+
+impl<M: Manifest> Default for SortedRegistry<M> {
+    fn default() -> Self {
+        Self {
+            by_id: BTreeMap::new(),
+            by_group: BTreeMap::new(),
+        }
+    }
+}
+
+impl<M: Manifest> SortedRegistry<M> {
+    /// An empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a manifest, failing if its id is already registered.
+    ///
+    /// On [`DuplicateId`], the registry is unchanged.
+    pub fn insert(&mut self, manifest: M) -> Result<(), DuplicateId> {
+        if self.by_id.contains_key(manifest.id()) {
+            return Err(DuplicateId(manifest.id().to_owned()));
+        }
+        let id = manifest.id().to_owned();
+        let group = manifest.group();
+        self.by_group.entry(group).or_default().insert(id.clone());
+        self.by_id.insert(id, manifest);
+        Ok(())
+    }
+
+    /// Number of registered manifests.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Whether no manifests are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Whether the given id is registered.
+    #[must_use]
+    pub fn contains(&self, id: &str) -> bool {
+        self.by_id.contains_key(id)
+    }
+
+    /// Look up a manifest by id.
+    #[must_use]
+    pub fn get(&self, id: &str) -> Option<&M> {
+        self.by_id.get(id)
+    }
+
+    /// Iterate `(id, manifest)` pairs in sorted id order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &M)> {
+        self.by_id.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Iterate manifest ids in sorted order.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.by_id.keys().map(String::as_str)
+    }
+
+    /// Iterate ids in the given group, in sorted order. Returns an empty
+    /// iterator if the group has no members.
+    pub fn ids_by_group(&self, group: M::Group) -> impl Iterator<Item = &str> {
+        self.by_group
+            .get(&group)
+            .into_iter()
+            .flat_map(|set| set.iter().map(String::as_str))
+    }
+
+    /// Iterate manifests in the given group, in sorted id order.
+    pub fn by_group(&self, group: M::Group) -> impl Iterator<Item = &M> {
+        self.ids_by_group(group)
+            .filter_map(move |id| self.by_id.get(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    enum Color {
+        Red,
+        Blue,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Item {
+        id: String,
+        color: Color,
+    }
+
+    impl Manifest for Item {
+        type Group = Color;
+        fn id(&self) -> &str {
+            &self.id
+        }
+        fn group(&self) -> Color {
+            self.color
+        }
+    }
+
+    fn item(id: &str, color: Color) -> Item {
+        Item {
+            id: id.to_owned(),
+            color,
+        }
+    }
+
+    #[test]
+    fn insert_is_unique() {
+        let mut reg: SortedRegistry<Item> = SortedRegistry::new();
+        reg.insert(item("a", Color::Red)).unwrap();
+        let err = reg.insert(item("a", Color::Blue)).unwrap_err();
+        assert_eq!(err.0, "a");
+        // Registry is unchanged after error.
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.get("a").unwrap().color, Color::Red);
+    }
+
+    #[test]
+    fn iteration_sorted_by_id() {
+        let mut reg: SortedRegistry<Item> = SortedRegistry::new();
+        for id in ["charlie", "alpha", "bravo"] {
+            reg.insert(item(id, Color::Red)).unwrap();
+        }
+        let ids: Vec<_> = reg.ids().collect();
+        assert_eq!(ids, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn by_group_returns_sorted_members() {
+        let mut reg: SortedRegistry<Item> = SortedRegistry::new();
+        reg.insert(item("b2", Color::Blue)).unwrap();
+        reg.insert(item("r1", Color::Red)).unwrap();
+        reg.insert(item("b1", Color::Blue)).unwrap();
+        let blue: Vec<_> = reg.ids_by_group(Color::Blue).collect();
+        assert_eq!(blue, vec!["b1", "b2"]);
+        let red: Vec<_> = reg.ids_by_group(Color::Red).collect();
+        assert_eq!(red, vec!["r1"]);
+    }
+
+    #[test]
+    fn by_group_for_empty_group_is_empty() {
+        let reg: SortedRegistry<Item> = SortedRegistry::new();
+        let empty: Vec<_> = reg.ids_by_group(Color::Red).collect();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn contains_and_get() {
+        let mut reg: SortedRegistry<Item> = SortedRegistry::new();
+        reg.insert(item("x", Color::Red)).unwrap();
+        assert!(reg.contains("x"));
+        assert!(!reg.contains("y"));
+        assert_eq!(reg.get("x").unwrap().id, "x");
+        assert!(reg.get("y").is_none());
+    }
+
+    #[test]
+    fn iter_yields_pairs() {
+        let mut reg: SortedRegistry<Item> = SortedRegistry::new();
+        reg.insert(item("a", Color::Red)).unwrap();
+        reg.insert(item("b", Color::Blue)).unwrap();
+        let pairs: Vec<_> = reg.iter().map(|(id, m)| (id, m.color)).collect();
+        assert_eq!(pairs, vec![("a", Color::Red), ("b", Color::Blue)]);
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let reg: SortedRegistry<Item> = SortedRegistry::default();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+    }
+}

--- a/crates/beast-manifest/src/schema.rs
+++ b/crates/beast-manifest/src/schema.rs
@@ -1,0 +1,197 @@
+//! JSON Schema validation primitives shared by every manifest loader.
+//!
+//! The [`CompiledSchema`] wrapper owns a `jsonschema::Validator` compiled once
+//! from a static schema string. Call [`CompiledSchema::load`] to run the
+//! two-stage pipeline (parse → validate) and get back a `serde_json::Value`
+//! the caller can then deserialize into a domain type.
+//!
+//! Validation errors are flattened into [`SchemaViolation`] records — a
+//! JSON-Pointer path plus the `jsonschema` message — so downstream error
+//! enums don't have to leak `jsonschema` types into their public API.
+
+use jsonschema::Validator;
+use thiserror::Error;
+
+/// A single JSON Schema validation error, flattened to a simple
+/// `(pointer, message)` pair so callers don't need to depend on `jsonschema`
+/// types directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaViolation {
+    /// JSON Pointer path to the failing node (e.g.
+    /// `/composition_hooks/0/threshold`). Empty string means the root.
+    pub pointer: String,
+    /// Human-readable message from the validator.
+    pub message: String,
+}
+
+/// Format a slice of [`SchemaViolation`] for embedding in error messages.
+///
+/// The output has one line per violation: `  at <pointer>: <message>\n`.
+/// An empty `pointer` is rendered as `<root>`.
+#[must_use]
+pub fn format_schema_errors(errors: &[SchemaViolation]) -> String {
+    let mut out = String::new();
+    for e in errors {
+        out.push_str("  at ");
+        out.push_str(if e.pointer.is_empty() {
+            "<root>"
+        } else {
+            e.pointer.as_str()
+        });
+        out.push_str(": ");
+        out.push_str(&e.message);
+        out.push('\n');
+    }
+    out
+}
+
+/// Errors returned by the generic two-stage load pipeline.
+///
+/// Domain crates wrap this in their own error enum with additional
+/// semantic-validation variants (invalid range ordering, duplicate hook,
+/// etc.). [`From`] is implemented manually by each consumer so the variants
+/// flow through without loss.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SchemaLoadError {
+    /// Input was not parsable as JSON.
+    #[error("manifest is not valid JSON: {0}")]
+    InvalidJson(String),
+
+    /// JSON Schema validation produced one or more errors.
+    #[error("manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    SchemaViolation(Vec<SchemaViolation>),
+}
+
+/// A pre-compiled JSON Schema validator.
+///
+/// Compile once (typically inside a `std::sync::OnceLock`) and reuse for
+/// every manifest load. The wrapper auto-selects the draft from the
+/// schema's `$schema` URI — the schemas in this workspace declare Draft
+/// 2020-12.
+pub struct CompiledSchema {
+    validator: Validator,
+}
+
+impl CompiledSchema {
+    /// Compile the given schema source text.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `schema_source` is not valid JSON or does not compile to a
+    /// valid JSON Schema. Intended for embedded (`include_str!`) schema
+    /// text: a compile failure is a bug in the shipped schema, not a
+    /// runtime condition to recover from.
+    #[must_use]
+    pub fn compile(schema_source: &str) -> Self {
+        let raw: serde_json::Value =
+            serde_json::from_str(schema_source).expect("embedded schema is valid JSON");
+        let validator = jsonschema::validator_for(&raw).expect("embedded schema compiles");
+        Self { validator }
+    }
+
+    /// Collect every validation error for `value`, flattened to
+    /// [`SchemaViolation`].
+    ///
+    /// An empty return value indicates the document passed validation.
+    #[must_use]
+    pub fn validate(&self, value: &serde_json::Value) -> Vec<SchemaViolation> {
+        self.validator
+            .iter_errors(value)
+            .map(|e| SchemaViolation {
+                pointer: e.instance_path().to_string(),
+                message: e.to_string(),
+            })
+            .collect()
+    }
+
+    /// Run the full two-stage load: parse `source` as JSON, then validate
+    /// against the schema.
+    ///
+    /// Returns the parsed `serde_json::Value` on success so the caller can
+    /// run its own semantic layer (typed deserialization, cross-field
+    /// checks, etc.) without reparsing.
+    pub fn load(&self, source: &str) -> Result<serde_json::Value, SchemaLoadError> {
+        let value: serde_json::Value = serde_json::from_str(source)
+            .map_err(|e| SchemaLoadError::InvalidJson(e.to_string()))?;
+        let violations = self.validate(&value);
+        if !violations.is_empty() {
+            return Err(SchemaLoadError::SchemaViolation(violations));
+        }
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINI_SCHEMA: &str = r#"{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["id", "count"],
+        "properties": {
+            "id": { "type": "string", "pattern": "^[a-z_]+$" },
+            "count": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+    }"#;
+
+    #[test]
+    fn compile_accepts_valid_schema() {
+        let _schema = CompiledSchema::compile(MINI_SCHEMA);
+    }
+
+    #[test]
+    fn load_accepts_valid_document() {
+        let schema = CompiledSchema::compile(MINI_SCHEMA);
+        let value = schema.load(r#"{"id": "foo", "count": 3}"#).unwrap();
+        assert_eq!(value["id"], "foo");
+    }
+
+    #[test]
+    fn load_rejects_invalid_json() {
+        let schema = CompiledSchema::compile(MINI_SCHEMA);
+        assert!(matches!(
+            schema.load("not json"),
+            Err(SchemaLoadError::InvalidJson(_))
+        ));
+    }
+
+    #[test]
+    fn load_reports_schema_violations() {
+        let schema = CompiledSchema::compile(MINI_SCHEMA);
+        let err = schema.load(r#"{"id": "UPPER", "count": -1}"#).unwrap_err();
+        match err {
+            SchemaLoadError::SchemaViolation(violations) => {
+                assert!(!violations.is_empty());
+                // Every violation must carry a non-empty message.
+                assert!(violations.iter().all(|v| !v.message.is_empty()));
+            }
+            other => panic!("expected SchemaViolation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn format_schema_errors_renders_root_and_path() {
+        let lines = format_schema_errors(&[
+            SchemaViolation {
+                pointer: String::new(),
+                message: "missing required field".to_owned(),
+            },
+            SchemaViolation {
+                pointer: "/count".to_owned(),
+                message: "must be >= 0".to_owned(),
+            },
+        ]);
+        assert!(lines.contains("  at <root>: missing required field\n"));
+        assert!(lines.contains("  at /count: must be >= 0\n"));
+    }
+
+    #[test]
+    fn validate_reports_empty_when_document_matches() {
+        let schema = CompiledSchema::compile(MINI_SCHEMA);
+        let value: serde_json::Value =
+            serde_json::from_str(r#"{"id": "foo", "count": 0}"#).unwrap();
+        assert!(schema.validate(&value).is_empty());
+    }
+}

--- a/crates/beast-primitives/Cargo.toml
+++ b/crates/beast-primitives/Cargo.toml
@@ -15,12 +15,11 @@ doctest = true
 [dependencies]
 beast-core = { workspace = true }
 beast-channels = { workspace = true }
+beast-manifest = { workspace = true }
 fixed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-jsonschema = { workspace = true }
-regex = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/beast-primitives/src/manifest.rs
+++ b/crates/beast-primitives/src/manifest.rs
@@ -13,50 +13,9 @@ use serde::{Deserialize, Serialize};
 use crate::category::{Modality, PrimitiveCategory};
 use crate::schema::PrimitiveLoadError;
 
-/// Origin of a primitive manifest. Same shape as
-/// [`beast_channels::Provenance`] to keep mod registration symmetric.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Provenance {
-    /// Canonical core primitive.
-    Core,
-    /// Registered by a mod with the given snake_case id.
-    Mod(String),
-    /// Evolved from a parent primitive at generation `n`.
-    Genesis {
-        /// Parent primitive id.
-        parent: String,
-        /// Generation at which the derivation occurred.
-        generation: u64,
-    },
-}
-
-impl Provenance {
-    pub(crate) fn parse(raw: &str) -> Result<Self, PrimitiveLoadError> {
-        if raw == "core" {
-            return Ok(Self::Core);
-        }
-        if let Some(rest) = raw.strip_prefix("mod:") {
-            return Ok(Self::Mod(rest.to_owned()));
-        }
-        if let Some(rest) = raw.strip_prefix("genesis:") {
-            let mut parts = rest.rsplitn(2, ':');
-            let gen_str = parts
-                .next()
-                .ok_or_else(|| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
-            let parent = parts
-                .next()
-                .ok_or_else(|| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
-            let generation: u64 = gen_str
-                .parse()
-                .map_err(|_| PrimitiveLoadError::InvalidProvenance(raw.to_owned()))?;
-            return Ok(Self::Genesis {
-                parent: parent.to_owned(),
-                generation,
-            });
-        }
-        Err(PrimitiveLoadError::InvalidProvenance(raw.to_owned()))
-    }
-}
+/// Canonical provenance enum, re-exported from `beast-manifest` to keep
+/// mod registration symmetric with [`beast_channels::Provenance`].
+pub use beast_manifest::Provenance;
 
 /// Parameter value type in a primitive's input schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/beast-primitives/src/registry.rs
+++ b/crates/beast-primitives/src/registry.rs
@@ -3,9 +3,14 @@
 //! Like [`beast_channels::ChannelRegistry`], the primitive registry is
 //! [`BTreeMap`]-backed so iteration order is stable across runs. Primitives
 //! are indexed primarily by id and secondarily by [`PrimitiveCategory`].
+//!
+//! The deterministic index structure itself lives in
+//! [`beast_manifest::SortedRegistry`]; this type wraps it and layers on the
+//! primitive-specific cross-registry validation against channels.
+//!
+//! [`BTreeMap`]: std::collections::BTreeMap
 
-use std::collections::{BTreeMap, BTreeSet};
-
+use beast_manifest::{DuplicateId, SortedRegistry};
 use thiserror::Error;
 
 use crate::category::PrimitiveCategory;
@@ -31,72 +36,77 @@ pub enum RegistryError {
     },
 }
 
+impl From<DuplicateId> for RegistryError {
+    fn from(e: DuplicateId) -> Self {
+        Self::DuplicateId(e.0)
+    }
+}
+
+impl beast_manifest::Manifest for PrimitiveManifest {
+    type Group = PrimitiveCategory;
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn group(&self) -> PrimitiveCategory {
+        self.category
+    }
+}
+
 /// Deterministic in-memory index of primitive manifests.
 #[derive(Debug, Clone, Default)]
 pub struct PrimitiveRegistry {
-    by_id: BTreeMap<String, PrimitiveManifest>,
-    by_category: BTreeMap<PrimitiveCategory, BTreeSet<String>>,
+    inner: SortedRegistry<PrimitiveManifest>,
 }
 
 impl PrimitiveRegistry {
     /// Empty registry.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Register a manifest; fail if the id is already present.
     pub fn register(&mut self, manifest: PrimitiveManifest) -> Result<(), RegistryError> {
-        if self.by_id.contains_key(&manifest.id) {
-            return Err(RegistryError::DuplicateId(manifest.id));
-        }
-        self.by_category
-            .entry(manifest.category)
-            .or_default()
-            .insert(manifest.id.clone());
-        self.by_id.insert(manifest.id.clone(), manifest);
-        Ok(())
+        Ok(self.inner.insert(manifest)?)
     }
 
     /// Number of registered primitives.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.by_id.len()
+        self.inner.len()
     }
 
     /// Whether no primitives are registered.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.by_id.is_empty()
+        self.inner.is_empty()
     }
 
     /// Whether the given id is registered.
     #[must_use]
     pub fn contains(&self, id: &str) -> bool {
-        self.by_id.contains_key(id)
+        self.inner.contains(id)
     }
 
     /// Look up a manifest by id.
     #[must_use]
     pub fn get(&self, id: &str) -> Option<&PrimitiveManifest> {
-        self.by_id.get(id)
+        self.inner.get(id)
     }
 
     /// Iterate `(id, manifest)` pairs in sorted id order.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &PrimitiveManifest)> {
-        self.by_id.iter().map(|(k, v)| (k.as_str(), v))
+        self.inner.iter()
     }
 
     /// Iterate primitive ids in sorted order.
     pub fn ids(&self) -> impl Iterator<Item = &str> {
-        self.by_id.keys().map(String::as_str)
+        self.inner.ids()
     }
 
     /// All primitive ids in the given category, in sorted order.
     pub fn ids_by_category(&self, category: PrimitiveCategory) -> impl Iterator<Item = &str> {
-        self.by_category
-            .get(&category)
-            .into_iter()
-            .flat_map(|set| set.iter().map(String::as_str))
+        self.inner.ids_by_group(category)
     }
 
     /// All primitives in the given category, in sorted id order.
@@ -104,8 +114,7 @@ impl PrimitiveRegistry {
         &self,
         category: PrimitiveCategory,
     ) -> impl Iterator<Item = &PrimitiveManifest> {
-        self.ids_by_category(category)
-            .filter_map(move |id| self.by_id.get(id))
+        self.inner.by_group(category)
     }
 
     /// Verify that every `composition_compatibility.channel_id` refers to a
@@ -116,12 +125,12 @@ impl PrimitiveRegistry {
         &self,
         channels: &beast_channels::ChannelRegistry,
     ) -> Result<(), RegistryError> {
-        for (id, manifest) in &self.by_id {
+        for (id, manifest) in self.inner.iter() {
             for entry in &manifest.composition_compatibility {
                 if let crate::manifest::CompatibilityEntry::ChannelId(target) = entry {
                     if !channels.contains(target) {
                         return Err(RegistryError::UnknownChannel {
-                            source_id: id.clone(),
+                            source_id: id.to_owned(),
                             target: target.clone(),
                         });
                     }

--- a/crates/beast-primitives/src/schema.rs
+++ b/crates/beast-primitives/src/schema.rs
@@ -8,13 +8,21 @@
 //!    semantic checks (range ordering, defaults matching declared types,
 //!    scaling parameters referring to known input parameters, provenance
 //!    parsing).
+//!
+//! The schema compilation + pointer-flattened validator lives in
+//! [`beast_manifest::CompiledSchema`]; primitive-specific semantic errors
+//! are encoded in [`PrimitiveLoadError`] below.
 
 use std::sync::OnceLock;
 
-use jsonschema::Validator;
+use beast_manifest::{CompiledSchema, ProvenanceParseError, SchemaLoadError};
 use thiserror::Error;
 
 use crate::manifest::PrimitiveManifest;
+
+/// Re-export of the shared violation record — kept here so downstream
+/// callers can continue to `use beast_primitives::SchemaViolation`.
+pub use beast_manifest::SchemaViolation;
 
 /// Raw JSON text of the primitive manifest schema. Embedded at compile time.
 pub const PRIMITIVE_MANIFEST_SCHEMA: &str =
@@ -28,7 +36,7 @@ pub enum PrimitiveLoadError {
     InvalidJson(String),
 
     /// JSON Schema validation produced one or more errors.
-    #[error("manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    #[error("manifest failed schema validation:\n{}", beast_manifest::format_schema_errors(.0))]
     SchemaViolation(Vec<SchemaViolation>),
 
     /// Deserialization into the typed manifest struct failed after schema
@@ -71,59 +79,29 @@ pub enum PrimitiveLoadError {
     },
 }
 
-/// A single JSON Schema validation error, flattened.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SchemaViolation {
-    /// JSON Pointer path to the failing node.
-    pub pointer: String,
-    /// Human-readable message from the validator.
-    pub message: String,
-}
-
-fn format_schema_errors(errors: &[SchemaViolation]) -> String {
-    let mut out = String::new();
-    for e in errors {
-        out.push_str("  at ");
-        out.push_str(if e.pointer.is_empty() {
-            "<root>"
-        } else {
-            e.pointer.as_str()
-        });
-        out.push_str(": ");
-        out.push_str(&e.message);
-        out.push('\n');
+impl From<SchemaLoadError> for PrimitiveLoadError {
+    fn from(e: SchemaLoadError) -> Self {
+        match e {
+            SchemaLoadError::InvalidJson(s) => Self::InvalidJson(s),
+            SchemaLoadError::SchemaViolation(v) => Self::SchemaViolation(v),
+        }
     }
-    out
 }
 
-fn compiled_schema() -> &'static Validator {
-    static SCHEMA: OnceLock<Validator> = OnceLock::new();
-    SCHEMA.get_or_init(|| {
-        let raw: serde_json::Value = serde_json::from_str(PRIMITIVE_MANIFEST_SCHEMA)
-            .expect("embedded primitive manifest schema is valid JSON");
-        // `jsonschema::validator_for` auto-selects the draft from the schema's
-        // `$schema` URI. Our file declares Draft 2020-12.
-        jsonschema::validator_for(&raw).expect("embedded primitive manifest schema compiles")
-    })
+impl From<ProvenanceParseError> for PrimitiveLoadError {
+    fn from(e: ProvenanceParseError) -> Self {
+        Self::InvalidProvenance(e.0)
+    }
+}
+
+fn compiled_schema() -> &'static CompiledSchema {
+    static SCHEMA: OnceLock<CompiledSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| CompiledSchema::compile(PRIMITIVE_MANIFEST_SCHEMA))
 }
 
 /// Load and fully validate a primitive manifest from its JSON source.
 pub fn load_primitive_manifest(source: &str) -> Result<PrimitiveManifest, PrimitiveLoadError> {
-    let value: serde_json::Value =
-        serde_json::from_str(source).map_err(|e| PrimitiveLoadError::InvalidJson(e.to_string()))?;
-
-    let schema = compiled_schema();
-    let violations: Vec<SchemaViolation> = schema
-        .iter_errors(&value)
-        .map(|e| SchemaViolation {
-            pointer: e.instance_path().to_string(),
-            message: e.to_string(),
-        })
-        .collect();
-    if !violations.is_empty() {
-        return Err(PrimitiveLoadError::SchemaViolation(violations));
-    }
-
+    let value = compiled_schema().load(source)?;
     PrimitiveManifest::from_validated_value(&value)
 }
 

--- a/documentation/architecture/CRATE_LAYOUT.md
+++ b/documentation/architecture/CRATE_LAYOUT.md
@@ -68,6 +68,36 @@ pub mod math;              // Gaussian sampling, saturating ops
 
 ## Layer 1: Data Definitions & Genetics
 
+### beast-manifest
+
+**Purpose**: Shared manifest-loading infrastructure reused by every L1 crate
+that loads JSON manifests (channels, primitives, future mod manifest kinds).
+Extracted from `beast-channels` and `beast-primitives` to keep the two-stage
+(schema → semantic) loader in one place.
+
+**Key Types**:
+- `CompiledSchema` (wraps `jsonschema::Validator`, runs the parse+validate
+  stage and returns `serde_json::Value` for semantic parsing)
+- `SchemaViolation` (flattened `{pointer, message}` pair, keeps `jsonschema`
+  types out of downstream public APIs)
+- `SchemaLoadError` (`InvalidJson` / `SchemaViolation`)
+- `Provenance` (canonical `core | mod:<id> | genesis:<parent>:<n>` enum
+  matching the schema regex; re-exported by `beast-channels` and
+  `beast-primitives`)
+- `SortedRegistry<M>` + `Manifest` trait (BTreeMap-backed deterministic
+  registry with `id` and `group` indices)
+
+**Dependencies**: `jsonschema`, `serde`, `serde_json`, `thiserror`
+
+**Modules**:
+```rust
+pub mod schema;            // CompiledSchema, SchemaViolation, SchemaLoadError
+pub mod provenance;        // Provenance, ProvenanceParseError
+pub mod registry;          // SortedRegistry, Manifest, DuplicateId
+```
+
+---
+
 ### beast-channels
 
 **Purpose**: Channel registry, manifest loading, schema validation.
@@ -79,7 +109,7 @@ pub mod math;              // Gaussian sampling, saturating ops
 - `CompositionHook` (rule for multi-channel interaction)
 - `ExpressionConditions` (biome, scale_band, season gates)
 
-**Dependencies**: `beast-core`, `serde_json`, `jsonschema`
+**Dependencies**: `beast-core`, `beast-manifest`, `serde_json`
 
 **Modules**:
 ```rust
@@ -108,7 +138,7 @@ pub fn validate_manifest(manifest: &ChannelManifest, schema: &JsonSchema) -> Res
 - `PrimitiveEffect` (runtime emission: primitive_id, parameters, source_channels)
 - `PrimitiveCategory` (enum: signal_emission, force_application, etc.)
 
-**Dependencies**: `beast-core`, `serde_json`
+**Dependencies**: `beast-core`, `beast-channels`, `beast-manifest`, `serde_json`
 
 **Modules**:
 ```rust


### PR DESCRIPTION
## Summary

Closes #75 — the highest-interest duplication debt in the workspace.

`beast-channels` and `beast-primitives` each reimplemented the same two-stage (JSON Schema validate → semantic parse) manifest loader, `SchemaViolation` formatting, provenance parsing, and BTreeMap-backed deterministic registry. Loader-policy, provenance-rule, and registry-iteration changes had two edit sites.

Extracted the shared pieces into a new L1 `beast-manifest` crate, leaning on the existing workspace `jsonschema` dep rather than adding a new one:

- **`CompiledSchema`** wraps `jsonschema::Validator` with a one-shot `load()` that runs parse → validate and returns a `serde_json::Value` for the consumer's semantic layer.
- **`SchemaViolation`** + **`format_schema_errors`** flatten validator output so downstream error enums don't leak `jsonschema` types (re-exported from both consumer crates for API continuity).
- **`Provenance`** + **`ProvenanceParseError`** unify the `core | mod:<id> | genesis:<parent>:<n>` discriminator; `Serialize`/`Deserialize` impls live here now. Both consumer crates re-export it, so `beast_channels::Provenance` and `beast_primitives::Provenance` continue to resolve to the same canonical enum.
- **`SortedRegistry<M>`** + **`Manifest`** trait captures the `id → manifest` + `group → ids` indexing pattern. `ChannelRegistry` and `PrimitiveRegistry` now wrap it and keep only their domain-specific cross-reference validation.

Each consumer crate drops its direct `jsonschema` + `regex` dependencies (regex wasn't actually used outside `jsonschema`'s internals), picks up `beast-manifest`, and converts domain error enums from `SchemaLoadError` / `ProvenanceParseError` via `From` impls so the existing `?` patterns work unchanged.

**Layering**: `beast-manifest` is a pure L1 sibling crate with no `beast-*` deps; `beast-channels` and `beast-primitives` gain one new L1 dep each and stay within the L1 → L0 rule from `CRATE_LAYOUT.md`. `CRATE_LAYOUT.md` updated to list the new crate.

Diff: +891 / −293 across 16 files. Net-new lines are mostly docs + tests in the shared crate; consumer crates shrank overall.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked` — every pre-existing test in both consumer crates still passes
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo build --workspace --release --locked`
- [x] 26 new unit tests in `beast-manifest` (schema parse/validate, provenance parse / serde / schema-conformant proptest round-trip, registry determinism + duplicate rejection)
- [x] Local quality-metrics check: duplicate rate **4.14%** (threshold 5%), public-API doc coverage **83.86%** (threshold 80%), no new CCN-10 or length-80 violations; `beast-manifest` itself sits at 88.89% public API doc coverage
- [x] `cargo deny check` — not installable locally; will run in CI

## Acceptance criteria ({#75})

- [x] Shared home for common loader/registry code (new L1 `beast-manifest` crate)
- [x] Both crates use shared infrastructure for JSON Schema validation, `SchemaViolation` formatting, provenance parsing, and `BTreeMap`-backed registry helpers
- [x] Existing tests in both crates still pass, unmodified
- [x] `cargo fmt --check` / `cargo clippy -D warnings` clean
- [x] No L1 ↔ L1 cycles (`beast-manifest` has zero `beast-*` dependencies)

---
_Generated by [Claude Code](https://claude.ai/code/session_012snQ3ejZLE6cb9ZZsNvF1p)_