### PR TITLE
docs: fix stale expression_conditions.scale_band references

### DIFF
--- a/documentation/architecture/IMPLEMENTATION_ARCHITECTURE.md
+++ b/documentation/architecture/IMPLEMENTATION_ARCHITECTURE.md
@@ -1466,7 +1466,7 @@ fn is_channel_expressed(
     
     // Scale-band check (CRITICAL for disease)
     let creature_mass_kg = creature.compute_mass_kg();
-    let (min_kg, max_kg) = channel.expression_conditions.scale_band;
+    let (min_kg, max_kg) = channel.scale_band;
     if creature_mass_kg < min_kg || creature_mass_kg > max_kg {
         return false;
     }

--- a/documentation/systems/02_trait_system.md
+++ b/documentation/systems/02_trait_system.md
@@ -141,7 +141,7 @@ Every channel is declared in a **manifest**—a JSON document specifying its ide
 | `composition_hooks[].emits[].parameter_mapping` | object | Map of (primitive_parameter_name → channel expression). Expressions use channel IDs and math operators. |
 | `expression_conditions` | object | Predicates controlling when channel is expressed (active). |
 | `expression_conditions.biome_flags` | list[string] | List of biome tags (e.g., "dark", "aquatic", "cave", "volcanic"); ["any"] means always expressible. |
-| `expression_conditions.scale_band` | [float, float] | [min_body_mass_kg, max_body_mass_kg] where channel is viable. Allows pathogens (grams) and macro-beasts (tons) to share schema. |
+| `scale_band` | object `{ min_kg, max_kg }` (top-level) | Applicable body-mass range. Authoritative, top-level field — not nested under `expression_conditions`. Allows pathogens (grams) and macro-beasts (tons) to share schema. |
 | `expression_conditions.developmental_stages` | list[string] | Stages in which channel can be expressed: ["larval", "juvenile", "adult", "geriatric"] or ["any"] |
 | `expression_conditions.dormant_if_unmet` | bool | If true, channel is present in genome but genetically silent until conditions are met; if false, channel causes developmental mismatch penalty (rare). |
 | `body_site_applicable` | bool | Can this channel vary per body region (limbs, torso, head, tail, etc.)? If false, channel is always global. |
@@ -1093,7 +1093,7 @@ if global_channels["light_absorption"] > 0.8:
 
 ```
 // Wound healing (regulatory family) triggers ability
-// Manifest may gate this by expression_conditions.scale_band: large creatures heal faster (higher metabolic budget)
+// Manifest may gate this by the top-level scale_band field: large creatures heal faster (higher metabolic budget)
 if global_channels["wound_healing"] > 0.3:
     healing_per_tick = base_healing * (1 + global_channels["wound_healing"] * 0.2)
     add_ability("RAPID_HEALING", trigger=Passive, power=healing_per_tick)

--- a/documentation/systems/11_phenotype_interpreter.md
+++ b/documentation/systems/11_phenotype_interpreter.md
@@ -587,25 +587,26 @@ function apply_scale_band_filtering(
     
     for channel_id in channel_registry.active_channels:
         channel_manifest = channel_registry.manifests[channel_id]
-        
-        if channel_manifest.expression_conditions == null:
+
+        if channel_manifest.scale_band == null:
             // No scale_band constraint; expressible at all scales
             continue
-        
-        if channel_manifest.expression_conditions.scale_band != null:
-            min_kg, max_kg = channel_manifest.expression_conditions.scale_band
-            
-            if creature_body_mass_kg < min_kg or creature_body_mass_kg > max_kg:
-                // Creature's mass is outside this channel's valid range
-                filtered_channels[channel_id] = 0.0  // Channel is dormant
-            // else: within range; channel expresses normally
-        
-        // Per-body-site channels: filter each site independently
-        if channel_manifest.body_site_applicable:
+
+        min_kg, max_kg = channel_manifest.scale_band
+        out_of_band = creature_body_mass_kg < min_kg or creature_body_mass_kg > max_kg
+
+        if out_of_band:
+            // Creature's mass is outside this channel's valid range
+            filtered_channels[channel_id] = 0.0  // Channel is dormant
+        // else: within range; channel expresses normally
+
+        // Per-body-site channels: filter each site independently when
+        // out-of-band. Uses the same top-level scale_band bounds — no
+        // per-site scale bands exist in the schema.
+        if channel_manifest.body_site_applicable and out_of_band:
             for body_region in resolved_phenotype.body_map:
-                if creature_body_mass_kg < min_kg or creature_body_mass_kg > max_kg:
-                    body_region.channel_amplitudes[channel_id] = 0.0
-    
+                body_region.channel_amplitudes[channel_id] = 0.0
+
     return filtered_channels
 ```
 
@@ -616,6 +617,8 @@ function apply_scale_band_filtering(
 - **Both scales** (e.g., `metabolic_rate`): scale_band = [1e-15, ∞] kg or no constraint. Active everywhere.
 
 **This stage executes BEFORE Stage 1 (Stat Resolver)** so that dormant channels contribute zero to stat calculations and composition hooks. Filtering is per-channel; body-site channels are filtered per-site-per-channel.
+
+**Authoritative `scale_band` field**: the top-level `ChannelManifest.scale_band` is the only source this stage consults. Any `ExpressionCondition::ScaleBand { min_kg, max_kg }` variants that appear on a composition hook's `expression_conditions` list are *additional runtime gates* evaluated later in Stage 2A (affordance filter) — not a second definition of the channel's scale band.
 
 ### 6.0B. Body-Site Aggregation (Issue #9)
 


### PR DESCRIPTION
## Summary
- `scale_band` is a **top-level** field on `ChannelManifest` (per `documentation/schemas/channel_manifest.schema.json`). Three docs still treated it as a nested field under `expression_conditions`; this PR brings them back in line with the schema and the S4.1 implementation (`beast_interpreter::scale_band::apply_scale_band_filter`).
- Updated: `11_phenotype_interpreter.md` §6.0 pseudocode; `IMPLEMENTATION_ARCHITECTURE.md` §9.x pseudocode; `02_trait_system.md` schema table + narrative comment.
- Adds a clarifying note in §6.0 that `ExpressionCondition::ScaleBand` variants on hooks are *additional runtime gates* evaluated in Stage 2A, not a second source-of-truth for the channel's scale band.

## Test plan
- [x] `rg 'expression_conditions\.scale_band'` over `documentation/` returns no matches.
- [x] Pseudocode now matches the shape the S4.1 implementation actually reads.

Closes #66