### PR TITLE
chore: gitignore CI quality-metrics scratch outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ Thumbs.db
 # Build artifacts
 *.pdb
 *.exe
+
+# CI scratch outputs written locally when reproducing the quality-metrics step
+/quality-lizard.txt
+/quality-functions.csv
+/quality-duplicates.txt
+/quality-summary.md


### PR DESCRIPTION
## Summary
- Adds the four `quality-*` scratch files written by the `quality-metrics` CI job to `.gitignore` so they don't show up as untracked locally when reproducing the step.
- Root-anchored (`/quality-...`) to match the existing `/target` convention.

## Test plan
- [x] `git status` stays clean after running the quality-metrics step locally.
- [x] CI unaffected — these files are never committed anyway.

Closes #83