### PR TITLE
chore(beast-primitives): pre-graphics audit fixups

### DIFF
--- a/crates/beast-primitives/src/effect.rs
+++ b/crates/beast-primitives/src/effect.rs
@@ -35,6 +35,19 @@ pub struct PrimitiveEffect {
     /// emitted concurrently for different sites without collapsing.
     pub body_site: Option<BodySite>,
     /// Channel ids that composed to produce this emission.
+    ///
+    /// **Ordering contract**: callers must populate this in
+    /// lexicographic ascending order. Determinism gates and any
+    /// downstream Chronicler / save-layer hashing treat this as a
+    /// canonical sequence, so the same emission produced by two
+    /// independent code paths must yield the same byte sequence.
+    /// The phenotype interpreter satisfies this contract by
+    /// iterating its hook map (a `BTreeMap`) and pushing channel
+    /// ids in iteration order, which is sorted by definition.
+    /// New producers should either (a) build via a `BTreeSet<String>`
+    /// then `into_iter().collect()`, or (b) call
+    /// `source_channels.sort()` before constructing the
+    /// `PrimitiveEffect`.
     pub source_channels: Vec<String>,
     /// Parameter values, keyed by parameter name.
     pub parameters: BTreeMap<String, Q3232>,

--- a/crates/beast-primitives/src/manifest.rs
+++ b/crates/beast-primitives/src/manifest.rs
@@ -65,7 +65,7 @@ pub enum MergeStrategy {
 
 /// Default value stored alongside a parameter spec. Kept as-is from JSON so
 /// callers can apply the default into their own domain types.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParameterDefault {
     /// Default for a `number`-typed parameter, already converted to Q32.32.
     Number(Q3232),
@@ -78,7 +78,7 @@ pub enum ParameterDefault {
 }
 
 /// Specification for a single input parameter on a primitive.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParameterSpec {
     /// Value type (number / integer / string / boolean).
     pub ty: ParameterType,
@@ -92,7 +92,7 @@ pub struct ParameterSpec {
 }
 
 /// A cost function's per-parameter power-law scaling term.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParameterScaling {
     /// Name of the parameter driving this term (must exist in `parameter_schema`).
     pub parameter: String,
@@ -103,7 +103,7 @@ pub struct ParameterScaling {
 }
 
 /// Metabolic cost function for a primitive.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CostFunction {
     /// Base cost incurred each emission, independent of parameters.
     pub base_metabolic_cost: Q3232,
@@ -133,7 +133,7 @@ pub struct ObservableSignature {
 }
 
 /// In-memory representation of a primitive manifest.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrimitiveManifest {
     /// Unique snake_case identifier.
     pub id: String,

--- a/crates/beast-primitives/src/math.rs
+++ b/crates/beast-primitives/src/math.rs
@@ -63,6 +63,21 @@ fn e() -> Q3232 {
 /// Natural logarithm on Q32.32.
 ///
 /// Returns `None` for `x <= 0` (mathematically undefined).
+///
+/// # Precision
+///
+/// Implementation: range reduction to `m ∈ [1, 2)` followed by 16
+/// terms of the artanh-form series for `ln(m)`. For the reduced
+/// argument, `|z| < 1/3` and the truncation error of the series is
+/// bounded by `|z|^33 / (33 * (1 - z²))` which is well under
+/// `2^-50`. Saturating fixed-point division accumulates a per-step
+/// rounding error of `≤ 2^-32`; over 16 terms this contributes
+/// `≤ 16 * 2^-32 ≈ 4e-9`. The dominant contributor is the
+/// fixed-point quantisation, not the truncation. Empirically
+/// `ln_of_e_is_one` (in tests below) holds to `1e-5`, so callers
+/// can treat results as accurate to roughly **4–5 decimal places**.
+/// Adequate for cost evaluation and balance tuning; unsuitable for
+/// numerical analyses that need ULP-level fidelity.
 pub(crate) fn q_ln(x: Q3232) -> Option<Q3232> {
     if x <= Q3232::ZERO {
         return None;
@@ -181,7 +196,17 @@ pub(crate) fn q_pow(base: Q3232, exp: Q3232) -> Option<Q3232> {
     // we don't expect negative parameter values so this branch is largely
     // defensive.
     let rounded: i64 = exp.to_num::<i64>();
-    if Q3232::from(rounded as i32) != exp {
+    // `Q3232::from(i32)` round-trips integers in `[i32::MIN, i32::MAX]`
+    // exactly. For exponents outside that range, `try_from` fails →
+    // we reject as undefined rather than relying on the silent
+    // narrowing that the previous `rounded as i32` did. (Even very
+    // large integer exponents would produce values far outside the
+    // Q32.32 representable range, so refusing them here is the right
+    // policy regardless.)
+    let Ok(rounded_i32) = i32::try_from(rounded) else {
+        return None;
+    };
+    if Q3232::from(rounded_i32) != exp {
         return None;
     }
     let mut result = Q3232::ONE;

--- a/crates/beast-primitives/src/math.rs
+++ b/crates/beast-primitives/src/math.rs
@@ -349,4 +349,18 @@ mod tests {
         let exp = Q3232::from(-100_i32);
         assert_eq!(q_pow(base, exp), None);
     }
+
+    #[test]
+    fn pow_negative_base_exp_outside_i32_range_rejected() {
+        // Per PR #169 review (MEDIUM): the new `i32::try_from` rejection
+        // path on the integer-rounded exponent had no dedicated test —
+        // the underflow path above exercises a different `None` branch.
+        // `i32::MAX as i64 + 1` is comfortably representable as Q3232
+        // (its integer part fits the upper 32 bits), so the round-trip
+        // check `i32::try_from(rounded)` is the load-bearing rejection.
+        let large_exp_i64: i64 = i32::MAX as i64 + 1;
+        let base = Q3232::from(-2_i32);
+        let exp = Q3232::from_num(large_exp_i64 as f64);
+        assert_eq!(q_pow(base, exp), None);
+    }
 }


### PR DESCRIPTION
Branched off master. 4 of 10 audit-fixup PRs.

Findings addressed (4/4):
- MEDIUM: ParameterDefault/Spec/Scaling, CostFunction, PrimitiveManifest now derive Eq (Q3232 is Eq, chain is safe).
- MEDIUM: q_ln precision bound documented (~4–5 decimal places).
- LOW: q_pow integer-exponent narrowing cast tightened via i32::try_from instead of silent wrap.
- LOW: PrimitiveEffect::source_channels ordering contract documented (lexicographic ascending).

Test plan: cargo test/clippy/fmt all green.

Audit refs: tasks #39, #40, #41, #42.