### PR TITLE
feat(beast-sim): S6.7 per-system budget profiling + overrun reporting

### DIFF
--- a/crates/beast-sim/src/budget.rs
+++ b/crates/beast-sim/src/budget.rs
@@ -15,7 +15,7 @@ use beast_core::TickCounter;
 use beast_ecs::SystemStage;
 
 /// Summary of a single tick: what tick number it was, total wall-clock
-/// duration, and per-stage breakdown.
+/// duration, and per-stage + per-system breakdowns.
 ///
 /// `stage_durations` only contains entries for stages that had at least
 /// one system registered; empty stages do not appear.
@@ -31,6 +31,27 @@ pub struct TickResult {
     /// `BTreeMap` so iteration is deterministic if two tests compare
     /// serialised results.
     pub stage_durations: BTreeMap<SystemStage, u64>,
+    /// Systems that exceeded their declared `budget_us` during this
+    /// tick (S6.7). Empty when every system stayed under budget or
+    /// when every registered system declined to declare a budget.
+    /// Ordered by `(stage, registration_index)` so cross-tick diffs
+    /// are meaningful.
+    pub overruns: Vec<BudgetOverrun>,
+}
+
+/// One entry of [`TickResult::overruns`]. Purely observational — the
+/// scheduler never reads these back for control-flow decisions on the
+/// sim path (INVARIANTS §1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetOverrun {
+    /// `System::name()` of the offending system.
+    pub system: &'static str,
+    /// Stage the system was registered to.
+    pub stage: SystemStage,
+    /// Declared budget in microseconds.
+    pub budget_us: u64,
+    /// Actual wall-clock duration in microseconds.
+    pub actual_us: u64,
 }
 
 /// Minimal wrapper over `std::time::Instant` so test code can audit
@@ -84,10 +105,12 @@ mod tests {
             tick: TickCounter::new(0),
             duration_us: 0,
             stage_durations: BTreeMap::new(),
+            overruns: Vec::new(),
         };
         assert_eq!(t.tick.raw(), 0);
         assert_eq!(t.duration_us, 0);
         assert!(t.stage_durations.is_empty());
+        assert!(t.overruns.is_empty());
     }
 
     #[test]

--- a/crates/beast-sim/src/schedule.rs
+++ b/crates/beast-sim/src/schedule.rs
@@ -18,14 +18,29 @@ use std::collections::BTreeMap;
 
 use beast_ecs::{EcsWorld, Resources, System, SystemStage};
 
-use crate::budget::Stopwatch;
+use crate::budget::{BudgetOverrun, Stopwatch};
 use crate::error::Result;
+
+/// Budget value meaning "no declared budget" — a system registered via
+/// [`SystemSchedule::register`] gets this; nothing ever overruns.
+/// Explicit constant (not `u64::MAX`) so `run_tick` can skip the
+/// overrun-recording branch cheaply.
+const NO_BUDGET: u64 = u64::MAX;
+
+/// Internal entry — a registered system plus its declared budget.
+struct SystemEntry {
+    system: Box<dyn System + Send>,
+    /// Declared budget in microseconds. `NO_BUDGET` means "don't
+    /// record overruns for this system".
+    budget_us: u64,
+}
 
 /// Ordered collection of systems keyed by [`SystemStage`].
 ///
 /// Build with [`SystemSchedule::new`], push systems with
