### PR TITLE
test(beast-ecs): S5.7 determinism integration tests

### DIFF
--- a/crates/beast-ecs/src/lib.rs
+++ b/crates/beast-ecs/src/lib.rs
@@ -60,5 +60,5 @@ pub use world::EcsWorld;
 // private to this crate.
 pub use specs::{
     Builder, Component, DenseVecStorage, Entity, EntityBuilder, NullStorage, ReadStorage,
-    VecStorage, WriteStorage,
+    VecStorage, WorldExt, WriteStorage,
 };

--- a/crates/beast-ecs/tests/determinism.rs
+++ b/crates/beast-ecs/tests/determinism.rs
@@ -1,0 +1,185 @@
+//! Integration determinism tests for the ECS foundation (S5.7 — issue #112).
+//!
+//! These tests exercise the full S5 surface:
+//!
+//! * `EcsWorld::new` + `components::register_all` (S5.1 + S5.2)
+//! * `System` trait + `SystemStage` (S5.3)
+//! * `Resources` with PRNG streams + tick counter (S5.4)
+//! * `SortedEntityIndex` (S5.5)
+//! * `for_each_entity_of` (S5.6)
+//!
+//! The goal is to *prove* the INVARIANTS §1 contract holds end-to-end at
+//! the L3 layer, before S6's scheduler and per-stage systems arrive.
+
+use beast_channels::ChannelRegistry;
+use beast_core::Q3232;
+use beast_ecs::components::{Age, HealthState, Position};
+use beast_ecs::storage::for_each_entity_of;
+use beast_ecs::{
+    components, Builder, EcsWorld, MarkerKind, Resources, System, SystemStage, WorldExt,
+};
+use beast_primitives::PrimitiveRegistry;
+use specs::Entity;
+
+// Use WorldExt via the re-export for create_entity under-the-hood.
+use beast_ecs as _;
+
+/// Toy system: advance every creature's `Age.ticks` by one. Uses the
+/// safe-sequential iteration pattern (Pattern A from `storage`).
+struct AgingSystem;
+
+impl System for AgingSystem {
+    fn name(&self) -> &'static str {
+        "aging"
+    }
+
+    fn stage(&self) -> SystemStage {
+        SystemStage::InputAndAging
+    }
+
+    fn run(&mut self, world: &mut EcsWorld, resources: &mut Resources) -> beast_ecs::Result<()> {
+        // Snapshot the index so we can iterate without holding a borrow
+        // through the mutable storage write.
+        let creatures: Vec<Entity> = resources
+            .entity_index
+            .entities_of(MarkerKind::Creature)
+            .collect();
+        let mut ages = world.world().write_storage::<Age>();
+        for entity in creatures {
+            if let Some(age) = ages.get_mut(entity) {
+                age.ticks += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Build a fixture world with `n` creatures. Each creature has `Age`,
+/// `HealthState`, and a deterministic `Position` derived from the seed.
+fn build_world(seed: u64, n: usize) -> (EcsWorld, Resources) {
+    let mut world = EcsWorld::new();
+    components::register_all(&mut world);
+    let mut resources = Resources::new(seed, ChannelRegistry::new(), PrimitiveRegistry::new());
+
+    for i in 0..n {
+        // Deterministic position derived from index — no RNG draws so
+        // the PRNG streams are preserved for later assertions.
+        let x = Q3232::from_num(i as i32);
+        let y = Q3232::from_num(-(i as i32));
+        let entity = world
+            .create_entity()
+            .with(components::Creature)
+            .with(Age::new(0))
+            .with(HealthState::full())
+            .with(Position::new(x, y))
+            .build();
+        resources.entity_index.insert(entity, MarkerKind::Creature);
+    }
+    (world, resources)
+}
+
+/// Compute a simple rolling hash over the ages + positions of every
+/// creature, visited via the sorted index. The order-of-visitation is
+/// what makes this a determinism test — if the index ever yielded a
+/// different order, the hash would change.
+fn state_hash(world: &EcsWorld, resources: &Resources) -> u64 {
+    let ages = world.world().read_storage::<Age>();
+    let positions = world.world().read_storage::<Position>();
+    let mut hash: u64 = 0xCBF2_9CE4_8422_2325; // FNV-1a offset basis
+    for entity in resources.entity_index.entities_of(MarkerKind::Creature) {
+        let age = ages.get(entity).copied().unwrap_or_default();
+        let pos = positions.get(entity).copied().unwrap_or_default();
+        for byte in age.ticks.to_le_bytes() {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
+        }
+        for byte in pos.x.to_bits().to_le_bytes() {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
+        }
+        for byte in pos.y.to_bits().to_le_bytes() {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
+        }
+    }
+    hash
+}
+
+#[test]
+fn aging_system_is_byte_identical_across_runs() {
+    // Run 1000 ticks twice from identical seeds and assert the final
+    // hash matches. The test is intentionally O(N_creatures * N_ticks)
+    // so its completion time bounds our per-tick cost.
+    const TICKS: usize = 1_000;
+    const CREATURES: usize = 100;
+
+    let run = || {
+        let (mut world, mut resources) = build_world(0xDEAD_BEEF, CREATURES);
+        let mut aging = AgingSystem;
+        for _ in 0..TICKS {
+            aging.run(&mut world, &mut resources).expect("run");
+            resources.advance_tick();
+        }
+        (state_hash(&world, &resources), resources.tick_counter.raw())
+    };
+    let (hash_a, ticks_a) = run();
+    let (hash_b, ticks_b) = run();
+    assert_eq!(hash_a, hash_b, "state hash must be identical across runs");
+    assert_eq!(ticks_a, TICKS as u64);
+    assert_eq!(ticks_b, TICKS as u64);
+}
+
+#[test]
+fn final_ages_are_equal_to_tick_count() {
+    // Each creature's age starts at 0; AgingSystem increments once per
+    // tick for every creature. After N ticks, every creature must have
+    // age = N.
+    const TICKS: u64 = 250;
+    const CREATURES: usize = 10;
+    let (mut world, mut resources) = build_world(42, CREATURES);
+    let mut aging = AgingSystem;
+    for _ in 0..TICKS {
+        aging.run(&mut world, &mut resources).expect("run");
+    }
+    let ages = world.world().read_storage::<Age>();
+    for entity in resources.entity_index.entities_of(MarkerKind::Creature) {
+        assert_eq!(ages.get(entity).copied().unwrap_or_default().ticks, TICKS);
+    }
+}
+
+#[test]
+fn for_each_entity_of_visits_in_ascending_order_on_every_call() {
+    // Regression guard: build a world, then call for_each_entity_of
+    // several times, asserting every call visits entities in the exact
+    // same ascending order.
+    let (_world, resources) = build_world(7, 32);
+    let mut runs: Vec<Vec<Entity>> = Vec::new();
+    for _ in 0..5 {
+        let mut visited = Vec::new();
+        for_each_entity_of(&resources, MarkerKind::Creature, |e| visited.push(e));
+        runs.push(visited);
+    }
+    for i in 1..runs.len() {
+        assert_eq!(runs[0], runs[i], "visitation order diverged on run {i}");
+    }
+    // And ascending by specs Entity (which orders by (index, generation)).
+    for pair in runs[0].windows(2) {
+        assert!(pair[0] < pair[1], "visitation not ascending: {pair:?}");
+    }
+}
+
+#[test]
+fn different_seeds_do_not_affect_aging_determinism() {
+    // AgingSystem doesn't touch PRNG; changing the world_seed should
+    // produce identical ages + identical iteration order (the only
+    // PRNG draws happen at `Resources::new`, which we run twice).
+    let (mut world_a, mut res_a) = build_world(1, 20);
+    let (mut world_b, mut res_b) = build_world(2, 20);
+    let mut aging = AgingSystem;
+    for _ in 0..100 {
+        aging.run(&mut world_a, &mut res_a).unwrap();
+        aging.run(&mut world_b, &mut res_b).unwrap();
+    }
+    // Positions + ages are driven by (index, TICKS), not PRNG, so hashes match.
+    assert_eq!(state_hash(&world_a, &res_a), state_hash(&world_b, &res_b));
+}

--- a/crates/beast-ecs/tests/determinism.rs
+++ b/crates/beast-ecs/tests/determinism.rs
@@ -16,13 +16,9 @@ use beast_core::Q3232;
 use beast_ecs::components::{Age, HealthState, Position};
 use beast_ecs::storage::for_each_entity_of;
 use beast_ecs::{
-    components, Builder, EcsWorld, MarkerKind, Resources, System, SystemStage, WorldExt,
+    components, Builder, EcsWorld, Entity, MarkerKind, Resources, System, SystemStage, WorldExt,
 };
 use beast_primitives::PrimitiveRegistry;
-use specs::Entity;
-
-// Use WorldExt via the re-export for create_entity under-the-hood.
-use beast_ecs as _;
 
 /// Toy system: advance every creature's `Age.ticks` by one. Uses the
 /// safe-sequential iteration pattern (Pattern A from `storage`).
@@ -86,9 +82,16 @@ fn state_hash(world: &EcsWorld, resources: &Resources) -> u64 {
     let ages = world.world().read_storage::<Age>();
     let positions = world.world().read_storage::<Position>();
     let mut hash: u64 = 0xCBF2_9CE4_8422_2325; // FNV-1a offset basis
+                                               // Note: `to_le_bytes` is platform-independent in Rust — always
+                                               // returns little-endian regardless of host endianness — so this
+                                               // hash reproduces bit-for-bit across architectures.
     for entity in resources.entity_index.entities_of(MarkerKind::Creature) {
-        let age = ages.get(entity).copied().unwrap_or_default();
-        let pos = positions.get(entity).copied().unwrap_or_default();
+        let age = ages
+            .get(entity)
+            .expect("creature must have Age in state_hash fixture");
+        let pos = positions
+            .get(entity)
+            .expect("creature must have Position in state_hash fixture");
         for byte in age.ticks.to_le_bytes() {
             hash ^= u64::from(byte);
             hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
@@ -143,7 +146,10 @@ fn final_ages_are_equal_to_tick_count() {
     }
     let ages = world.world().read_storage::<Age>();
     for entity in resources.entity_index.entities_of(MarkerKind::Creature) {
-        assert_eq!(ages.get(entity).copied().unwrap_or_default().ticks, TICKS);
+        let age = ages
+            .get(entity)
+            .expect("creature must have Age in final_ages test");
+        assert_eq!(age.ticks, TICKS);
     }
 }
 

--- a/crates/beast-ecs/tests/iteration_order.rs
+++ b/crates/beast-ecs/tests/iteration_order.rs
@@ -1,0 +1,71 @@
+//! Sorted entity index total-order tests (S5.7 — issue #112).
+
+use beast_ecs::{Builder, EcsWorld, MarkerKind, SortedEntityIndex};
+use specs::Entity;
+
+#[test]
+fn iter_all_gives_marker_then_entity_total_order() {
+    // 50 creatures + 50 pathogens, inserted in interleaved order.
+    let mut world = EcsWorld::new();
+    let entities: Vec<Entity> = (0..100).map(|_| world.create_entity().build()).collect();
+
+    let mut index = SortedEntityIndex::new();
+    // Interleave Creature/Pathogen insertions so sort-ness is
+    // unmistakably doing work.
+    for (i, entity) in entities.iter().enumerate() {
+        let marker = if i % 2 == 0 {
+            MarkerKind::Creature
+        } else {
+            MarkerKind::Pathogen
+        };
+        index.insert(*entity, marker);
+    }
+
+    let all: Vec<(MarkerKind, Entity)> = index.iter_all().collect();
+
+    // 1) Length: every entity appears exactly once.
+    assert_eq!(all.len(), entities.len());
+
+    // 2) Ordering: MarkerKind ascending (Creature < Pathogen), then
+    //    Entity ascending within each group.
+    for pair in all.windows(2) {
+        let (ka, ea) = pair[0];
+        let (kb, eb) = pair[1];
+        assert!(
+            ka < kb || (ka == kb && ea < eb),
+            "iter_all total order broken: {:?} then {:?}",
+            pair[0],
+            pair[1]
+        );
+    }
+
+    // 3) Creature group comes first, exactly 50 entries.
+    let creature_count = all
+        .iter()
+        .take_while(|(k, _)| *k == MarkerKind::Creature)
+        .count();
+    assert_eq!(creature_count, 50);
+    let pathogen_count = all.len() - creature_count;
+    assert_eq!(pathogen_count, 50);
+}
+
+#[test]
+fn iteration_order_is_stable_across_repeated_calls() {
+    let mut world = EcsWorld::new();
+    let entities: Vec<Entity> = (0..20).map(|_| world.create_entity().build()).collect();
+
+    let mut index = SortedEntityIndex::new();
+    // Insert 10 creatures + 10 agents out of order.
+    for i in [17, 3, 11, 5, 1, 9, 15, 7, 13, 19] {
+        index.insert(entities[i], MarkerKind::Creature);
+    }
+    for i in [8, 0, 4, 12, 2, 6, 16, 10, 14, 18] {
+        index.insert(entities[i], MarkerKind::Agent);
+    }
+
+    let a: Vec<(MarkerKind, Entity)> = index.iter_all().collect();
+    let b: Vec<(MarkerKind, Entity)> = index.iter_all().collect();
+    let c: Vec<(MarkerKind, Entity)> = index.iter_all().collect();
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+}


### PR DESCRIPTION
Stacked on #111 (S5.6). Final S5 story — closes out the ECS foundation sprint.

## Summary
Two integration test files that prove the S5 foundation satisfies INVARIANTS §1 end-to-end, before the S6 scheduler and per-stage systems arrive.

## `tests/determinism.rs`
- **`aging_system_is_byte_identical_across_runs`** — build a 100-creature world, run 1000 ticks of a toy `AgingSystem`, compute an FNV-1a hash over `(age, position)` per creature iterated via `entity_index`. Two independent runs must produce bit-identical hashes.
- **`final_ages_are_equal_to_tick_count`** — after N ticks, every creature's age equals N. Sanity check on the loop.
- **`for_each_entity_of_visits_in_ascending_order_on_every_call`** — five repeated calls all yield the same ascending-Entity-order visitation.
- **`different_seeds_do_not_affect_aging_determinism`** — a PRNG-free system produces identical hashes under two different seeds (positions and ages are index-derived, not RNG-derived).

## `tests/iteration_order.rs`
- **`iter_all_gives_marker_then_entity_total_order`** — 50 creatures + 50 pathogens interleaved; `iter_all` yields all 100 in `(MarkerKind asc, Entity asc)` total order, counted per bucket.
- **`iteration_order_is_stable_across_repeated_calls`** — three back-to-back `iter_all` calls produce identical output vectors.

## Incidental
- Re-exported `specs::WorldExt` from `lib.rs` so integration tests (and later crates) can call `world.read_storage` / `write_storage` without a direct `specs` dep.

## Test plan
- [x] `cargo test -p beast-ecs --tests` — 33 unit + 4 determinism + 2 iteration_order = 39 green.
- [x] `cargo clippy -p beast-ecs --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Determinism test suite completes in < 50ms on my machine.

Refs #17. Closes #112. **Closes S5 epic #17** once this chain merges.