### PR TITLE
feat(beast-ecs): S8.2 BiomeCell + BiomeKind components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "beast-primitives",
  "proptest",
  "serde",
+ "serde_json",
  "specs",
  "thiserror",
 ]

--- a/crates/beast-ecs/Cargo.toml
+++ b/crates/beast-ecs/Cargo.toml
@@ -29,6 +29,10 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+# S8.2 (#142) — round-trip tests for new components serialise via JSON
+# to verify the snake_case wire form. The runtime uses bincode through
+# beast-serde; serde_json is dev-only here.
+serde_json = { workspace = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/beast-ecs/src/components.rs
+++ b/crates/beast-ecs/src/components.rs
@@ -9,11 +9,13 @@
 //! components additionally derive `Serialize`/`Deserialize` so the save
 //! path (S7) can round-trip them without further plumbing.
 
+pub mod biome;
 pub mod markers;
 pub mod physiology;
 pub mod spatial;
 pub mod traits;
 
+pub use biome::{BiomeCell, BiomeKind};
 pub use markers::{Agent, Biome, Creature, Faction, Pathogen, Settlement};
 pub use physiology::{Age, DevelopmentalStage, HealthState, Mass, Species};
 pub use spatial::{Position, Velocity};
@@ -41,6 +43,8 @@ pub fn register_all(world: &mut crate::EcsWorld) {
 
     world.register_component::<GenomeComponent>();
     world.register_component::<PhenotypeComponent>();
+
+    world.register_component::<BiomeCell>();
 }
 
 #[cfg(test)]
@@ -89,5 +93,6 @@ mod tests {
         is_dense::<Species>();
         is_dense::<GenomeComponent>();
         is_dense::<PhenotypeComponent>();
+        is_dense::<BiomeCell>();
     }
 }

--- a/crates/beast-ecs/src/components/biome.rs
+++ b/crates/beast-ecs/src/components/biome.rs
@@ -49,9 +49,20 @@ pub enum BiomeKind {
 
 impl BiomeKind {
     /// String form expected by future channel manifests that filter
-    /// by terrain (e.g., "expression_conditions: { terrain: forest }").
+    /// by **terrain** (e.g., "expression_conditions: { terrain: forest }").
     /// Stable across versions — a rename would break every shipping
     /// manifest that references it.
+    ///
+    /// Distinct from the existing `biome_flag` expression-condition
+    /// kind, which is a free-form ecological/sensory niche tag (e.g.,
+    /// `complex_soundscape`, `nocturnal`). A future schema kind will
+    /// enum-constrain terrain matches to these strings — tracked in
+    /// issue #156.
+    ///
+    /// Equivalent to the snake_case form produced by
+    /// `serde_json::to_string`, locked in by the
+    /// `as_str_matches_serde_for_every_variant` test below so a new
+    /// `BiomeKind` variant can't silently desynchronise the two.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -105,9 +116,15 @@ impl BiomeCell {
         }
     }
 