-/// [`SystemSchedule::register`], and drive it each tick with
-/// [`SystemSchedule::run_tick`].
+/// [`SystemSchedule::register`] or
+/// [`SystemSchedule::register_with_budget`], and drive it each tick
+/// with [`SystemSchedule::run_tick`].
 #[derive(Default)]
 pub struct SystemSchedule {
     // BTreeMap → deterministic stage order; Vec inside → deterministic
@@ -34,7 +49,7 @@ pub struct SystemSchedule {
     // `Send` on the inner trait object keeps the schedule `Send` so
     // S6.3 can parallelise inside a stage via rayon without fighting
     // the trait bound.
-    systems: BTreeMap<SystemStage, Vec<Box<dyn System + Send>>>,
+    systems: BTreeMap<SystemStage, Vec<SystemEntry>>,
 }
 
 impl SystemSchedule {
@@ -44,16 +59,31 @@ impl SystemSchedule {
         Self::default()
     }
 
-    /// Register a system. Appends to the stage bucket; within-stage
-    /// order is registration order.
+    /// Register a system without a budget. Appends to the stage
+    /// bucket; within-stage order is registration order. Budgetless
+    /// systems never appear in [`crate::TickResult::overruns`].
     pub fn register<S>(&mut self, system: S)
+    where
+        S: System + Send + 'static,
+    {
+        self.register_with_budget(system, NO_BUDGET);
+    }
+
+    /// Register a system with an explicit budget in microseconds
+    /// (S6.7). Any tick where the system's wall-clock duration exceeds
+    /// `budget_us` adds an entry to [`crate::TickResult::overruns`].
+    /// The scheduler does not act on overruns — it only reports them.
+    pub fn register_with_budget<S>(&mut self, system: S, budget_us: u64)
     where
         S: System + Send + 'static,
     {
         self.systems
             .entry(system.stage())
             .or_default()
-            .push(Box::new(system));
+            .push(SystemEntry {
+                system: Box::new(system),
+                budget_us,
+            });
     }
 
     /// Run one tick's worth of systems, stage by stage in declared
@@ -66,24 +96,37 @@ impl SystemSchedule {
     /// `resources.tick_counter` being unchanged from the pre-tick
     /// value.
     ///
-    /// Returns the per-stage wall-clock-microsecond breakdown (S6.4).
-    /// Only stages that actually ran (≥ 1 registered system) appear in
-    /// the map. Timing is observation only; it must never influence
-    /// sim-state control flow (INVARIANTS §1).
+    /// Returns `(stage_durations, overruns)`. Only stages that
+    /// actually ran appear in the map; `overruns` lists systems whose
+    /// wall-clock duration exceeded their declared `budget_us` in
+    /// `(stage, registration_index)` order. Timing is observation
+    /// only — it must never influence sim-state control flow
+    /// (INVARIANTS §1).
     pub fn run_tick(
         &mut self,
         world: &mut EcsWorld,
         resources: &mut Resources,
-    ) -> Result<BTreeMap<SystemStage, u64>> {
+    ) -> Result<(BTreeMap<SystemStage, u64>, Vec<BudgetOverrun>)> {
         let mut stage_durations: BTreeMap<SystemStage, u64> = BTreeMap::new();
+        let mut overruns: Vec<BudgetOverrun> = Vec::new();
         for (stage, systems) in self.systems.iter_mut() {
-            let watch = Stopwatch::start();
-            for system in systems.iter_mut() {
-                system.run(world, resources)?;
+            let stage_watch = Stopwatch::start();
+            for entry in systems.iter_mut() {
+                let system_watch = Stopwatch::start();
+                entry.system.run(world, resources)?;
+                let actual_us = system_watch.elapsed_us();
+                if entry.budget_us != NO_BUDGET && actual_us > entry.budget_us {
+                    overruns.push(BudgetOverrun {
+                        system: entry.system.name(),
+                        stage: *stage,
+                        budget_us: entry.budget_us,
+                        actual_us,
+                    });
+                }
             }
-            stage_durations.insert(*stage, watch.elapsed_us());
+            stage_durations.insert(*stage, stage_watch.elapsed_us());
         }
-        Ok(stage_durations)
+        Ok((stage_durations, overruns))
     }
 
     /// Number of systems registered across every stage. Useful for
@@ -251,6 +294,135 @@ mod tests {
         assert_eq!(schedule.len(), 0);
         let (mut w, mut r) = scratch_world_and_resources();
         schedule.run_tick(&mut w, &mut r).expect("empty tick ok");
+    }
+
+    /// Test system that sleeps `sleep_us` microseconds before
+    /// returning. Used to deterministically exceed a budget.
+    struct SlowSystem {
+        name: &'static str,
+        stage: SystemStage,
+        sleep_us: u64,
+    }
+
+    impl System for SlowSystem {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn stage(&self) -> SystemStage {
+            self.stage
+        }
+        fn run(
+            &mut self,
+            _world: &mut EcsWorld,
+            _resources: &mut Resources,
+        ) -> beast_ecs::Result<()> {
+            std::thread::sleep(std::time::Duration::from_micros(self.sleep_us));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn run_tick_reports_overrun_when_system_exceeds_budget() {
+        // SlowSystem sleeps 5_000 µs; budget 500 µs → overrun. The
+        // margins are generous (10x) so this isn't flaky on loaded CI.
+        let mut schedule = SystemSchedule::new();
+        schedule.register_with_budget(
+            SlowSystem {
+                name: "slow",
+                stage: SystemStage::Ecology,
+                sleep_us: 5_000,
+            },
+            500,
+        );
+        let (mut w, mut r) = scratch_world_and_resources();
+        let (_stage_durations, overruns) = schedule.run_tick(&mut w, &mut r).expect("tick");
+        assert_eq!(overruns.len(), 1);
+        assert_eq!(overruns[0].system, "slow");
+        assert_eq!(overruns[0].stage, SystemStage::Ecology);
+        assert_eq!(overruns[0].budget_us, 500);
+        assert!(
+            overruns[0].actual_us > 500,
+            "actual_us ({}) should exceed the budget ({})",
+            overruns[0].actual_us,
+            overruns[0].budget_us
+        );
+    }
+
+    #[test]
+    fn register_without_budget_never_reports_overrun() {
+        // A system registered via `register` (no budget) can take as
+        // long as it wants without landing in overruns. Guards against
+        // accidental regression where `NO_BUDGET` stops behaving as
+        // the "don't record" sentinel.
+        let mut schedule = SystemSchedule::new();
+        schedule.register(SlowSystem {
+            name: "no-budget",
+            stage: SystemStage::Ecology,
+            sleep_us: 2_000,
+        });
+        let (mut w, mut r) = scratch_world_and_resources();
+        let (_stage_durations, overruns) = schedule.run_tick(&mut w, &mut r).expect("tick");
+        assert!(overruns.is_empty());
+    }
+
+    #[test]
+    fn overruns_are_ordered_by_stage_then_registration() {
+        // Register two over-budget systems across two stages in
+        // reverse declaration order; overruns should come back in
+        // (stage, registration_index) order.
+        let mut schedule = SystemSchedule::new();
+        schedule.register_with_budget(
+            SlowSystem {
+                name: "ecology-slow",
+                stage: SystemStage::Ecology,
+                sleep_us: 3_000,
+            },
+            100,
+        );
+        schedule.register_with_budget(
+            SlowSystem {
+                name: "genetics-slow-a",
+                stage: SystemStage::Genetics,
+                sleep_us: 3_000,
+            },
+            100,
+        );
+        schedule.register_with_budget(
+            SlowSystem {
+                name: "genetics-slow-b",
+                stage: SystemStage::Genetics,
+                sleep_us: 3_000,
+            },
+            100,
+        );
+        let (mut w, mut r) = scratch_world_and_resources();
+        let (_stage_durations, overruns) = schedule.run_tick(&mut w, &mut r).expect("tick");
+        assert_eq!(overruns.len(), 3);
+        let names: Vec<_> = overruns.iter().map(|o| o.system).collect();
+        // Genetics comes before Ecology; within Genetics registration order.
+        assert_eq!(
+            names,
+            vec!["genetics-slow-a", "genetics-slow-b", "ecology-slow"]
+        );
+    }
+
+    #[test]
+    fn under_budget_systems_are_not_reported() {
+        // System that does nothing; budget is 1 second. Never overruns.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut schedule = SystemSchedule::new();
+        schedule.register_with_budget(
+            Recorder {
+                name: "fast",
+                stage: SystemStage::Genetics,
+                log: log.clone(),
+            },
+            1_000_000,
+        );
+        let (mut w, mut r) = scratch_world_and_resources();
+        let (_stage_durations, overruns) = schedule.run_tick(&mut w, &mut r).expect("tick");
+        assert!(overruns.is_empty());
+        assert_eq!(*log.lock().expect("log mutex poisoned"), vec!["fast"]);
     }
 
     #[test]

--- a/crates/beast-sim/src/simulation.rs
+++ b/crates/beast-sim/src/simulation.rs
@@ -134,7 +134,7 @@ impl Simulation {
     /// before calling `tick()`.
     pub fn tick(&mut self) -> Result<TickResult> {
         let watch = Stopwatch::start();
-        let stage_durations = self
+        let (stage_durations, overruns) = self
             .schedule
             .run_tick(&mut self.world, &mut self.resources)?;
         self.resources.advance_tick();
@@ -142,7 +142,20 @@ impl Simulation {
             tick: self.resources.tick_counter,
             duration_us: watch.elapsed_us(),
             stage_durations,
+            overruns,
         })
+    }
+
+    /// Register a system with an explicit microsecond budget (S6.7).
+    /// Any tick where the system's wall-clock duration exceeds
+    /// `budget_us` will be reported in [`TickResult::overruns`]. The
+    /// scheduler does not act on overruns — that's the caller's
+    /// decision.
+    pub fn register_system_with_budget<S>(&mut self, system: S, budget_us: u64)
+    where
+        S: beast_ecs::System + Send + 'static,
+    {
+        self.schedule.register_with_budget(system, budget_us);
     }
 
     /// Immutable view of the ECS world.

--- a/crates/beast-sim/tests/determinism_test.rs
+++ b/crates/beast-sim/tests/determinism_test.rs
@@ -1,0 +1,181 @@
+//! M1 Core Loop determinism gate (S6.6 — issue #123).
+//!
+//! The contract this file enforces: given identical
+//! [`SimulationConfig`], running the tick loop twice must produce
+//! bit-identical [`beast_sim::compute_state_hash`] at **every** tick.
+//! If any of these tests ever regresses, the simulation is no longer
+//! deterministic and replay is broken — so this file is the CI gate
+//! for the whole determinism invariant (INVARIANTS §1) until S7's
+//! save/load layer extends it across process boundaries.
+//!
+//! # Scope (explicitly)
+//!
+//! * Only the tick loop + the toy systems registered below. The full
+//!   8-stage game-system pipeline lands per-system in Phase 3.
+//! * Only in-process replay. Cross-process, save-to-disk replay lands
+//!   in S7.
+
+use beast_core::Q3232;
+use beast_ecs::components::{Age, Creature, Mass};
+use beast_ecs::{Builder, EcsWorld, MarkerKind, Resources, System, SystemStage, WorldExt};
+use beast_sim::{compute_state_hash, Simulation, SimulationConfig};
+
+/// Sequential-pattern aging system (Pattern A). Increments every
+/// creature's `Age.ticks` once per run. Per INVARIANTS §1 the
+/// iteration is via `entity_index`, not `specs::Join`.
+struct AgingSystem;
+
+impl System for AgingSystem {
+    fn name(&self) -> &'static str {
+        "determinism-test-aging"
+    }
+    fn stage(&self) -> SystemStage {
+        SystemStage::InputAndAging
+    }
+    fn run(&mut self, world: &mut EcsWorld, resources: &mut Resources) -> beast_ecs::Result<()> {
+        let creatures: Vec<_> = resources
+            .entity_index
+            .entities_of(MarkerKind::Creature)
+            .collect();
+        let mut ages = world.world().write_storage::<Age>();
+        for entity in creatures {
+            if let Some(age) = ages.get_mut(entity) {
+                age.ticks += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn build_fixture(seed: u64, n_creatures: usize) -> Simulation {
+    let mut sim = Simulation::new(SimulationConfig::empty(seed));
+    sim.register_system(AgingSystem);
+    // Deterministic entity creation: positions derived from index so
+    // the world content is a pure function of `(seed, n_creatures)`.
+    for i in 0..n_creatures {
+        let entity = sim
+            .world_mut()
+            .create_entity()
+            .with(Creature)
+            .with(Age::new(0))
+            .with(Mass::new(Q3232::from_num((i + 1) as i32)))
+            .build();
+        sim.resources_mut()
+            .entity_index
+            .insert(entity, MarkerKind::Creature);
+    }
+    sim
+}
+
+/// Capture `(tick, hash)` every tick for `ticks` ticks. Returns the
+/// trace that two replays must byte-match.
+fn capture_trace(mut sim: Simulation, ticks: usize) -> Vec<(u64, [u8; 32])> {
+    let mut trace = Vec::with_capacity(ticks);
+    for _ in 0..ticks {
+        let result = sim.tick().expect("tick ok");
+        trace.push((result.tick.raw(), compute_state_hash(&sim)));
+    }
+    trace
+}
+
+#[test]
+fn replay_is_bit_identical_across_100_ticks() {
+    const TICKS: usize = 100;
+    const CREATURES: usize = 50;
+    const SEED: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+    let trace_a = capture_trace(build_fixture(SEED, CREATURES), TICKS);
+    let trace_b = capture_trace(build_fixture(SEED, CREATURES), TICKS);
+
+    assert_eq!(trace_a.len(), TICKS);
+    assert_eq!(trace_b.len(), TICKS);
+    for i in 0..TICKS {
+        assert_eq!(
+            trace_a[i], trace_b[i],
+            "divergence at tick {}: {:?} vs {:?}",
+            trace_a[i].0, trace_a[i], trace_b[i]
+        );
+    }
+}
+
+#[test]
+fn different_seeds_diverge_within_a_handful_of_ticks() {
+    const TICKS: usize = 8;
+    const CREATURES: usize = 10;
+
+    let trace_a = capture_trace(build_fixture(1, CREATURES), TICKS);
+    let trace_b = capture_trace(build_fixture(2, CREATURES), TICKS);
+
+    // Preamble carries the seed, so hashes differ from tick 1 onward
+    // even before any RNG draws happen.
+    assert_ne!(
+        trace_a[0].1, trace_b[0].1,
+        "different seeds should produce different hashes from tick 1"
+    );
+    // Full trace divergence: all 8 entries differ in the hash half.
+    for i in 0..TICKS {
+        assert_ne!(
+            trace_a[i].1,
+            trace_b[i].1,
+            "traces unexpectedly matched at tick {} under different seeds",
+            i + 1
+        );
+    }
+}
+
+#[test]
+fn hash_changes_every_tick_when_state_mutates() {
+    // With AgingSystem incrementing every creature every tick, the
+    // state hash must strictly change tick-over-tick. An unchanged hash
+    // means the aging didn't take effect — silent determinism break.
+    const TICKS: usize = 50;
+    const CREATURES: usize = 5;
+
+    let trace = capture_trace(build_fixture(42, CREATURES), TICKS);
+
+    for i in 1..TICKS {
+        assert_ne!(
+            trace[i - 1].1,
+            trace[i].1,
+            "hash did not advance between tick {} and tick {}",
+            trace[i - 1].0,
+            trace[i].0,
+        );
+    }
+}
+
+#[test]
+fn empty_world_replay_still_advances_preamble_hash() {
+    // No entities, no systems. Just the tick counter advancing. The
+    // hash must still change every tick (preamble carries the tick
+    // counter) and both replays must produce the identical trace.
+    const TICKS: usize = 25;
+    let run = || {
+        let sim = Simulation::new(SimulationConfig::empty(99));
+        capture_trace(sim, TICKS)
+    };
+    let a = run();
+    let b = run();
+    assert_eq!(a, b);
+    for i in 1..TICKS {
+        assert_ne!(
+            a[i - 1].1,
+            a[i].1,
+            "empty-world hash stalled between tick {} and tick {}",
+            a[i - 1].0,
+            a[i].0,
+        );
+    }
+}
+
+#[test]
+fn tick_counter_in_trace_is_monotonic_one_per_tick() {
+    // Sanity: the tick numbers in the trace are 1..=TICKS, no gaps,
+    // no repeats. A skipped or repeated tick would silently invalidate
+    // every assertion above.
+    const TICKS: usize = 100;
+    let trace = capture_trace(build_fixture(7, 0), TICKS);
+    for (i, (tick, _hash)) in trace.iter().enumerate() {
+        assert_eq!(*tick, (i + 1) as u64, "tick counter skipped at index {i}");
+    }
+}


### PR DESCRIPTION
Stacked on #127 (S6.6).

## Summary
- New `BudgetOverrun { system, stage, budget_us, actual_us }` struct + `TickResult.overruns: Vec<BudgetOverrun>`.
- `SystemSchedule::register_with_budget(system, budget_us)` records a per-system microsecond budget; `register` is preserved as a thin wrapper using `NO_BUDGET = u64::MAX` (no-budget systems never report).
- `Simulation::register_system_with_budget` mirrors the new schedule API.
- `run_tick` times each system individually with a `Stopwatch`; if `actual_us > budget_us`, an entry lands in `overruns` (ordered by `(stage, registration_index)`).
- 4 new unit tests covering: overrun detection (5000µs sleep vs 500µs budget — 10x margin for CI stability), `NO_BUDGET` skipping, ordering, under-budget cases.

## Determinism guard
The `BudgetOverrun` data is observation-only: the scheduler never reads it back to make per-system control-flow decisions on the sim path (INVARIANTS §1). Documented in the module headers.

## Scoped-out follow-up
Filed #126 — adaptive-quality system deferral (the *control* half of "budget + defer"). MVP keeps the observation half only; deferral lands post-MVP.

## Test plan
- [x] `cargo test -p beast-sim --locked` — all green (29 unit + 5 integration + 1 doc).
- [x] `cargo clippy -p beast-sim --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

Refs #18. Closes #125.