### PR TITLE
chore(beast-manifest): pre-graphics audit fixups

### DIFF
--- a/crates/beast-manifest/src/provenance.rs
+++ b/crates/beast-manifest/src/provenance.rs
@@ -27,7 +27,15 @@ pub struct ProvenanceParseError(pub String);
 /// `"mod:foo"`, `"genesis:foo:123"`). Keeping the string form canonical
 /// means save files are self-describing and round-trippable without a
 /// separate enum tag.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+///
+/// `PartialOrd`/`Ord` are derived (declaration order: Core < Mod < Genesis,
+/// with within-variant ordering by string then `generation`) so
+/// `Provenance` can key a `BTreeMap` or live in a `BTreeSet` without an
+/// allocation. The ordering is stable and deterministic — it does not
+/// match `to_schema_string` lexicographic order, which is intentional:
+/// callers that want lexicographic UI display should sort by the
+/// rendered string explicitly.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Provenance {
     /// A canonical entry shipped by the core game.
     Core,

--- a/crates/beast-manifest/src/provenance.rs
+++ b/crates/beast-manifest/src/provenance.rs
@@ -203,6 +203,45 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn ord_is_declaration_order_with_within_variant_lexicographic() {
+        // Locks the canonical sort order documented on `Provenance`.
+        // A reorder of variants in the source enum (or a derive change)
+        // would shift `BTreeMap<Provenance, _>` iteration and break
+        // any consumer that snapshots the order — including replay
+        // fingerprints. This test fails on first compile if either
+        // happens.
+        assert!(Provenance::Core < Provenance::Mod("a".to_owned()));
+        assert!(
+            Provenance::Mod("a".to_owned())
+                < Provenance::Genesis {
+                    parent: "p".to_owned(),
+                    generation: 0,
+                }
+        );
+        // Within Mod, lexicographic by id.
+        assert!(Provenance::Mod("a".to_owned()) < Provenance::Mod("b".to_owned()));
+        // Within Genesis, lexicographic by parent then numeric by generation.
+        assert!(
+            Provenance::Genesis {
+                parent: "a".to_owned(),
+                generation: 99,
+            } < Provenance::Genesis {
+                parent: "b".to_owned(),
+                generation: 0,
+            }
+        );
+        assert!(
+            Provenance::Genesis {
+                parent: "a".to_owned(),
+                generation: 1,
+            } < Provenance::Genesis {
+                parent: "a".to_owned(),
+                generation: 2,
+            }
+        );
+    }
+
     proptest! {
         // Any schema-conformant `mod:<id>` round-trips through parse.
         #[test]

--- a/crates/beast-manifest/src/registry.rs
+++ b/crates/beast-manifest/src/registry.rs
@@ -27,7 +27,13 @@ pub struct DuplicateId(pub String);
 /// Implementors expose a unique id and a grouping key used for the
 /// secondary index. [`Self::Group`] must be `Ord + Copy` so the registry
 /// can BTreeMap-index it.
-pub trait Manifest {
+///
+/// `Clone` is a supertrait because [`SortedRegistry`] derives `Clone`
+/// and stores `M` by value in its internal `BTreeMap`. Without
+/// `Clone` here, `SortedRegistry::clone()` would fail at the call
+/// site rather than at the trait impl, which is a confusing
+/// diagnostic.
+pub trait Manifest: Clone {
     /// Type of the grouping key (e.g. `ChannelFamily`, `PrimitiveCategory`).
     type Group: Ord + Copy;
 

--- a/crates/beast-manifest/src/registry.rs
+++ b/crates/beast-manifest/src/registry.rs
@@ -33,6 +33,10 @@ pub struct DuplicateId(pub String);
 /// `Clone` here, `SortedRegistry::clone()` would fail at the call
 /// site rather than at the trait impl, which is a confusing
 /// diagnostic.
+///
+/// Current implementors: `beast_channels::ChannelManifest` and
+/// `beast_primitives::PrimitiveManifest` (both already derive
+/// `Clone`).
 pub trait Manifest: Clone {
     /// Type of the grouping key (e.g. `ChannelFamily`, `PrimitiveCategory`).
     type Group: Ord + Copy;


### PR DESCRIPTION
Branched off master. 2 of 10 audit-fixup PRs.

## Findings addressed (2 / 2 in this crate)

### MEDIUM (2)
- **\`Manifest\` trait now has \`Clone\` as a supertrait.** \`SortedRegistry<M>\`'s \`derive(Clone)\` implicitly required \`M: Clone\`; without an explicit supertrait, the diagnostic surfaced at the \`SortedRegistry::clone()\` call site rather than at the trait impl. Both shipping implementors (ChannelManifest, PrimitiveManifest) already derive Clone — non-breaking.
- **\`Provenance\` now derives \`PartialOrd + Ord\`.** Three-variant enum (Core, Mod(String), Genesis{...}) sorts by declaration order with within-variant lexicographic / numeric order — a no-allocation total ordering that lets Provenance live in a BTreeMap key or BTreeSet element. Doc notes the order intentionally doesn't match \`to_schema_string\` lexicographic form.

## Test plan
- [x] \`cargo test --workspace\` — all crates green.
- [x] \`cargo clippy -p beast-manifest --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

Audit refs: tasks #34, #35.