-    /// Conventional ocean cell with the spec's default 288.15K (15°C)
-    /// surface temperature and 1000mm precipitation. Used by the
-    /// world-gen default when a coordinate hasn't been classified yet.
+    /// Conventional ocean cell at the spec's default 288K (~15°C, the
+    /// integer-Kelvin approximation of 288.15K) surface temperature and
+    /// 1000mm precipitation. Used by the world-gen default when a
+    /// coordinate hasn't been classified yet.
+    ///
+    /// The 0.15K shave keeps every default constructor expressible as
+    /// an integer Q3232 literal; the climate model (S8.5) is the right
+    /// place to introduce sub-Kelvin precision when seasonal deltas
+    /// land.
     #[must_use]
     pub fn ocean() -> Self {
         Self::new(
@@ -148,6 +165,34 @@ mod tests {
     fn biome_kind_serialises_as_snake_case_in_json() {
         let s = serde_json::to_string(&BiomeKind::Forest).unwrap();
         assert_eq!(s, "\"forest\"");
+    }
+
+    #[test]
+    fn as_str_matches_serde_for_every_variant() {
+        // Lock-in: `as_str` is hand-written, `serde(rename_all =
+        // "snake_case")` is automatic. A new variant (e.g.,
+        // `TemperateForest`) gets a serde string for free but the
+        // compiler won't flag a missing `as_str` arm — it would
+        // produce a stale string. Asserting per-variant equivalence
+        // here means a missing arm fails the test on first add.
+        for variant in [
+            BiomeKind::Ocean,
+            BiomeKind::Forest,
+            BiomeKind::Plains,
+            BiomeKind::Desert,
+            BiomeKind::Mountain,
+            BiomeKind::Tundra,
+        ] {
+            let serde_form = serde_json::to_string(&variant).unwrap();
+            let trimmed = serde_form.trim_matches('"');
+            assert_eq!(
+                variant.as_str(),
+                trimmed,
+                "as_str / serde divergence for {variant:?}: as_str={:?}, serde={:?}",
+                variant.as_str(),
+                trimmed,
+            );
+        }
     }
 
     #[test]

--- a/crates/beast-ecs/src/components/biome.rs
+++ b/crates/beast-ecs/src/components/biome.rs
@@ -1,0 +1,198 @@
+//! Biome geography components — [`BiomeCell`] and [`BiomeKind`].
+//!
+//! Pairs with the existing [`crate::components::Biome`] marker
+//! (`NullStorage`, presence-only). When an entity carries the `Biome`
+//! marker, it should also carry a `BiomeCell` describing the patch's
+//! terrain, base climate, and ecological budget.
+//!
+//! `BiomeCell.temperature_kelvin` and `BiomeCell.precipitation_mm_per_year`
+//! are the **base** values for the cell. The climate system (S8.5)
+//! reads them and applies a season-aware seasonal delta when reading,
+//! never mutating the underlying field — this keeps the closed-cycle
+//! invariant exact (after 1000 ticks the visible value matches the
+//! base, with no accumulated rounding error).
+//!
+//! # Determinism
+//!
+//! All numeric fields are Q32.32 fixed-point integers. `BiomeKind` is
+//! `Ord` and serialises as snake_case so two equal cells round-trip
+//! to byte-identical JSON.
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+use specs::{Component, DenseVecStorage};
+
+/// Coarse terrain classification for a biome cell. The MVP keeps the
+/// taxonomy small; future expansion (rainforest, taiga, savanna…)
+/// happens behind the `#[non_exhaustive]` attribute so existing match
+/// sites won't break.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BiomeKind {
+    /// Open salt-water sea — the default for un-generated cells.
+    #[default]
+    Ocean,
+    /// Wooded continent interior, mid-temperature, mid-precipitation.
+    Forest,
+    /// Open grassland, mid-temperature, low precipitation.
+    Plains,
+    /// Hot, dry, low carrying capacity.
+    Desert,
+    /// High elevation, cold, sparse cover.
+    Mountain,
+    /// Polar / sub-polar, cold, mid precipitation as snow.
+    Tundra,
+}
+
+impl BiomeKind {
+    /// String form expected by future channel manifests that filter
+    /// by terrain (e.g., "expression_conditions: { terrain: forest }").
+    /// Stable across versions — a rename would break every shipping
+    /// manifest that references it.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BiomeKind::Ocean => "ocean",
+            BiomeKind::Forest => "forest",
+            BiomeKind::Plains => "plains",
+            BiomeKind::Desert => "desert",
+            BiomeKind::Mountain => "mountain",
+            BiomeKind::Tundra => "tundra",
+        }
+    }
+}
+
+/// Per-cell biome state. Stored on every entity carrying the
+/// [`crate::components::Biome`] marker; the world-gen pass (S8.1)
+/// allocates one entity per grid cell.
+///
+/// `Default` is intentionally not derived — every cell needs an
+/// explicit `BiomeKind` choice; the all-zeros default would be silent
+/// "Ocean with 0K, 0mm rainfall, 0 carrying capacity" which is rarely
+/// the intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BiomeCell {
+    /// Terrain classification.
+    pub kind: BiomeKind,
+    /// Base annual mean temperature in Kelvin, Q32.32. The climate
+    /// system overlays a seasonal delta; this field is the closed
+    /// reference point.
+    pub temperature_kelvin: Q3232,
+    /// Base annual precipitation in millimetres per year, Q32.32.
+    pub precipitation_mm_per_year: Q3232,
+    /// Maximum number of creatures the cell sustains. Population
+    /// dynamics (S15+) consult this to throttle reproduction.
+    pub carrying_capacity: u32,
+}
+
+impl BiomeCell {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(
+        kind: BiomeKind,
+        temperature_kelvin: Q3232,
+        precipitation_mm_per_year: Q3232,
+        carrying_capacity: u32,
+    ) -> Self {
+        Self {
+            kind,
+            temperature_kelvin,
+            precipitation_mm_per_year,
+            carrying_capacity,
+        }
+    }
+
+    /// Conventional ocean cell with the spec's default 288.15K (15°C)
+    /// surface temperature and 1000mm precipitation. Used by the
+    /// world-gen default when a coordinate hasn't been classified yet.
+    #[must_use]
+    pub fn ocean() -> Self {
+        Self::new(
+            BiomeKind::Ocean,
+            Q3232::from_num(288),
+            Q3232::from_num(1000),
+            0,
+        )
+    }
+}
+
+impl Component for BiomeCell {
+    type Storage = DenseVecStorage<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn biome_kind_default_is_ocean() {
+        assert_eq!(BiomeKind::default(), BiomeKind::Ocean);
+    }
+
+    #[test]
+    fn biome_kind_as_str_is_stable() {
+        // Locked in: a rename of these strings would break every
+        // shipped channel manifest that expression-filters on terrain.
+        assert_eq!(BiomeKind::Ocean.as_str(), "ocean");
+        assert_eq!(BiomeKind::Forest.as_str(), "forest");
+        assert_eq!(BiomeKind::Plains.as_str(), "plains");
+        assert_eq!(BiomeKind::Desert.as_str(), "desert");
+        assert_eq!(BiomeKind::Mountain.as_str(), "mountain");
+        assert_eq!(BiomeKind::Tundra.as_str(), "tundra");
+    }
+
+    #[test]
+    fn biome_kind_serialises_as_snake_case_in_json() {
+        let s = serde_json::to_string(&BiomeKind::Forest).unwrap();
+        assert_eq!(s, "\"forest\"");
+    }
+
+    #[test]
+    fn biome_cell_ocean_preset_round_trips_through_serde() {
+        let original = BiomeCell::ocean();
+        let s = serde_json::to_string(&original).unwrap();
+        let parsed: BiomeCell = serde_json::from_str(&s).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn biome_cell_constructor_carries_inputs() {
+        let cell = BiomeCell::new(
+            BiomeKind::Forest,
+            Q3232::from_num(283),
+            Q3232::from_num(1500),
+            64,
+        );
+        assert_eq!(cell.kind, BiomeKind::Forest);
+        assert_eq!(cell.temperature_kelvin, Q3232::from_num(283));
+        assert_eq!(cell.precipitation_mm_per_year, Q3232::from_num(1500));
+        assert_eq!(cell.carrying_capacity, 64);
+    }
+
+    #[test]
+    fn biome_cell_storage_is_densevec() {
+        // Locks in the storage choice — switching to VecStorage would
+        // waste memory for a sparse biome map.
+        fn is_dense<C>()
+        where
+            C: specs::Component<Storage = specs::DenseVecStorage<C>>,
+        {
+        }
+        is_dense::<BiomeCell>();
+    }
+
+    #[test]
+    fn biome_kind_ord_is_declaration_order() {
+        // BiomeKind backs deterministic iteration in places that key by
+        // it (e.g., a future BTreeMap<BiomeKind, _>). Lock the order.
+        use BiomeKind::*;
+        assert!(Ocean < Forest);
+        assert!(Forest < Plains);
+        assert!(Plains < Desert);
+        assert!(Desert < Mountain);
+        assert!(Mountain < Tundra);
+    }
+}


### PR DESCRIPTION
First story of Sprint S8 — World Generation. Independent of the open S7 chain, so it stacks on `master` directly.

## Summary
Adds the per-cell biome data type that pairs with the existing `Biome` marker. World-gen (S8.1, #141) will allocate one entity per grid cell with both the marker and a `BiomeCell`.

- `BiomeKind` — coarse terrain classification: Ocean (default), Forest, Plains, Desert, Mountain, Tundra. `#[non_exhaustive]` so expansion doesn't break match sites. Stable `as_str` mapping for future channel-manifest filters.
- `BiomeCell { kind, temperature_kelvin, precipitation_mm_per_year, carrying_capacity }`. All Q32.32; no float. No `Default` derive (would silently mean "Ocean with 0K, 0 capacity").
- `BiomeCell::ocean()` preset (288K / 1000mm / 0 capacity) for un-classified cells — matches the world-gen sea-level default.
- `Component<Storage = DenseVecStorage>` registered in `components::register_all`. Storage choice locked in via the existing `data_storage_is_densevec` guard.

## Climate-system coupling
`temperature_kelvin` / `precipitation_mm_per_year` are **base** values. S8.5's `ClimateSystem` will overlay a seasonal delta when reading rather than mutating the field — closed-cycle invariant (values at tick 1000 == values at tick 0) holds exactly with no accumulated rounding.

## Save layer
SaveFile carry-through (extending `SerializedEntity` with `Option<BiomeCell>`) is a tiny follow-up that lands once the S7 chain merges. Not blocking S8.2.

## Tests (6 new, all green)
- `biome_kind_default_is_ocean`
- `biome_kind_as_str_is_stable`
- `biome_kind_serialises_as_snake_case_in_json`
- `biome_cell_ocean_preset_round_trips_through_serde`
- `biome_cell_constructor_carries_inputs`
- `biome_cell_storage_is_densevec`
- `biome_kind_ord_is_declaration_order`

## Test plan
- [x] `cargo test -p beast-ecs --locked` — green.
- [x] `cargo test --workspace --locked` — green.
- [x] `cargo clippy -p beast-ecs --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

Refs #20. Closes #142.