### PR TITLE
feat(beast-primitives/interpreter): first-class body_site + activation_cost on PrimitiveEffect (#67 part 1)

### DIFF
--- a/crates/beast-core/src/body_site.rs
+++ b/crates/beast-core/src/body_site.rs
@@ -1,0 +1,62 @@
+//! Canonical body-site taxonomy.
+//!
+//! A small foundational enum used across layers: `beast_primitives::PrimitiveEffect`
+//! tags emissions with the site they apply to, and `beast_interpreter` uses the
+//! same variants when building per-region phenotype maps. Living in L0 keeps
+//! the type free of both channel and primitive machinery.
+//!
+//! Ordinal order is the deterministic iteration order used by per-site
+//! emission. Do **not** reorder variants without updating fixture tests.
+
+/// Canonical body-site enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BodySite {
+    /// The creature as a whole (global emissions).
+    Global,
+    /// Head.
+    Head,
+    /// Jaw / mouth.
+    Jaw,
+    /// Body core / torso.
+    Core,
+    /// Left limb.
+    LimbLeft,
+    /// Right limb.
+    LimbRight,
+    /// Tail.
+    Tail,
+    /// Generic appendage (antenna, tentacle, etc.).
+    Appendage,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the declared enum order. Per-site aggregation iterates variants
+    /// in this order (see `beast-interpreter::body_map`), so variant
+    /// reordering would silently change output-hash byte order and break
+    /// the determinism gate. This test guards the invariant at the type's
+    /// definition site.
+    #[test]
+    fn variant_order_is_stable() {
+        let ordered = [
+            BodySite::Global,
+            BodySite::Head,
+            BodySite::Jaw,
+            BodySite::Core,
+            BodySite::LimbLeft,
+            BodySite::LimbRight,
+            BodySite::Tail,
+            BodySite::Appendage,
+        ];
+        for pair in ordered.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "{:?} must sort before {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+}

--- a/crates/beast-core/src/lib.rs
+++ b/crates/beast-core/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+pub mod body_site;
 pub mod entity;
 pub mod error;
 pub mod fixed_point;
@@ -29,6 +30,7 @@ pub mod math;
 pub mod prng;
 pub mod time;
 
+pub use body_site::BodySite;
 pub use entity::{EntityId, EntityIdAllocator};
 pub use error::{Error, Result};
 pub use fixed_point::Q3232;

--- a/crates/beast-interpreter/src/emission.rs
+++ b/crates/beast-interpreter/src/emission.rs
@@ -11,14 +11,10 @@
 //!
 //! # Known follow-ups (deliberately deferred past S4.4)
 //!
-//! * **Body-site fanout — [issue #67]**. §6.2B dedups by
-//!   `(primitive_id, body_site)`, but [`beast_primitives::PrimitiveEffect`]
-//!   does not yet carry a `body_site` field. S4.4 therefore dedups flat by
-//!   `primitive_id` only.
-//! * **First-class activation cost — [issue #67]**. Until
-//!   [`beast_primitives::PrimitiveEffect`] gains a dedicated `activation_cost`
-//!   field we surface the evaluated cost via the [`ACTIVATION_COST_PARAM`]
-//!   sentinel parameter below.
+//! * **Body-site fanout — [issue #67]**. `PrimitiveEffect.body_site` is now
+//!   first-class, but emission still produces one global effect per hook
+//!   (fanout into per-region effects for `body_site_applicable` channels
+//!   is the remaining half of #67).
 //! * **Set-valued Union merge — [issue #95]**. `MergeStrategy::Union`
 //!   currently collapses to `Max` because parameter values are scalar
 //!   `Q3232`. When set-valued parameters land, `Union` can implement true
@@ -39,15 +35,6 @@ use crate::error::{InterpreterError, Result};
 use crate::parameter_map::{collect_channel_refs, eval_expression};
 use crate::phenotype::ResolvedPhenotype;
 
-/// Parameter name reserved for the cost output on a [`PrimitiveEffect`].
-///
-/// Until [`beast_primitives::PrimitiveEffect`] gains a first-class
-/// `activation_cost` field (#67 / follow-up), we surface the evaluated cost
-/// inside `parameters` under this key so downstream consumers have access
-/// without a schema break. The leading underscore keeps it visually distinct
-/// from user-declared parameters.
-pub const ACTIVATION_COST_PARAM: &str = "_activation_cost";
-
 /// Build [`PrimitiveEffect`]s from the given fired hooks and merge duplicates.
 ///
 /// For every `(fired_hook, emit_spec)` pair the emitter:
@@ -58,8 +45,8 @@ pub const ACTIVATION_COST_PARAM: &str = "_activation_cost";
 ///    [`InterpreterError::UnknownPrimitive`] when absent.
 /// 3. Computes the activation cost through
 ///    [`beast_primitives::evaluate_cost`] using the evaluated parameters and
-///    stores it under [`ACTIVATION_COST_PARAM`] in the emission's
-///    `parameters` map.
+///    stores it on the emission's first-class
+///    [`activation_cost`](PrimitiveEffect::activation_cost) field.
 /// 4. Builds a [`PrimitiveEffect`] whose
 ///    [`source_channels`](PrimitiveEffect::source_channels) is the sorted,
 ///    deduplicated union of the firing hook's context channels and every
@@ -67,9 +54,9 @@ pub const ACTIVATION_COST_PARAM: &str = "_activation_cost";
 ///
 /// After every effect is built, effects are grouped by `primitive_id` and
 /// merged per §6.2B. Single-effect groups pass through unchanged;
-/// multi-effect groups merge each parameter via `max` (the doc's default)
-/// with the exception of [`ACTIVATION_COST_PARAM`], which sums across the
-/// group.
+/// multi-effect groups apply the manifest's declared merge strategy per
+/// parameter, and sum `activation_cost` across the group (each source hook
+/// incurs its own cost).
 ///
 /// The returned vector is sorted by `primitive_id` (grouped via
 /// [`BTreeMap`]), which gives deterministic output ordering without relying
@@ -154,13 +141,13 @@ fn build_effect(
     // Evaluate the cost against the just-computed parameters. `evaluate_cost`
     // falls back to manifest-declared defaults for any scaling term whose
     // parameter is absent from the map.
-    let cost = evaluate_cost(manifest, &parameters).map_err(|e| InterpreterError::ParseError {
-        message: format!(
-            "cost evaluation for primitive `{}` failed: {e}",
-            emit.primitive_id
-        ),
-    })?;
-    parameters.insert(ACTIVATION_COST_PARAM.to_owned(), cost);
+    let activation_cost =
+        evaluate_cost(manifest, &parameters).map_err(|e| InterpreterError::ParseError {
+            message: format!(
+                "cost evaluation for primitive `{}` failed: {e}",
+                emit.primitive_id
+            ),
+        })?;
 
     // Source channels = hook-context channels ∪ expression-referenced
     // channels, deduplicated and sorted (via `BTreeSet` below).
@@ -168,8 +155,12 @@ fn build_effect(
 
     Ok(PrimitiveEffect {
         primitive_id: emit.primitive_id.clone(),
+        // Fanout for `body_site_applicable` channels is the remaining
+        // half of #67; until then every emission is global.
+        body_site: None,
         source_channels,
         parameters,
+        activation_cost,
         emitter,
         provenance: manifest.provenance.clone(),
     })
@@ -205,20 +196,16 @@ fn collect_source_channels(fired: &FiredHook, emit: &EmitSpec) -> Vec<String> {
 ///
 /// Single-effect groups return the single effect unchanged. Multi-effect
 /// groups collect every parameter's values across the group, then apply
-/// the per-parameter strategy declared on `manifest.merge_strategy` — with
-/// two fixed rules that do not come from the manifest:
+/// the per-parameter strategy declared on `manifest.merge_strategy`.
+/// Parameters absent from that map default to [`MergeStrategy::Max`], the
+/// spec's conservative fallback per §6.2B (line 802).
 ///
-/// * [`ACTIVATION_COST_PARAM`] always sums (each source hook incurs its
-///   own cost; the sentinel parameter is not declared in
-///   `parameter_schema`, so manifests can't override it).
-/// * Parameters absent from `manifest.merge_strategy` default to
-///   [`MergeStrategy::Max`], the spec's conservative fallback per §6.2B
-///   (line 802).
-///
-/// `source_channels` is re-unioned across the group. `emitter` and
-/// `provenance` are copied from the first effect (all group members share
-/// the same emitting entity and the same primitive manifest, hence the same
-/// provenance).
+/// [`activation_cost`](PrimitiveEffect::activation_cost) sums across the
+/// group (each source hook incurs its own cost) and is not declarable on
+/// the manifest. `source_channels` is re-unioned across the group.
+/// `emitter` and `provenance` are copied from the first effect (all group
+/// members share the same emitting entity and the same primitive manifest,
+/// hence the same provenance).
 ///
 /// # Determinism
 ///
@@ -244,16 +231,20 @@ fn merge_group(mut group: Vec<PrimitiveEffect>, manifest: &PrimitiveManifest) ->
     // Carry identity fields from the first effect; group members share
     // them by construction.
     let primitive_id = group[0].primitive_id.clone();
+    let body_site = group[0].body_site;
     let emitter = group[0].emitter;
     let provenance = group[0].provenance.clone();
 
-    // Collect every parameter value across the group before applying any
-    // strategy. Using a `BTreeMap<String, Vec<Q3232>>` keeps both the
-    // outer key iteration and the inner per-key order deterministic
+    // Collect every parameter value and every per-hook activation_cost
+    // across the group before applying any strategy. Using a
+    // `BTreeMap<String, Vec<Q3232>>` for parameters keeps both the outer
+    // key iteration and the inner per-key order deterministic
     // (lexicographic over keys, input-order within each key).
     let mut per_param: BTreeMap<String, Vec<Q3232>> = BTreeMap::new();
     let mut source_set: BTreeSet<String> = BTreeSet::new();
+    let mut activation_cost = Q3232::ZERO;
     for effect in group {
+        activation_cost = activation_cost.saturating_add(effect.activation_cost);
         for ch in effect.source_channels {
             source_set.insert(ch);
         }
@@ -272,8 +263,10 @@ fn merge_group(mut group: Vec<PrimitiveEffect>, manifest: &PrimitiveManifest) ->
 
     PrimitiveEffect {
         primitive_id,
+        body_site,
         source_channels: source_set.into_iter().collect(),
         parameters: merged_params,
+        activation_cost,
         emitter,
         provenance,
     }
@@ -281,16 +274,9 @@ fn merge_group(mut group: Vec<PrimitiveEffect>, manifest: &PrimitiveManifest) ->
 
 /// Resolve the merge strategy for a single parameter.
 ///
-/// * The sentinel [`ACTIVATION_COST_PARAM`] always sums — it is not
-///   declarable via `manifest.merge_strategy` because it is not part of
-///   `parameter_schema`. Callers (mod authors) cannot override this until
-///   activation cost is promoted to a first-class field per issue #67.
-/// * Other parameters consult `manifest.merge_strategy`; an absent key
-///   resolves to [`MergeStrategy::Max`] per §6.2B line 802.
+/// Parameters consult `manifest.merge_strategy`; an absent key resolves to
+/// [`MergeStrategy::Max`] per §6.2B line 802.
 fn strategy_for(param_name: &str, manifest: &PrimitiveManifest) -> MergeStrategy {
-    if param_name == ACTIVATION_COST_PARAM {
-        return MergeStrategy::Sum;
-    }
     manifest
         .merge_strategy
         .get(param_name)
@@ -504,7 +490,7 @@ mod tests {
         // 0.5 * 8 = 4
         assert_eq!(e.parameters["intensity"], Q3232::from_num(4_i32));
         // cost = 1.0 (base only, no scaling term)
-        assert_eq!(e.parameters[ACTIVATION_COST_PARAM], Q3232::from_num(1_i32));
+        assert_eq!(e.activation_cost, Q3232::from_num(1_i32));
         assert_eq!(e.source_channels, vec!["auditory".to_string()]);
     }
 
@@ -558,7 +544,7 @@ mod tests {
         // within a small epsilon rather than bit-exact — the determinism
         // contract is bit-identical reproducibility across runs, which is
         // covered by `same_inputs_produce_identical_outputs_twice` below.
-        let cost = e.parameters[ACTIVATION_COST_PARAM];
+        let cost = e.activation_cost;
         let diff = cost.saturating_sub(Q3232::from_num(3_i32)).saturating_abs();
         assert!(
             diff < Q3232::from_num(0.001_f64),
@@ -601,7 +587,7 @@ mod tests {
         // max(0.3, 0.8) = 0.8
         assert_eq!(e.parameters["intensity"], Q3232::from_num(0.8_f64));
         // cost: base 1.0 per hook, summed = 2.0
-        assert_eq!(e.parameters[ACTIVATION_COST_PARAM], Q3232::from_num(2_i32));
+        assert_eq!(e.activation_cost, Q3232::from_num(2_i32));
         // Source channels unioned from both hooks.
         assert_eq!(e.source_channels, vec!["a".to_string(), "b".to_string()]);
     }
@@ -1074,18 +1060,16 @@ mod tests {
     }
 
     #[test]
-    fn activation_cost_still_sums_regardless_of_declared_strategy() {
-        // `_activation_cost` is a sentinel parameter inserted by
-        // `build_effect` — not something manifests declare in
-        // `parameter_schema`, and not something they can override via
-        // `merge_strategy`. It must continue to sum across the group so
-        // each source hook's cost is accounted for.
+    fn activation_cost_sums_across_the_group_regardless_of_strategy() {
+        // `activation_cost` is a first-class field on `PrimitiveEffect`;
+        // manifests cannot declare a merge strategy for it. It always sums
+        // across the group so each source hook's cost is accounted for,
+        // even when the strategy declared for user parameters is something
+        // else (here `delta` uses `sum` for variety, but the invariant
+        // holds for any strategy).
         let manifest = manifest_with_strategies("cost_fixture", &["delta"], &[("delta", "sum")]);
         let effect = run_two_hook_merge(manifest, "delta", "3", "5");
         // Base cost 1.0 per hook × 2 hooks = 2.0.
-        assert_eq!(
-            effect.parameters[ACTIVATION_COST_PARAM],
-            Q3232::from_num(2_i32)
-        );
+        assert_eq!(effect.activation_cost, Q3232::from_num(2_i32));
     }
 }

--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -55,7 +55,7 @@ pub use body_map::{
 pub use composition::{
     resolve_hooks, CompositionKind, EmitSpec, FiredHook, HookId, InterpreterHook,
 };
-pub use emission::{emit_primitives, ACTIVATION_COST_PARAM};
+pub use emission::emit_primitives;
 pub use error::{InterpreterError, Result};
 pub use expression::filter_hooks_by_affordances;
 pub use interpreter::interpret_phenotype;

--- a/crates/beast-interpreter/src/phenotype.rs
+++ b/crates/beast-interpreter/src/phenotype.rs
@@ -14,28 +14,13 @@ use std::collections::BTreeMap;
 
 use beast_core::{TickCounter, Q3232};
 
-/// Canonical body-site enum. Ordinal order is the deterministic iteration
-/// order used by per-site emission in [`crate::body_map`]. Do **not** reorder
-/// variants without updating fixture tests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum BodySite {
-    /// The creature as a whole (global emissions).
-    Global,
-    /// Head.
-    Head,
-    /// Jaw / mouth.
-    Jaw,
-    /// Body core / torso.
-    Core,
-    /// Left limb.
-    LimbLeft,
-    /// Right limb.
-    LimbRight,
-    /// Tail.
-    Tail,
-    /// Generic appendage (antenna, tentacle, etc.).
-    Appendage,
-}
+/// Canonical body-site taxonomy.
+///
+/// Re-exported from [`beast_core`] so existing `beast_interpreter::phenotype::BodySite`
+/// call sites keep working. The enum itself lives in L0 — see
+/// [`beast_core::BodySite`] for the authoritative definition and ordering
+/// guarantees.
+pub use beast_core::BodySite;
 
 /// Life stage used as an expression-condition gate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/beast-interpreter/tests/determinism.rs
+++ b/crates/beast-interpreter/tests/determinism.rs
@@ -10,8 +10,8 @@
 
 mod common;
 
-use beast_core::EntityId;
-use beast_interpreter::{interpret_phenotype, ACTIVATION_COST_PARAM};
+use beast_core::{EntityId, Q3232};
+use beast_interpreter::interpret_phenotype;
 
 use crate::common::{standard_phenotypes, standard_world};
 
@@ -117,15 +117,22 @@ fn every_effect_has_registered_primitive_id() {
 
 #[test]
 fn activation_cost_is_present_on_every_effect() {
-    // The emitter stores the evaluated cost under the sentinel parameter
-    // (§6.2B workaround until PrimitiveEffect grows a dedicated field — issue
-    // #67). Every emitted effect must carry it.
+    // Activation cost is now a first-class field on `PrimitiveEffect` (#67);
+    // the emitter must populate it non-zero for every emission against the
+    // fixture world.
+    //
+    // The `> Q3232::ZERO` assertion is fixture-specific: every primitive in
+    // `common::standard_world()` declares a positive `base_metabolic_cost`,
+    // so any emission must carry a strictly positive cost. A zero-cost
+    // primitive (none exist in the fixture today) would trip this check
+    // even on a correct emission — add it to the fixture first, or relax
+    // the assertion to `>= Q3232::ZERO`, before introducing one.
     let effects = run_once();
     for per_phenotype in &effects {
         for effect in per_phenotype {
             assert!(
-                effect.parameters.contains_key(ACTIVATION_COST_PARAM),
-                "effect `{}` missing activation cost parameter",
+                effect.activation_cost > Q3232::ZERO,
+                "effect `{}` has zero activation_cost",
                 effect.primitive_id,
             );
         }

--- a/crates/beast-primitives/src/effect.rs
+++ b/crates/beast-primitives/src/effect.rs
@@ -10,7 +10,7 @@
 
 use std::collections::BTreeMap;
 
-use beast_core::{EntityId, Q3232};
+use beast_core::{BodySite, EntityId, Q3232};
 
 use crate::manifest::Provenance;
 
@@ -25,10 +25,27 @@ use crate::manifest::Provenance;
 pub struct PrimitiveEffect {
     /// Primitive manifest id.
     pub primitive_id: String,
+    /// Body site this emission applies to, when the firing hook uses
+    /// `body_site_applicable` channels. `None` means the emission is
+    /// global — it applies to the creature as a whole, not to any single
+    /// anatomical region.
+    ///
+    /// Per the phenotype-interpreter spec (§6.0B / §6.2B) the dedup key
+    /// is `(primitive_id, body_site)`, so the same primitive can be
+    /// emitted concurrently for different sites without collapsing.
+    pub body_site: Option<BodySite>,
     /// Channel ids that composed to produce this emission.
     pub source_channels: Vec<String>,
     /// Parameter values, keyed by parameter name.
     pub parameters: BTreeMap<String, Q3232>,
+    /// Activation cost for this emission, evaluated from the manifest's
+    /// [`crate::CostFunction`] against `parameters` at emission time.
+    ///
+    /// First-class field rather than a `_activation_cost` sentinel key in
+    /// `parameters` — manifests therefore cannot override the merge
+    /// strategy for activation cost, which always sums across hooks that
+    /// emit the same primitive in one tick.
+    pub activation_cost: Q3232,
     /// Entity emitting the effect.
     pub emitter: EntityId,
     /// Origin of the primitive (propagated from the manifest so downstream


### PR DESCRIPTION
Partial progress on #67. Per-site fanout + dedup-by-\`(primitive_id, body_site)\` follow in a companion PR.

## Summary

Three coordinated changes retire the \`_activation_cost\` sentinel and lay the plumbing #67's fanout half will need:

1. **Move \`BodySite\` to L0.** The enum needed to live somewhere \`beast-primitives\` (L1) can reach. Relocating it to \`beast_core::body_site\` (alongside \`EntityId\`, \`Q3232\`) sidesteps an L1→L2 cycle. \`beast_interpreter::phenotype\` now \`pub use\`s it so every existing call site still resolves.
2. **Add two first-class fields to \`PrimitiveEffect\`.** \`body_site: Option<BodySite>\` (None for now — fanout populates Some(site) in PR 2) and \`activation_cost: Q3232\` (evaluated from the manifest \`CostFunction\` at emission time).
3. **Retire \`ACTIVATION_COST_PARAM\`.** \`build_effect\` writes directly to \`activation_cost\` instead of inserting the \`_activation_cost\` sentinel into \`parameters\`. \`merge_group\` sums \`activation_cost\` across the group via a direct \`Q3232::saturating_add\` fold; \`strategy_for\`'s sentinel carve-out is gone.

No behaviour change for existing tests — all emissions still come out global (\`body_site: None\`), activation costs still sum across hooks firing the same primitive.

## Test plan

- [x] Unit — 20 emission tests migrated to \`effect.activation_cost\` reads; all pass.
- [x] Integration — the 1000-run S4.6 determinism gate still passes byte-identical with a first-class-field assertion replacing the sentinel-key assertion (fixture-specificity comment added).
- [x] Unit — \`beast_core::body_site::tests::variant_order_is_stable\` pins the enum ordinal order at the definition site so a future reorder trips here instead of at the downstream determinism gate.
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets --locked\` — interpreter integration at 102, core at 52, workspace all green.
- [x] \`cargo test --workspace --doc --locked\`
- [x] \`cargo build --workspace --release --locked\`
- [x] \`cargo deny check\`
- [x] \`.github/scripts/run-quality-metrics.sh\` — PASS (4.20% duplicates, 83.57% public-API doc coverage — dipped 0.35 pp from master because \`ACTIVATION_COST_PARAM\` was a documented pub const and has been removed; still well above the 80% gate).

## Review

Reviewed by \`rust-reviewer\` before push. Verdict: **Approve**, 2 MEDIUMs (design notes for PR 2, not blockers) + 3 LOWs. Applied:

- Replaced raw HTML \`../../../beast-primitives/...\` doc paths in \`body_site.rs\` with plain crate-name prose (the originals would break if the crate layout shifts).
- Added the \`variant_order_is_stable\` unit test.
- Added a fixture-specificity comment on \`activation_cost_is_present_on_every_effect\` documenting the positive-base-cost assumption.

MEDIUMs carried into PR 2's scope (explicit acknowledgement, not deferred work):
- \`merge_group\` currently groups by \`primitive_id\` and carries \`group[0].body_site\` forward. The PR-2 fanout change must switch the key to \`(primitive_id, body_site)\` before that carry-forward becomes load-bearing.
- \`Option<BodySite>\` (vs \`BodySite::Global\` as a default sentinel) is the right call for PR 1 — \`None\` distinguishes "fanout hasn't run yet" from "explicitly global", which will matter when fanout lands.

## Scope notes

- Two commits split by crate layer: L0 \`BodySite\` relocation, then L1+L2 field promotion.
- Orthogonal to already-merged #70 (source_channels union) and #71 (merge_strategy field). With PR 2 (fanout), umbrella #77 will close.