### PR TITLE
feat(beast-ecs): S5.2 component type definitions (15 types)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ version = "0.1.0"
 dependencies = [
  "beast-channels",
  "beast-core",
+ "beast-genome",
  "beast-primitives",
  "proptest",
  "serde",

--- a/crates/beast-ecs/Cargo.toml
+++ b/crates/beast-ecs/Cargo.toml
@@ -16,6 +16,7 @@ doctest = true
 beast-core = { workspace = true }
 beast-channels = { workspace = true }
 beast-primitives = { workspace = true }
+beast-genome = { workspace = true }
 specs = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/beast-ecs/src/components.rs
+++ b/crates/beast-ecs/src/components.rs
@@ -1,5 +1,93 @@
-//! Component type definitions (S5.2 — issue TBD).
+//! Component type definitions (S5.2 — issue #106).
 //!
-//! This module is intentionally empty until S5.2 lands. It exists so the
-//! crate-level layout is stable across the seven S5 story PRs — each
-//! story can add its own module without touching `lib.rs`.
+//! The simulation's core data types, split across submodules by theme.
+//! Marker components (empty structs with `NullStorage`) distinguish
+//! "what kind of thing am I" without costing per-entity memory; data
+//! components (`DenseVecStorage`) carry per-entity state.
+//!
+//! Every component in this module implements [`specs::Component`]. Data
+//! components additionally derive `Serialize`/`Deserialize` so the save
+//! path (S7) can round-trip them without further plumbing.
+
+pub mod markers;
+pub mod physiology;
+pub mod spatial;
+pub mod traits;
+
+pub use markers::{Agent, Biome, Creature, Faction, Pathogen, Settlement};
+pub use physiology::{Age, DevelopmentalStage, HealthState, Mass, Species};
+pub use spatial::{Position, Velocity};
+pub use traits::{GenomeComponent, PhenotypeComponent};
+
+/// Register every component defined in this crate on the given
+/// [`crate::EcsWorld`]. Convenience helper so tests and higher-layer
+/// code don't have to repeat the fifteen `register_component` calls.
+pub fn register_all(world: &mut crate::EcsWorld) {
+    world.register_component::<Creature>();
+    world.register_component::<Pathogen>();
+    world.register_component::<Agent>();
+    world.register_component::<Faction>();
+    world.register_component::<Settlement>();
+    world.register_component::<Biome>();
+
+    world.register_component::<Position>();
+    world.register_component::<Velocity>();
+
+    world.register_component::<Age>();
+    world.register_component::<Mass>();
+    world.register_component::<HealthState>();
+    world.register_component::<DevelopmentalStage>();
+    world.register_component::<Species>();
+
+    world.register_component::<GenomeComponent>();
+    world.register_component::<PhenotypeComponent>();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EcsWorld;
+
+    #[test]
+    fn register_all_does_not_panic_on_fresh_world() {
+        let mut world = EcsWorld::new();
+        register_all(&mut world);
+    }
+
+    #[test]
+    fn marker_storage_is_null() {
+        // NullStorage is zero-sized per entity — so adding a marker to a
+        // million entities costs the same as adding it to one. Locked in
+        // so future refactors that accidentally switch to VecStorage fail
+        // this test.
+        fn is_null<C>()
+        where
+            C: specs::Component<Storage = specs::NullStorage<C>>,
+        {
+        }
+        is_null::<Creature>();
+        is_null::<Pathogen>();
+        is_null::<Agent>();
+        is_null::<Faction>();
+        is_null::<Settlement>();
+        is_null::<Biome>();
+    }
+
+    #[test]
+    fn data_storage_is_densevec() {
+        fn is_dense<C>()
+        where
+            C: specs::Component<Storage = specs::DenseVecStorage<C>>,
+        {
+        }
+        is_dense::<Position>();
+        is_dense::<Velocity>();
+        is_dense::<Age>();
+        is_dense::<Mass>();
+        is_dense::<HealthState>();
+        is_dense::<DevelopmentalStage>();
+        is_dense::<Species>();
+        is_dense::<GenomeComponent>();
+        is_dense::<PhenotypeComponent>();
+    }
+}

--- a/crates/beast-ecs/src/components/markers.rs
+++ b/crates/beast-ecs/src/components/markers.rs
@@ -1,0 +1,62 @@
+//! Marker (tag) components with [`specs::NullStorage`].
+//!
+//! Zero-size per entity: presence vs. absence is the data. Use for
+//! "what kind of entity am I" questions (Is this a creature? A biome
+//! cell?). Storage cost stays constant regardless of how many entities
+//! carry the tag.
+
+use serde::{Deserialize, Serialize};
+use specs::{Component, NullStorage};
+
+/// The entity is a creature (macro-scale beast).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Creature;
+
+/// The entity is a pathogen (micro-scale organism — disease, parasite,
+/// symbiont). Treated identically to a creature under the scale-band
+/// unification invariant (INVARIANTS §5); the marker lets systems pick
+/// the appropriate spatial strategy without dropping into a generic
+/// `Mass < 1g` check.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Pathogen;
+
+/// The entity is an agent — settlement NPC, caravan leader, faction
+/// diplomat, etc. Distinct from `Creature` so the interaction/combat
+/// pipelines can skip creature-specific primitive effects.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Agent;
+
+/// The entity is a faction — a social grouping of agents, settlements,
+/// or territories. Zero-state marker; the actual roster lives on other
+/// components (to be added as the faction system matures).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Faction;
+
+/// The entity is a settlement — a persistent location inhabited by
+/// agents.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Settlement;
+
+/// The entity is a biome cell — a discrete patch of the world map with
+/// its own climate, carrying capacity, and hazard profile.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Biome;
+
+impl Component for Creature {
+    type Storage = NullStorage<Self>;
+}
+impl Component for Pathogen {
+    type Storage = NullStorage<Self>;
+}
+impl Component for Agent {
+    type Storage = NullStorage<Self>;
+}
+impl Component for Faction {
+    type Storage = NullStorage<Self>;
+}
+impl Component for Settlement {
+    type Storage = NullStorage<Self>;
+}
+impl Component for Biome {
+    type Storage = NullStorage<Self>;
+}

--- a/crates/beast-ecs/src/components/physiology.rs
+++ b/crates/beast-ecs/src/components/physiology.rs
@@ -29,14 +29,25 @@ impl Component for Age {
 /// Body mass in kilograms. The scale-band invariant (INVARIANTS §5)
 /// uses this value to decide channel expressibility; keep the field
 /// strictly positive and in Q32.32.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Default` is intentionally **not** derived — a zero-mass creature
+/// would break scale-band filtering (every band starts at `≥ 0`, so
+/// zero is always "in band" vacuously) and would also divide-by-zero
+/// in any system that normalises by mass. Callers must supply an
+/// explicit value via `Mass::new`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Mass {
     /// Kilograms, Q32.32.
     pub kg: Q3232,
 }
 
 impl Mass {
-    /// Convenience constructor.
+    /// Convenience constructor. Does not validate positivity — mass
+    /// values can be arbitrarily small in the micro/pathogen band
+    /// (`1e-15 kg`). A `debug_assert!(kg > Q3232::ZERO)` would be
+    /// tempting but would forbid the intentionally-zero test fixtures
+    /// the interpreter uses for "dormant channel" checks; leave the
+    /// contract in prose.
     #[must_use]
     pub fn new(kg: Q3232) -> Self {
         Self { kg }

--- a/crates/beast-ecs/src/components/physiology.rs
+++ b/crates/beast-ecs/src/components/physiology.rs
@@ -84,8 +84,21 @@ impl HealthState {
     }
 
     /// Convenience constructor with explicit values.
+    ///
+    /// Debug-asserts that both `health` and `energy` fall in the
+    /// documented `[0, 1]` unit interval. Release builds skip the
+    /// check (zero cost); production callers that update via saturating
+    /// arithmetic stay in range by construction.
     #[must_use]
     pub fn new(health: Q3232, energy: Q3232) -> Self {
+        debug_assert!(
+            Q3232::ZERO <= health && health <= Q3232::ONE,
+            "HealthState::new: health out of [0, 1]: {health:?}"
+        );
+        debug_assert!(
+            Q3232::ZERO <= energy && energy <= Q3232::ONE,
+            "HealthState::new: energy out of [0, 1]: {energy:?}"
+        );
         Self { health, energy }
     }
 }

--- a/crates/beast-ecs/src/components/physiology.rs
+++ b/crates/beast-ecs/src/components/physiology.rs
@@ -1,0 +1,188 @@
+//! Physiological components: [`Age`], [`Mass`], [`HealthState`],
+//! [`DevelopmentalStage`], [`Species`].
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+use specs::{Component, DenseVecStorage};
+
+/// Creature age, measured in simulation ticks since birth. A `u64`
+/// because a long-lived creature plus a large tick budget could exceed
+/// `u32::MAX` within a single replay.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Age {
+    /// Ticks since birth.
+    pub ticks: u64,
+}
+
+impl Age {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(ticks: u64) -> Self {
+        Self { ticks }
+    }
+}
+
+impl Component for Age {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Body mass in kilograms. The scale-band invariant (INVARIANTS §5)
+/// uses this value to decide channel expressibility; keep the field
+/// strictly positive and in Q32.32.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Mass {
+    /// Kilograms, Q32.32.
+    pub kg: Q3232,
+}
+
+impl Mass {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(kg: Q3232) -> Self {
+        Self { kg }
+    }
+}
+
+impl Component for Mass {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Discrete health state: two unit-interval Q32.32 values.
+///
+/// * `health` — structural integrity; zero triggers the death check.
+/// * `energy` — metabolic reserve; low values feed starvation logic.
+///
+/// Both values are clamped to `[0, 1]` by convention; systems that
+/// update them use saturating Q3232 arithmetic.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthState {
+    /// Structural integrity, `[0, 1]`.
+    pub health: Q3232,
+    /// Metabolic reserve, `[0, 1]`.
+    pub energy: Q3232,
+}
+
+impl HealthState {
+    /// Fully healthy, fully fed.
+    #[must_use]
+    pub fn full() -> Self {
+        Self {
+            health: Q3232::ONE,
+            energy: Q3232::ONE,
+        }
+    }
+
+    /// Convenience constructor with explicit values.
+    #[must_use]
+    pub fn new(health: Q3232, energy: Q3232) -> Self {
+        Self { health, energy }
+    }
+}
+
+impl Component for HealthState {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Developmental stage a creature currently occupies.
+///
+/// The enum order reflects normal progression; ordering comparisons are
+/// meaningful (`Egg < Larval < Juvenile < Adult < Geriatric`) so
+/// systems can `if stage < DevelopmentalStage::Juvenile { ... }`.
+///
+/// Maps onto `beast_channels::ExpressionCondition::DevelopmentalStage`
+/// strings via `as_str` — the interpreter consumes that form.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum DevelopmentalStage {
+    /// Pre-hatch / pre-birth.
+    Egg,
+    /// Post-hatch juvenile; some channels still dormant.
+    Larval,
+    /// Grown juvenile, not yet reproductively active.
+    Juvenile,
+    /// Reproductively active adult. Default.
+    #[default]
+    Adult,
+    /// Declining: senescence modifiers start to dominate.
+    Geriatric,
+}
+
+impl DevelopmentalStage {
+    /// String form expected by
+    /// `beast_channels::ExpressionCondition::DevelopmentalStage`. Stable
+    /// across versions — a rename would break every channel manifest.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DevelopmentalStage::Egg => "egg",
+            DevelopmentalStage::Larval => "larval",
+            DevelopmentalStage::Juvenile => "juvenile",
+            DevelopmentalStage::Adult => "adult",
+            DevelopmentalStage::Geriatric => "geriatric",
+        }
+    }
+}
+
+impl Component for DevelopmentalStage {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Species membership. The `id` is assigned by the speciation system
+/// (S12); two creatures with the same `id` are reproductively
+/// compatible.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct Species {
+    /// Species id. `0` is the default "unassigned" bucket.
+    pub id: u32,
+}
+
+impl Species {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(id: u32) -> Self {
+        Self { id }
+    }
+}
+
+impl Component for Species {
+    type Storage = DenseVecStorage<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn developmental_stage_ordering_is_birth_to_death() {
+        use DevelopmentalStage::*;
+        assert!(Egg < Larval);
+        assert!(Larval < Juvenile);
+        assert!(Juvenile < Adult);
+        assert!(Adult < Geriatric);
+    }
+
+    #[test]
+    fn developmental_stage_str_is_stable() {
+        // Locked in as the canonical form for channel manifest matching.
+        assert_eq!(DevelopmentalStage::Egg.as_str(), "egg");
+        assert_eq!(DevelopmentalStage::Larval.as_str(), "larval");
+        assert_eq!(DevelopmentalStage::Juvenile.as_str(), "juvenile");
+        assert_eq!(DevelopmentalStage::Adult.as_str(), "adult");
+        assert_eq!(DevelopmentalStage::Geriatric.as_str(), "geriatric");
+    }
+
+    #[test]
+    fn health_full_is_one_by_one() {
+        let h = HealthState::full();
+        assert_eq!(h.health, Q3232::ONE);
+        assert_eq!(h.energy, Q3232::ONE);
+    }
+
+    #[test]
+    fn species_default_is_zero() {
+        assert_eq!(Species::default(), Species::new(0));
+    }
+}

