### PR TITLE
feat(beast-ecs): S5.1 scaffold crate + EcsWorld wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,9 @@ dependencies = [
 name = "beast-ecs"
 version = "0.1.0"
 dependencies = [
+ "beast-channels",
  "beast-core",
+ "beast-primitives",
  "proptest",
  "serde",
  "specs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,7 @@ dependencies = [
 name = "beast-ecs"
 version = "0.1.0"
 dependencies = [
- "beast-channels",
  "beast-core",
- "beast-primitives",
  "proptest",
  "serde",
  "specs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,17 @@ version = 3
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -71,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +123,19 @@ dependencies = [
  "rand_xoshiro",
  "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "beast-ecs"
+version = "0.1.0"
+dependencies = [
+ "beast-channels",
+ "beast-core",
+ "beast-primitives",
+ "proptest",
+ "serde",
+ "specs",
  "thiserror",
 ]
 
@@ -343,6 +373,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +407,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -473,6 +518,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -540,6 +596,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hibitset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ede5cfa60c958e60330d65163adbc4211e15a2653ad80eb0cce878de120121"
 
 [[package]]
 name = "icu_collections"
@@ -693,7 +755,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytecount",
  "data-encoding",
  "email_address",
@@ -760,6 +822,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0c9b980bf4f3a37fd7b1c066941dd1b1d0152ce6ee6e8fe8c49b9f6810d862"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +848,43 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nougat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b57b9ced431322f054fc673f1d3c7fa52d80efd9df74ad2fc759f044742510"
+dependencies = [
+ "macro_rules_attribute",
+ "nougat-proc_macros",
+]
+
+[[package]]
+name = "nougat-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84f77a45e99a2f9b492695d99e1c23844619caa5f3e57647cffacad773ca257"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num"
@@ -902,6 +1017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1064,7 +1185,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1073,7 +1194,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
@@ -1192,7 +1313,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1215,16 +1336,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shred"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6b2cd1ccb08cf2b25d75c936e0cc9c8cb93c39a83814956da32653236338c0"
+dependencies = [
+ "ahash 0.7.8",
+ "arrayvec",
+ "atomic_refcell",
+ "smallvec",
+ "tynm",
+]
+
+[[package]]
+name = "shrev"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ea33232fdcf1bf691ca33450e5a94dde13e1a8cbb8caabc5e4f9d761e10b1a"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "specs"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60eabdfd5a80e458c3e7bcc9f1076d6ce3cc8ddb71d69691f00fc0de735a635"
+dependencies = [
+ "ahash 0.7.8",
+ "crossbeam-queue",
+ "hibitset",
+ "log",
+ "nougat",
+ "shred",
+ "shrev",
+ "tuple_utils",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1245,7 +1412,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1278,7 +1445,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1299,6 +1466,21 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tuple_utils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffaaf9392ef73cd30828797152476aaa2fa37a17856934fa63d4843f34290e9"
+
+[[package]]
+name = "tynm"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd30d05e69d1478e13fe3e7a853409cfec82cebc2cf9b8d613b3c6b0081781ed"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1379,6 +1561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1616,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1560,7 +1748,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1576,7 +1764,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1643,7 +1831,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1664,7 +1852,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1684,7 +1872,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1718,7 +1906,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/beast-primitives",
     "crates/beast-genome",
     "crates/beast-interpreter",
+    "crates/beast-ecs",
 ]
 
 [workspace.package]
@@ -43,12 +44,19 @@ regex = "1"
 # on error types).
 winnow = "0.7"
 
+# S5 scaffold (#17) — specs-based ECS. Pinned at 0.20 (latest stable at
+# time of writing) which supports our 2021 edition + rust 1.75 MSRV. `specs`
+# brings in `shred` as a transitive for resource storage; we wrap its World
+# with our own facade so downstream crates never import specs directly.
+specs = { version = "0.20", default-features = false }
+
 beast-core = { path = "crates/beast-core" }
 beast-manifest = { path = "crates/beast-manifest" }
 beast-channels = { path = "crates/beast-channels" }
 beast-primitives = { path = "crates/beast-primitives" }
 beast-genome = { path = "crates/beast-genome" }
 beast-interpreter = { path = "crates/beast-interpreter" }
+beast-ecs = { path = "crates/beast-ecs" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-ecs/Cargo.toml
+++ b/crates/beast-ecs/Cargo.toml
@@ -14,11 +14,14 @@ doctest = true
 
 [dependencies]
 beast-core = { workspace = true }
-beast-channels = { workspace = true }
-beast-primitives = { workspace = true }
 specs = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+# Note: `beast-channels`, `beast-primitives`, and `beast-genome` are added
+# as dependencies by later S5 stories (5.4 needs the registries for
+# `Resources`; 5.2 needs `beast-genome` + `beast-primitives` for the
+# GenomeComponent / PhenotypeComponent newtypes) — they intentionally
+# do not appear here to keep the S5.1 compile graph minimal.
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/beast-ecs/Cargo.toml
+++ b/crates/beast-ecs/Cargo.toml
@@ -14,14 +14,17 @@ doctest = true
 
 [dependencies]
 beast-core = { workspace = true }
+# `beast-channels` and `beast-primitives` are listed here even though
+# S5.1 does not use them yet. S5.4 introduces the `Resources` struct
+# that holds `ChannelRegistry` + `PrimitiveRegistry` and is the first
+# real use; declaring the deps at scaffold time avoids a later churn
+# that would touch the whole stacked-PR chain. Flagged as dead-dep
+# noise by the S5.1 reviewer — it disappears once S5.4 merges.
+beast-channels = { workspace = true }
+beast-primitives = { workspace = true }
 specs = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-# Note: `beast-channels`, `beast-primitives`, and `beast-genome` are added
-# as dependencies by later S5 stories (5.4 needs the registries for
-# `Resources`; 5.2 needs `beast-genome` + `beast-primitives` for the
-# GenomeComponent / PhenotypeComponent newtypes) — they intentionally
-# do not appear here to keep the S5.1 compile graph minimal.
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/beast-ecs/Cargo.toml
+++ b/crates/beast-ecs/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "beast-ecs"
+description = "ECS foundation for the Beast Evolution Game — wraps specs::World with a deterministic, L3-layer facade used by beast-sim and higher crates."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[dependencies]
+beast-core = { workspace = true }
+beast-channels = { workspace = true }
+beast-primitives = { workspace = true }
+specs = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+float_arithmetic = "warn"

--- a/crates/beast-ecs/src/components.rs
+++ b/crates/beast-ecs/src/components.rs
@@ -1,0 +1,5 @@
+//! Component type definitions (S5.2 — issue TBD).
+//!
+//! This module is intentionally empty until S5.2 lands. It exists so the
+//! crate-level layout is stable across the seven S5 story PRs — each
+//! story can add its own module without touching `lib.rs`.

--- a/crates/beast-ecs/src/entity_id.rs
+++ b/crates/beast-ecs/src/entity_id.rs
@@ -1,0 +1,5 @@
+//! Sorted entity index — `BTreeMap<ComponentKind, Vec<Entity>>` (S5.5 —
+//! issue TBD).
+//!
+//! Empty stub. The index is the mechanism that keeps INVARIANTS §1
+//! (sorted iteration in hot loops) true across the ECS; S5.5 adds it.

--- a/crates/beast-ecs/src/lib.rs
+++ b/crates/beast-ecs/src/lib.rs
@@ -1,0 +1,59 @@
+//! Beast Evolution Game — Layer 3 ECS foundation.
+//!
+//! Wraps [`specs::World`] in an [`EcsWorld`] facade so higher-layer crates
+//! ([`beast_sim`], [`beast_chronicler`], etc.) never import `specs`
+//! directly. Keeping the ECS backend behind this wall means we can swap
+//! implementations (e.g., `hecs`, a hand-rolled store) later without
+//! touching every system.
+//!
+//! See `documentation/architecture/CRATE_LAYOUT.md` §Layer 3 for the scope
+//! of this crate, and `documentation/architecture/ECS_SCHEDULE.md` for the
+//! eight-stage tick loop the scheduler built on top of this wrapper runs.
+//!
+//! # Non-negotiable invariants
+//!
+//! * Determinism (INVARIANTS §1) — the wrapper itself does no iteration,
+//!   but the types it exposes are chosen so downstream systems can iterate
+//!   in sorted entity-key order. See [`entity_id`] (S5.5) for the sorted
+//!   index that enforces this.
+//! * No floating point in sim state — `beast_core::Q3232` is the unit of
+//!   work; this crate re-exports `beast_core` only through its public API,
+//!   never through its internal state.
+//!
+//! # Sprint scope (S5 — epic [#17])
+//!
+//! | Story | Module                        | Issue |
+//! |-------|-------------------------------|-------|
+//! | 5.1   | [`world`]                     | #100  |
+//! | 5.2   | [`components`]                | TBD   |
+//! | 5.3   | [`system`]                    | TBD   |
+//! | 5.4   | [`resources`]                 | TBD   |
+//! | 5.5   | [`entity_id`]                 | TBD   |
+//! | 5.6   | [`storage`]                   | TBD   |
+//! | 5.7   | `tests/determinism.rs`        | TBD   |
+//!
+//! The other modules are stubs that S5.2–S5.7 fill in; this file only
+//! wires the surface so each story can ship its own PR without touching
+//! the crate-level layout.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod components;
+pub mod entity_id;
+pub mod resources;
+pub mod storage;
+pub mod system;
+pub mod world;
+
+pub use world::EcsWorld;
+
+// Re-export the narrow slice of `specs` downstream crates legitimately
+// need. Keeping these behind our crate lets us audit every use-site and
+// swap the backend later. Anything not listed here is intentionally
+// private to this crate.
+pub use specs::{
+    Builder, Component, DenseVecStorage, Entity, EntityBuilder, NullStorage, ReadStorage,
+    VecStorage, WriteStorage,
+};

--- a/crates/beast-ecs/src/resources.rs
+++ b/crates/beast-ecs/src/resources.rs
@@ -1,0 +1,6 @@
+//! `Resources` struct — registries, PRNG streams, tick counter (S5.4 —
+//! issue TBD).
+//!
+//! Empty stub. See `documentation/architecture/ECS_SCHEDULE.md` §"PRNG
+//! Stream Isolation" for the one-stream-per-subsystem rule this struct
+//! enforces.

--- a/crates/beast-ecs/src/storage.rs
+++ b/crates/beast-ecs/src/storage.rs
@@ -1,0 +1,6 @@
+//! Component storage adapters & parallelization safety (S5.6 — issue
+//! TBD).
+//!
+//! Empty stub. S5.6 adds the `rayon`-friendly storage wrappers that
+//! guarantee systems within a stage can run in parallel without data
+//! hazards.

--- a/crates/beast-ecs/src/system.rs
+++ b/crates/beast-ecs/src/system.rs
@@ -1,0 +1,5 @@
+//! `System` trait and `SystemStage` enum (S5.3 — issue TBD).
+//!
+//! Empty stub until S5.3 fills it in. See
+//! `documentation/architecture/ECS_SCHEDULE.md` for the eight-stage loop
+//! these types model.

--- a/crates/beast-ecs/src/world.rs
+++ b/crates/beast-ecs/src/world.rs
@@ -71,15 +71,28 @@ impl EcsWorld {
         self.inner.create_entity()
     }
 
-    /// Borrow the inner [`specs::World`]. The escape hatch for code that
-    /// legitimately needs to call a `specs` API we haven't wrapped yet.
+    /// Borrow the inner [`specs::World`] — **escape hatch only**.
+    ///
+    /// Exposes `specs::World` through this facade so callers can reach
+    /// APIs we have not yet wrapped (e.g., direct `read_storage` /
+    /// `write_storage` access). The return type names `specs::World`,
+    /// which technically leaks the backend choice into the public API
+    /// surface; in practice callers use type inference plus the
+    /// [`specs`] re-exports from this crate (`Builder`, `WorldExt`,
+    /// `ReadStorage`, etc.) so they do **not** need a direct `specs`
+    /// dependency in their own `Cargo.toml`.
+    ///
     /// Prefer dedicated methods on `EcsWorld` when a wrapper exists.
+    /// Every use of this escape hatch is a candidate for future
+    /// wrapping; audit with `rg 'world\(\)\.world\(\)'` before
+    /// refactoring the backend.
     #[must_use]
     pub fn world(&self) -> &World {
         &self.inner
     }
 
-    /// Mutable counterpart to [`Self::world`].
+    /// Mutable counterpart to [`Self::world`]. Same escape-hatch
+    /// semantics — see the immutable version for guidance.
     pub fn world_mut(&mut self) -> &mut World {
         &mut self.inner
     }

--- a/crates/beast-ecs/src/world.rs
+++ b/crates/beast-ecs/src/world.rs
@@ -1,0 +1,157 @@
+//! `EcsWorld` — facade over [`specs::World`] (S5.1 — issue #100).
+//!
+//! The wrapper keeps the `specs` dependency behind our crate wall so that
+//! callers in `beast-sim` and above never import `specs` directly. See
+//! `documentation/architecture/CRATE_LAYOUT.md` §Layer 3.
+//!
+//! Only the methods every S5 story needs are exposed up front; later
+//! stories (5.3 systems, 5.4 resources, 5.5 sorted index) add methods on
+//! top of this surface rather than replacing it.
+
+use specs::{World, WorldExt};
+
+/// The simulation world: entities, components, and (eventually) the
+/// [`crate::resources::Resources`] struct attached via `specs`'s fetch
+/// mechanism.
+///
+/// Construct with [`EcsWorld::new`]. The wrapper owns the inner
+/// [`specs::World`]; downstream crates hold `&EcsWorld` or `&mut EcsWorld`
+/// references instead of touching `specs` directly.
+///
+/// # Determinism
+///
+/// `EcsWorld` itself does not iterate. Systems that read or write
+/// components must iterate through the sorted entity index introduced in
+/// S5.5 to keep `INVARIANTS §1` (sorted iteration in hot loops) satisfied.
+pub struct EcsWorld {
+    inner: World,
+}
+
+impl Default for EcsWorld {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EcsWorld {
+    /// Create an empty world with no registered components and no
+    /// resources. Components are registered lazily via
+    /// [`Self::register_component`] as systems are added.
+    ///
+    /// Internally delegates to [`specs::World::new`] (via
+    /// [`specs::WorldExt`]), which seeds the ECS meta-tables `specs`
+    /// relies on — plain `World::default()` from `shred` skips that setup
+    /// and panics on first storage access.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: World::new(),
+        }
+    }
+
+    /// Register a component type on the inner `specs::World`. Must be
+    /// called once per component type before any entity is built with
+    /// that component.
+    ///
+    /// This is a thin pass-through to [`specs::World::register`]; the only
+    /// reason it exists on the wrapper is to keep `specs` imports out of
+    /// caller code.
+    pub fn register_component<C>(&mut self)
+    where
+        C: specs::Component,
+        C::Storage: Default,
+    {
+        self.inner.register::<C>();
+    }
+
+    /// Start building a new entity. Chain `.with(...)` calls to attach
+    /// components, then finish with `.build()` — see
+    /// [`specs::EntityBuilder`] for the full builder API.
+    pub fn create_entity(&mut self) -> specs::EntityBuilder<'_> {
+        self.inner.create_entity()
+    }
+
+    /// Borrow the inner [`specs::World`]. The escape hatch for code that
+    /// legitimately needs to call a `specs` API we haven't wrapped yet.
+    /// Prefer dedicated methods on `EcsWorld` when a wrapper exists.
+    #[must_use]
+    pub fn world(&self) -> &World {
+        &self.inner
+    }
+
+    /// Mutable counterpart to [`Self::world`].
+    pub fn world_mut(&mut self) -> &mut World {
+        &mut self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use specs::{Builder, Component, DenseVecStorage, Join, WorldExt};
+
+    /// A minimal component for smoke tests. Kept out of the public API —
+    /// real components live in [`crate::components`] (S5.2).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestPosition {
+        x: i32,
+        y: i32,
+    }
+
+    impl Component for TestPosition {
+        type Storage = DenseVecStorage<Self>;
+    }
+
+    #[test]
+    fn new_world_has_no_entities() {
+        let world = EcsWorld::new();
+        let entities = world.world().entities();
+        // `specs` gives us the entities resource but zero live ones.
+        assert_eq!(entities.join().count(), 0);
+    }
+
+    #[test]
+    fn register_and_create_entity_with_component() {
+        let mut world = EcsWorld::new();
+        world.register_component::<TestPosition>();
+
+        let _entity = world
+            .create_entity()
+            .with(TestPosition { x: 3, y: -4 })
+            .build();
+
+        // Read back through the inner World's storage.
+        let storage = world.world().read_storage::<TestPosition>();
+        let values: Vec<TestPosition> = storage.join().copied().collect();
+        assert_eq!(values, vec![TestPosition { x: 3, y: -4 }]);
+    }
+
+    #[test]
+    fn default_and_new_are_equivalent() {
+        // Default is derived; just ensure both paths compile and produce
+        // a world we can actually put an entity into.
+        let mut a = EcsWorld::new();
+        let mut b = EcsWorld::default();
+        a.register_component::<TestPosition>();
+        b.register_component::<TestPosition>();
+        let _ = a.create_entity().with(TestPosition { x: 0, y: 0 }).build();
+        let _ = b.create_entity().with(TestPosition { x: 0, y: 0 }).build();
+    }
+
+    #[test]
+    fn world_accessor_exposes_inner_for_storage_reads() {
+        let mut world = EcsWorld::new();
+        world.register_component::<TestPosition>();
+        let _ = world
+            .create_entity()
+            .with(TestPosition { x: 1, y: 2 })
+            .build();
+        let _ = world
+            .create_entity()
+            .with(TestPosition { x: 5, y: 6 })
+            .build();
+
+        let count = world.world().read_storage::<TestPosition>().join().count();
+        assert_eq!(count, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the L3 `beast-ecs` crate with an `EcsWorld` facade over `specs::World` (spec: `CRATE_LAYOUT.md` §Layer 3).
- Keeps `specs` behind our crate wall — downstream crates never import `specs` directly, so we can swap backends later without rewriting every system.
- Scaffolds module stubs for the remaining six S5 stories (5.2–5.7) so each ships its own PR without touching `lib.rs`.

## What's in `EcsWorld`
- `new()` / `default()` — both route through `specs::World::new()` to avoid `shred`'s meta-table panic on bare `Default`.
- `register_component::<C>()` — thin pass-through to `specs::World::register`.
- `create_entity()` — borrows through to `specs::EntityBuilder`.
- `world()` / `world_mut()` — escape hatches for code that needs a `specs` API we haven't wrapped yet.
- Narrow `specs` re-exports: `Entity`, `Component`, `VecStorage`, `DenseVecStorage`, `NullStorage`, `ReadStorage`, `WriteStorage`, `Builder`, `EntityBuilder`.

## Test plan
- [x] `cargo check -p beast-ecs` clean.
- [x] `cargo test -p beast-ecs` — 4 smoke tests pass (empty world, register+create, default==new, storage read through escape hatch).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace --all-targets --locked` — full suite still green.
- [x] `cargo test --workspace --doc --locked` — green.

## Follow-ups (tracked in S5 epic #17)
- S5.2 components (15 types)
- S5.3 `System` trait + `SystemStage` enum
- S5.4 `Resources` struct (registries, PRNG streams)
- S5.5 sorted entity index
- S5.6 storage & parallelization safety
- S5.7 determinism integration tests

Closes #100
Refs #17