### PR TITLE
chore(beast-core): pre-graphics audit fixups

### DIFF
--- a/crates/beast-core/src/entity.rs
+++ b/crates/beast-core/src/entity.rs
@@ -76,7 +76,10 @@ impl fmt::Display for EntityId {
 /// respected even in bootstrap code.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EntityIdAllocator {
-    next: u32,
+    /// `pub(crate)` so external callers can't bypass `alloc()` /
+    /// `is_exhausted()` by struct-literal construction. The internal
+    /// tests fast-forward by setting this directly.
+    pub(crate) next: u32,
 }
 
 impl EntityIdAllocator {

--- a/crates/beast-core/src/error.rs
+++ b/crates/beast-core/src/error.rs
@@ -16,11 +16,11 @@ use thiserror::Error;
 pub enum Error {
     /// Fixed-point conversion failed (value out of Q32.32 range).
     #[error("fixed-point conversion out of range: {0}")]
-    FixedPointRange(String),
+    FixedPointRange(&'static str),
 
     /// PRNG seeding or stream-splitting failed.
     #[error("prng error: {0}")]
-    Prng(String),
+    Prng(&'static str),
 
     /// Invariant violation in `beast-core` — indicates a programmer bug, not a
     /// recoverable runtime condition.

--- a/crates/beast-core/src/math.rs
+++ b/crates/beast-core/src/math.rs
@@ -127,8 +127,29 @@ pub fn inv_lerp_q3232(a: Q3232, b: Q3232, v: Q3232) -> Q3232 {
 /// let delta = (sample - mean).saturating_abs();
 /// assert!(delta <= Q3232::from_num(16_i32));
 /// ```
+///
+/// # Cross-target determinism
+///
+/// The closed-form result depends on IEEE-754 `ln`, `sqrt`, `cos` and a
+/// fused multiply-add. Bit-for-bit equality holds across `x86_64` and
+/// `aarch64` with default rounding mode; this is locked in by the
+/// `target_arch`-gated `compile_error!` below. To port to a new target,
+/// add it to the gate (and bring up cross-target replay coverage in
+/// the determinism gate, issue #154) so a regression cannot land
+/// silently.
 #[allow(clippy::float_arithmetic)]
 pub fn gaussian_q3232(rng: &mut Prng, mean: Q3232, stddev: Q3232) -> Q3232 {
+    // SAFETY (determinism): see the function doc — this gate fires at
+    // compile time on any target_arch we have not audited for IEEE-754
+    // bit-exact `ln`/`sqrt`/`cos`/`mul_add`. Adding a new arch means
+    // bringing up cross-target replay coverage first (#154).
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    compile_error!(
+        "gaussian_q3232 is only audited for cross-process determinism on \
+         x86_64 and aarch64. To support another target, add it to the cfg \
+         gate after extending the cross-target replay determinism job in \
+         issue #154."
+    );
     // Draw two uniforms in (0, 1]. Box–Muller requires u1 > 0 because of ln.
     // We shift the standard [0, 1) draw by one ULP worth (2^-53) so that
     // u1 is strictly positive. This biases the distribution by a negligible

--- a/crates/beast-core/src/math.rs
+++ b/crates/beast-core/src/math.rs
@@ -139,10 +139,12 @@ pub fn inv_lerp_q3232(a: Q3232, b: Q3232, v: Q3232) -> Q3232 {
 /// silently.
 #[allow(clippy::float_arithmetic)]
 pub fn gaussian_q3232(rng: &mut Prng, mean: Q3232, stddev: Q3232) -> Q3232 {
-    // SAFETY (determinism): see the function doc — this gate fires at
-    // compile time on any target_arch we have not audited for IEEE-754
-    // bit-exact `ln`/`sqrt`/`cos`/`mul_add`. Adding a new arch means
-    // bringing up cross-target replay coverage first (#154).
+    // Determinism gate: this fires at compile time on any
+    // target_arch we have not audited for IEEE-754 bit-exact
+    // `ln`/`sqrt`/`cos`/`mul_add`. Adding a new arch means bringing
+    // up cross-target replay coverage first (#154). The `// SAFETY:`
+    // prefix is intentionally avoided — the crate `#![forbid(unsafe_code)]`
+    // and there is no unsafe-block invariant being documented.
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     compile_error!(
         "gaussian_q3232 is only audited for cross-process determinism on \

--- a/crates/beast-core/src/prng.rs
+++ b/crates/beast-core/src/prng.rs
@@ -33,9 +33,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// | Range | Reserved for |
 /// |-------|--------------|
-/// | `0..=8` | Production subsystems (Genetics, Phenotype, …, Testing). |
+/// | `0..=7` | Allocated production subsystems (Genetics, Phenotype, Physics, Combat, Physiology, Ecology, Worldgen, Chronicler). |
+/// | `8` | `Testing` — sim never runs against this slot, but it lives in the low-discriminant range so test setup pays bounded `long_jump` cost. |
 /// | `9..=4095` | Future production subsystems — pick the lowest unused. |
-/// | `4096..=u16::MAX` | Test-only / scratch slots. Free to renumber, but `long_jump` is called once per discriminant unit at split, so very large values cost startup latency. |
+/// | `4096..=u16::MAX` | Future test-only / scratch slots. Free to renumber, but `long_jump` is called once per discriminant unit at split, so very large values cost startup latency. |
 ///
 /// **Adding a new production variant**: pick the lowest unused
 /// discriminant in the production range (currently 9), assign it

--- a/crates/beast-core/src/prng.rs
+++ b/crates/beast-core/src/prng.rs
@@ -24,10 +24,22 @@ use serde::{Deserialize, Serialize};
 /// Enumeration of per-subsystem PRNG streams. Each variant corresponds to
 /// exactly one independent `Prng` instance in the simulation.
 ///
-/// **Adding a new variant**: append only — never reorder, never remove. The
-/// discriminant drives the `long_jump` count used to derive the stream, so
-/// reordering would shuffle every subsystem's stream and break replay
-/// compatibility with all existing saves.
+/// # Discriminant layout (the stable contract)
+///
+/// The numeric **discriminant value** is the stable identifier — *not* the
+/// position in source order. The discriminant drives [`Stream::jumps`],
+/// which feeds `Xoshiro256PlusPlus::long_jump`, so changing a discriminant
+/// reseeds the stream and breaks every shipping save.
+///
+/// | Range | Reserved for |
+/// |-------|--------------|
+/// | `0..=8` | Production subsystems (Genetics, Phenotype, …, Testing). |
+/// | `9..=4095` | Future production subsystems — pick the lowest unused. |
+/// | `4096..=u16::MAX` | Test-only / scratch slots. Free to renumber, but `long_jump` is called once per discriminant unit at split, so very large values cost startup latency. |
+///
+/// **Adding a new production variant**: pick the lowest unused
+/// discriminant in the production range (currently 9), assign it
+/// explicitly with `= N`, and never reorder existing variants in source.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum Stream {
@@ -48,7 +60,10 @@ pub enum Stream {
     /// Chronicler sampling and clustering randomness.
     Chronicler = 7,
     /// Explicit testing stream — never used by the live simulation.
-    Testing = 0xFFFF,
+    /// Kept in the low-discriminant range so test setup pays bounded
+    /// `long_jump` cost (8 invocations) rather than the ~65k that the
+    /// previous `0xFFFF` slot would have triggered.
+    Testing = 8,
 }
 
 impl Stream {


### PR DESCRIPTION
Branched off master. First of 10 audit-fixup PRs (one per crate) addressing the comprehensive pre-graphics rust-reviewer pass.

## Findings addressed (4 / 4 in this crate)

### HIGH (3)
- **`Stream::Testing` discriminant trap.** Relocated `Testing` from `0xFFFF` to `8`. Previous high discriminant triggered ~65k `long_jump` calls per split — now bounded at 8. Module doc now documents the discriminant-vs-source-order contract and reserves ranges for production (`0..=4095`) vs test-only growth (`4096..=u16::MAX`). `Stream` is not serialized anywhere, so renumber is non-breaking.
- **`gaussian_q3232` cross-arch determinism gate.** Added `#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]` `compile_error!`. The function depends on IEEE-754 bit-exact `ln`/`sqrt`/`cos`/`mul_add` which is only audited on those two arches. Adding a new target now requires updating the gate + bringing up cross-target replay coverage in #154.
- **`EntityIdAllocator::next` visibility.** Tightened to `pub(crate)` so external callers can't construct `EntityIdAllocator { next: u32::MAX - 1 }` and bypass the alloc/is_exhausted invariant. Internal tests fast-forward via struct literal still work.

### MEDIUM (1)
- **`Error::Prng` and `Error::FixedPointRange`** switched from `String` to `&'static str` to match `Invariant`/`OutOfRange`. Neither variant has a production constructor today; the switch is non-breaking and removes the heap allocation.

## Test plan
- [x] `cargo test --workspace` — all crates green (full suite).
- [x] `cargo clippy -p beast-core --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

Audit refs: tasks #30 (Stream), #31 (gaussian), #32 (EntityIdAllocator), #33 (Error variants).