--- a/crates/beast-ecs/src/components/spatial.rs
+++ b/crates/beast-ecs/src/components/spatial.rs
@@ -1,0 +1,69 @@
+//! Spatial components: [`Position`] and [`Velocity`] on a 2-D plane,
+//! both in Q32.32 fixed-point.
+//!
+//! The world's coordinate system is deliberately deterministic — no
+//! `f32`/`f64` anywhere in the hot path. See INVARIANTS §1.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+use specs::{Component, DenseVecStorage};
+
+/// Position on the 2-D world plane, measured in metres from the
+/// world-coordinate origin. Both axes are signed Q32.32.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Position {
+    /// X coordinate (east-positive).
+    pub x: Q3232,
+    /// Y coordinate (north-positive).
+    pub y: Q3232,
+}
+
+impl Position {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(x: Q3232, y: Q3232) -> Self {
+        Self { x, y }
+    }
+}
+
+impl Component for Position {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Velocity in metres-per-tick, Q32.32.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Velocity {
+    /// Eastward velocity component.
+    pub vx: Q3232,
+    /// Northward velocity component.
+    pub vy: Q3232,
+}
+
+impl Velocity {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(vx: Q3232, vy: Q3232) -> Self {
+        Self { vx, vy }
+    }
+}
+
+impl Component for Velocity {
+    type Storage = DenseVecStorage<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_default_is_origin() {
+        let p = Position::default();
+        assert_eq!(p, Position::new(Q3232::ZERO, Q3232::ZERO));
+    }
+
+    #[test]
+    fn velocity_default_is_rest() {
+        let v = Velocity::default();
+        assert_eq!(v, Velocity::new(Q3232::ZERO, Q3232::ZERO));
+    }
+}

--- a/crates/beast-ecs/src/components/traits.rs
+++ b/crates/beast-ecs/src/components/traits.rs
@@ -66,8 +66,26 @@ pub struct PhenotypeComponent {
 impl PhenotypeComponent {
     /// Build from an already-sorted effect list (the interpreter emits
     /// them sorted — no re-sorting required here).
+    ///
+    /// In debug builds, verifies that `effects` is sorted by
+    /// `(primitive_id, body_site)`. A violation indicates the caller is
+    /// feeding a phenotype that bypassed the interpreter's emission
+    /// path, which would silently break the determinism invariant
+    /// (INVARIANTS §1) — downstream systems hash the phenotype in
+    /// visit order. Release builds skip the check; production callers
+    /// are expected to go through `beast_interpreter::emit_primitives`
+    /// which preserves the sort.
     #[must_use]
     pub fn new(effects: Vec<PrimitiveEffect>) -> Self {
+        debug_assert!(
+            effects.windows(2).all(|pair| {
+                (&pair[0].primitive_id, &pair[0].body_site)
+                    <= (&pair[1].primitive_id, &pair[1].body_site)
+            }),
+            "PhenotypeComponent::new: effects must be sorted by \
+             (primitive_id, body_site); caller bypassed the interpreter \
+             emission path"
+        );
         Self { effects }
     }
 }

--- a/crates/beast-ecs/src/components/traits.rs
+++ b/crates/beast-ecs/src/components/traits.rs
@@ -1,0 +1,77 @@
+//! Genetic/phenotypic components — [`GenomeComponent`] and
+//! [`PhenotypeComponent`].
+//!
+//! These are newtype wrappers over types defined in `beast-genome`
+//! (L1) and `beast-primitives` (L1). Keeping the `specs::Component`
+//! impls here avoids adding a `specs` dependency to the L1 crates — the
+//! ECS is an L3 concern.
+
+use beast_genome::Genome;
+use beast_primitives::PrimitiveEffect;
+use serde::{Deserialize, Serialize};
+use specs::{Component, DenseVecStorage};
+
+// NOTE: `PrimitiveEffect` does not currently derive `Serialize` /
+// `Deserialize` (see `beast-primitives`). When S7 adds save/load, the
+// derive there will land in the same PR that re-enables it on
+// [`PhenotypeComponent`]. Until then, `PhenotypeComponent` is save-path
+// opaque — the interpreter re-derives it each tick from the genome, so
+// a save can simply drop the cached phenotype and rebuild.
+
+/// A creature's evolvable genotype. Newtype over [`beast_genome::Genome`]
+/// so the L1 genome crate does not have to know about `specs`.
+///
+/// Mutable per tick (the mutation system in Stage 1 writes it back).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenomeComponent(pub Genome);
+
+impl GenomeComponent {
+    /// Wrap an existing genome as a component.
+    #[must_use]
+    pub fn new(genome: Genome) -> Self {
+        Self(genome)
+    }
+
+    /// Immutable view of the underlying genome.
+    #[must_use]
+    pub fn genome(&self) -> &Genome {
+        &self.0
+    }
+
+    /// Mutable view — the mutation system in Stage 1 calls this to
+    /// apply point mutations.
+    pub fn genome_mut(&mut self) -> &mut Genome {
+        &mut self.0
+    }
+}
+
+impl Component for GenomeComponent {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// The creature's current phenotype — the `Vec<PrimitiveEffect>`
+/// produced by the interpreter in Stage 2. Read by every downstream
+/// physics/combat/physiology system; rewritten each tick by Stage 2.
+///
+/// Stored as a sorted `Vec` rather than a `Set` because ordering
+/// already comes out of the interpreter sorted by `primitive_id`
+/// (emission merges by `(primitive_id, site_id)` and returns sorted).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PhenotypeComponent {
+    /// Primitive effects emitted by Stage 2 for this creature, sorted by
+    /// `(primitive_id, site_id)` per the interpreter contract.
+    pub effects: Vec<PrimitiveEffect>,
+}
+
+impl PhenotypeComponent {
+    /// Build from an already-sorted effect list (the interpreter emits
+    /// them sorted — no re-sorting required here).
+    #[must_use]
+    pub fn new(effects: Vec<PrimitiveEffect>) -> Self {
+        Self { effects }
+    }
+}
+
+impl Component for PhenotypeComponent {
+    type Storage = DenseVecStorage<Self>;
+}


### PR DESCRIPTION
Stacked on #105 (S5.4).

## Summary
Fifteen components split by theme across four submodules in `crates/beast-ecs/src/components/`:

| Module | Components | Storage |
|---|---|---|
| `markers` | `Creature`, `Pathogen`, `Agent`, `Faction`, `Settlement`, `Biome` | `NullStorage` (zero-cost tags) |
| `spatial` | `Position { x, y }`, `Velocity { vx, vy }` | `DenseVecStorage`, Q32.32 both axes |
| `physiology` | `Age`, `Mass`, `HealthState`, `DevelopmentalStage`, `Species` | `DenseVecStorage` |
| `traits` | `GenomeComponent`, `PhenotypeComponent` | `DenseVecStorage`, newtypes over L1 types |

## Design notes
- `GenomeComponent` and `PhenotypeComponent` are newtypes so `beast-genome` and `beast-primitives` (both L1) stay free of any `specs` dep — the `Component` impl lives here in L3.
- `DevelopmentalStage` enum is `Ord` so systems can write `if stage < Juvenile`, and has `as_str` returning the canonical string consumed by `beast_channels::ExpressionCondition::DevelopmentalStage`.
- `components::register_all(world)` registers all fifteen in one call — useful for tests and the upcoming S6 scheduler bootstrap.
- Storage-kind tests are type-gated (`fn is_null<C: Component<Storage = NullStorage<C>>>()`) so accidentally switching a marker to `VecStorage` fails at compile time, not just at runtime.

## Caveat
`PhenotypeComponent` currently does **not** derive `Serialize`/`Deserialize` because `beast_primitives::PrimitiveEffect` isn't serde-derived yet. That derive lands in the same S7 save/load PR and will re-enable it here.

## Test plan
- [x] `cargo test -p beast-ecs` — 21 tests pass.
- [x] `cargo clippy -p beast-ecs --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Storage kind verified at compile time (marker_storage_is_null, data_storage_is_densevec).

Refs #17. Closes #106.