### PR TITLE
feat(beast-sim): S6.4 TickResult + wall-clock budget tracking

### DIFF
--- a/crates/beast-sim/src/budget.rs
+++ b/crates/beast-sim/src/budget.rs
@@ -1,4 +1,106 @@
-//! Performance budget tracking (S6.4, S6.7 — issues TBD).
+//! Per-tick timing and budget tracking (S6.4 — issue #119).
 //!
-//! Empty stub. Reads `std::time::Instant` for observation only — never
-//! feeds back into sim state.
+//! Timing here is **observation only** — the returned
+//! [`TickResult`] feeds logging and future budget-defer logic (S6.7),
+//! but never flows back into sim state. INVARIANTS §1 forbids wall-clock
+//! reads on the sim path; this module stays clean by never exposing its
+//! timing values to the scheduler's per-system decisions — the scheduler
+//! calls `stopwatch()` and later writes the result into `TickResult`
+//! without reading it for control flow.
+
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+use beast_core::TickCounter;
+use beast_ecs::SystemStage;
+
+/// Summary of a single tick: what tick number it was, total wall-clock
+/// duration, and per-stage breakdown.
+///
+/// `stage_durations` only contains entries for stages that had at least
+/// one system registered; empty stages do not appear.
+#[derive(Debug, Clone)]
+pub struct TickResult {
+    /// The tick counter value **after** the tick completed. For the
+    /// first successful tick this is `1`.
+    pub tick: TickCounter,
+    /// Total wall-clock microseconds for the whole tick (all stages +
+    /// the `advance_tick` bump).
+    pub duration_us: u64,
+    /// Wall-clock microseconds per stage that actually ran. Uses
+    /// `BTreeMap` so iteration is deterministic if two tests compare
+    /// serialised results.
+    pub stage_durations: BTreeMap<SystemStage, u64>,
+}
+
+/// Minimal wrapper over `std::time::Instant` so test code can audit
+/// every start/stop site. Consumers should not read `raw_start` —
+/// the accessor exists only for observability, not control flow.
+#[derive(Debug)]
+pub(crate) struct Stopwatch {
+    started_at: Instant,
+}
+
+impl Stopwatch {
+    /// Start a new stopwatch at "now".
+    pub(crate) fn start() -> Self {
+        Self {
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Elapsed microseconds since `start`. Saturates on overflow — any
+    /// tick longer than ~584,000 years wraps, which is fine.
+    pub(crate) fn elapsed_us(&self) -> u64 {
+        let elapsed = self.started_at.elapsed();
+        let micros: u128 = elapsed.as_micros();
+        u64::try_from(micros).unwrap_or(u64::MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopwatch_elapsed_is_monotonic_non_negative() {
+        let w = Stopwatch::start();
+        let a = w.elapsed_us();
+        // Busy spin a tiny bit to guarantee > 0 elapsed. 10 µs is
+        // conservative on every platform we target.
+        while w.elapsed_us() < a + 10 {
+            std::hint::spin_loop();
+        }
+        let b = w.elapsed_us();
+        assert!(b >= a, "elapsed went backwards: {a} -> {b}");
+    }
+
+    #[test]
+    fn tick_result_defaults_cleanly() {
+        let t = TickResult {
+            tick: TickCounter::new(0),
+            duration_us: 0,
+            stage_durations: BTreeMap::new(),
+        };
+        assert_eq!(t.tick.raw(), 0);
+        assert_eq!(t.duration_us, 0);
+        assert!(t.stage_durations.is_empty());
+    }
+
+    #[test]
+    fn stage_durations_is_btreemap_for_ordered_iteration() {
+        let mut sd: BTreeMap<SystemStage, u64> = BTreeMap::new();
+        sd.insert(SystemStage::Ecology, 5);
+        sd.insert(SystemStage::InputAndAging, 2);
+        sd.insert(SystemStage::Genetics, 3);
+        let keys: Vec<SystemStage> = sd.keys().copied().collect();
+        assert_eq!(
+            keys,
+            vec![
+                SystemStage::InputAndAging,
+                SystemStage::Genetics,
+                SystemStage::Ecology
+            ]
+        );
+    }
+}

--- a/crates/beast-sim/src/budget.rs
+++ b/crates/beast-sim/src/budget.rs
@@ -49,8 +49,9 @@ impl Stopwatch {
         }
     }
 
-    /// Elapsed microseconds since `start`. Saturates on overflow — any
-    /// tick longer than ~584,000 years wraps, which is fine.
+    /// Elapsed microseconds since `start`. Saturates at `u64::MAX` on
+    /// overflow (via `u64::try_from(u128)`) — any tick longer than
+    /// ~584,000 years saturates rather than wrapping, which is fine.
     pub(crate) fn elapsed_us(&self) -> u64 {
         let elapsed = self.started_at.elapsed();
         let micros: u128 = elapsed.as_micros();
@@ -66,11 +67,13 @@ mod tests {
     fn stopwatch_elapsed_is_monotonic_non_negative() {
         let w = Stopwatch::start();
         let a = w.elapsed_us();
-        // Busy spin a tiny bit to guarantee > 0 elapsed. 10 µs is
-        // conservative on every platform we target.
-        while w.elapsed_us() < a + 10 {
-            std::hint::spin_loop();
-        }
+        // Sleep rather than busy-spin. Busy-spinning made the test
+        // unreliable on loaded CI runners where scheduler yield times
+        // could exceed the 10 µs comparison window, and on platforms
+        // with coarser `Instant` resolution it would run longer than
+        // intended. 50 µs sleep is enough to advance every clock we
+        // target, without load-sensitivity.
+        std::thread::sleep(std::time::Duration::from_micros(50));
         let b = w.elapsed_us();
         assert!(b >= a, "elapsed went backwards: {a} -> {b}");
     }

--- a/crates/beast-sim/src/lib.rs
+++ b/crates/beast-sim/src/lib.rs
@@ -43,6 +43,7 @@ pub mod schedule;
 pub mod simulation;
 pub mod tick;
 
+pub use budget::TickResult;
 pub use error::{Result, SimError};
 pub use schedule::SystemSchedule;
 pub use simulation::{Simulation, SimulationConfig};

--- a/crates/beast-sim/src/lib.rs
+++ b/crates/beast-sim/src/lib.rs
@@ -36,7 +36,12 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
-pub mod budget;
+// `budget` is pub(crate): its public surface (`TickResult`) is
+// re-exported at the crate root below. Keeping the module path
+// crate-internal prevents future items added to `budget.rs` from
+// accidentally becoming part of the public API without an explicit
+// re-export decision.
+pub(crate) mod budget;
 pub mod determinism;
 pub mod error;
 pub mod schedule;

--- a/crates/beast-sim/src/schedule.rs
+++ b/crates/beast-sim/src/schedule.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 
 use beast_ecs::{EcsWorld, Resources, System, SystemStage};
 
+use crate::budget::Stopwatch;
 use crate::error::Result;
 
 /// Ordered collection of systems keyed by [`SystemStage`].
@@ -64,13 +65,25 @@ impl SystemSchedule {
     /// (aborted mid-way by an error) is still observable via
     /// `resources.tick_counter` being unchanged from the pre-tick
     /// value.
-    pub fn run_tick(&mut self, world: &mut EcsWorld, resources: &mut Resources) -> Result<()> {
-        for systems in self.systems.values_mut() {
+    ///
+    /// Returns the per-stage wall-clock-microsecond breakdown (S6.4).
+    /// Only stages that actually ran (≥ 1 registered system) appear in
+    /// the map. Timing is observation only; it must never influence
+    /// sim-state control flow (INVARIANTS §1).
+    pub fn run_tick(
+        &mut self,
+        world: &mut EcsWorld,
+        resources: &mut Resources,
+    ) -> Result<BTreeMap<SystemStage, u64>> {
+        let mut stage_durations: BTreeMap<SystemStage, u64> = BTreeMap::new();
+        for (stage, systems) in self.systems.iter_mut() {
+            let watch = Stopwatch::start();
             for system in systems.iter_mut() {
                 system.run(world, resources)?;
             }
+            stage_durations.insert(*stage, watch.elapsed_us());
         }
-        Ok(())
+        Ok(stage_durations)
     }
 
     /// Number of systems registered across every stage. Useful for

--- a/crates/beast-sim/src/simulation.rs
+++ b/crates/beast-sim/src/simulation.rs
@@ -15,6 +15,7 @@ use beast_core::TickCounter;
 use beast_ecs::{components, EcsWorld, Resources};
 use beast_primitives::PrimitiveRegistry;
 
+use crate::budget::{Stopwatch, TickResult};
 use crate::error::Result;
 use crate::schedule::SystemSchedule;
 
@@ -119,15 +120,25 @@ impl Simulation {
     /// Advance the simulation by one tick.
     ///
     /// Runs every registered system in declared [`beast_ecs::SystemStage`]
-    /// order, then increments the tick counter. If any system returns
-    /// an error the tick aborts — the counter is **not** advanced, so
-    /// `sim.tick()` returning `Err` leaves `resources.tick_counter`
-    /// unchanged.
-    pub fn tick(&mut self) -> Result<()> {
-        self.schedule
+    /// order, then increments the tick counter. Returns a
+    /// [`TickResult`] with the total + per-stage wall-clock durations
+    /// in microseconds — observation only, never fed back into sim
+    /// state.
+    ///
+    /// If any system returns an error the tick aborts — the counter is
+    /// **not** advanced, so `sim.tick()` returning `Err` leaves
+    /// `resources.tick_counter` unchanged.
+    pub fn tick(&mut self) -> Result<TickResult> {
+        let watch = Stopwatch::start();
+        let stage_durations = self
+            .schedule
             .run_tick(&mut self.world, &mut self.resources)?;
         self.resources.advance_tick();
-        Ok(())
+        Ok(TickResult {
+            tick: self.resources.tick_counter,
+            duration_us: watch.elapsed_us(),
+            stage_durations,
+        })
     }
 
     /// Immutable view of the ECS world.
@@ -189,8 +200,9 @@ mod tests {
     fn tick_advances_the_counter_exactly_once() {
         let mut sim = Simulation::new(SimulationConfig::empty(5));
         for expected in 1..=20 {
-            sim.tick().expect("tick");
+            let result = sim.tick().expect("tick");
             assert_eq!(sim.current_tick().raw(), expected);
+            assert_eq!(result.tick.raw(), expected);
         }
     }
 
@@ -198,8 +210,52 @@ mod tests {
     fn tick_with_no_systems_succeeds_and_advances() {
         let mut sim = Simulation::new(SimulationConfig::empty(5));
         assert!(sim.schedule().is_empty());
-        sim.tick().expect("empty tick ok");
+        let result = sim.tick().expect("empty tick ok");
         assert_eq!(sim.current_tick().raw(), 1);
+        assert_eq!(result.tick.raw(), 1);
+        // No systems ran → no stage entries.
+        assert!(result.stage_durations.is_empty());
+    }
+
+    #[test]
+    fn tick_result_reports_stage_and_tick_metadata() {
+        use beast_ecs::{EcsWorld, Resources, System, SystemStage};
+
+        struct Noop(SystemStage);
+        impl System for Noop {
+            fn name(&self) -> &'static str {
+                "noop"
+            }
+            fn stage(&self) -> SystemStage {
+                self.0
+            }
+            fn run(
+                &mut self,
+                _world: &mut EcsWorld,
+                _resources: &mut Resources,
+            ) -> beast_ecs::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut sim = Simulation::new(SimulationConfig::empty(11));
+        sim.register_system(Noop(SystemStage::Genetics));
+        sim.register_system(Noop(SystemStage::Ecology));
+
+        let r = sim.tick().expect("tick");
+        assert_eq!(r.tick.raw(), 1);
+        // Both stages ran exactly once — each appears in the map.
+        assert!(r.stage_durations.contains_key(&SystemStage::Genetics));
+        assert!(r.stage_durations.contains_key(&SystemStage::Ecology));
+        assert_eq!(r.stage_durations.len(), 2);
+        // Per-stage + total are monotonically consistent (total ≥ sum).
+        let sum: u64 = r.stage_durations.values().sum();
+        assert!(
+            r.duration_us >= sum,
+            "total ({}) must be ≥ sum of stages ({})",
+            r.duration_us,
+            sum
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #117 (S6.2). **Skips S6.3** — parallel dispatch is filed as scoped-out (#118); serial dispatch is sufficient for the MVP determinism gate, and parallelism needs a SystemData-style access declaration which is a post-M1 refactor.

## Summary
`Simulation::tick` now returns `Result<TickResult>` with:
- `tick: TickCounter` — post-tick counter value
- `duration_us: u64` — total wall-clock for the tick
- `stage_durations: BTreeMap<SystemStage, u64>` — per-stage microseconds

## Determinism
Timing is **observation only** — never flows back into sim state (INVARIANTS §1). The scheduler calls a private `Stopwatch` wrapper over `std::time::Instant`; values are written into `TickResult` and returned but never read for control-flow decisions. S6.7 will act on them to defer systems when a stage overruns.

## Changes
- `budget::TickResult` and crate-private `budget::Stopwatch`.
- `SystemSchedule::run_tick` now returns `BTreeMap<SystemStage, u64>` (only stages that actually ran appear).
- `Simulation::tick` wraps `run_tick` in an outer `Stopwatch` for the total.
- `TickResult` re-exported at the crate root.

## Test plan
- [x] 4 new tests: stopwatch monotonicity, TickResult defaults, stage_durations BTreeMap total-ordering, metadata-reports test (two-stage run asserts both stages in map, `total ≥ Σ stage durations`).
- [x] Existing `tick` tests updated to read `TickResult`.
- [x] `cargo test -p beast-sim` — 15 tests + 1 doc test green.
- [x] `cargo clippy -p beast-sim --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

Refs #18. Closes #119.