### PR TITLE
chore(beast-world): pre-graphics audit fixups

### DIFF
--- a/crates/beast-world/src/archipelago.rs
+++ b/crates/beast-world/src/archipelago.rs
@@ -96,7 +96,7 @@ pub fn generate_archipelago(
     // the symmetric pair `seed = 0` ↔ `seed = 0x5A5A...` that bare
     // XOR would create.
     let elevation_seed = seed;
-    let moisture_seed = crate::noise::splitmix64_pub(seed ^ 0x5A5A_5A5A_5A5A_5A5A);
+    let moisture_seed = crate::noise::splitmix64(seed ^ 0x5A5A_5A5A_5A5A_5A5A);
 
     let width = config.width;
     let height = config.height;
@@ -170,6 +170,15 @@ fn validate_config(config: &WorldConfig) -> Result<(), GenerationError> {
     if config.octaves == 0 {
         return Err(GenerationError::ZeroOctaves);
     }
+    // Noise-shape parameters must be strictly positive. A zero
+    // `frequency` collapses every cell onto the same lattice
+    // point (constant map); zero `gain` stalls fBm after one
+    // octave; non-positive `lacunarity` flips frequency direction
+    // each octave producing a subtle deterministic bias that's
+    // hard to diagnose from a degenerate map alone.
+    check_positive("frequency", config.frequency)?;
+    check_positive("gain", config.gain)?;
+    check_positive("lacunarity", config.lacunarity)?;
     // Range checks for unit-interval thresholds. Without these, a
     // misconfigured WorldConfig (e.g., loaded from an external
     // file) silently produces a degenerate world rather than a
@@ -205,6 +214,15 @@ fn check_unit_threshold(name: &'static str, value: Q3232) -> Result<(), Generati
     if value < Q3232::ZERO || value > Q3232::ONE {
         return Err(GenerationError::InvalidThresholds {
             detail: format!("{name} ({value:?}) must be in [0, 1]"),
+        });
+    }
+    Ok(())
+}
+
+fn check_positive(name: &'static str, value: Q3232) -> Result<(), GenerationError> {
+    if value <= Q3232::ZERO {
+        return Err(GenerationError::InvalidThresholds {
+            detail: format!("{name} ({value:?}) must be > 0"),
         });
     }
     Ok(())
@@ -360,6 +378,41 @@ mod tests {
             generate_archipelago(&cfg, 0).unwrap_err(),
             GenerationError::ZeroOctaves
         ));
+    }
+
+    #[test]
+    fn rejects_zero_frequency() {
+        let mut cfg = WorldConfig::default_archipelago();
+        cfg.frequency = Q3232::ZERO;
+        assert!(matches!(
+            generate_archipelago(&cfg, 0).unwrap_err(),
+            GenerationError::InvalidThresholds { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_gain() {
+        let mut cfg = WorldConfig::default_archipelago();
+        cfg.gain = Q3232::ZERO;
+        assert!(matches!(
+            generate_archipelago(&cfg, 0).unwrap_err(),
+            GenerationError::InvalidThresholds { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_negative_lacunarity() {
+        let mut cfg = WorldConfig::default_archipelago();
+        cfg.lacunarity = -Q3232::ONE;
+        assert!(matches!(
+            generate_archipelago(&cfg, 0).unwrap_err(),
+            GenerationError::InvalidThresholds { .. }
+        ));
+    }
+
+    #[test]
+    fn world_config_default_matches_default_archipelago() {
+        assert_eq!(WorldConfig::default(), WorldConfig::default_archipelago());
     }
 
     #[test]

--- a/crates/beast-world/src/archipelago.rs
+++ b/crates/beast-world/src/archipelago.rs
@@ -411,6 +411,35 @@ mod tests {
     }
 
     #[test]
+    fn rejects_negative_frequency() {
+        // Per PR #170 review: `Q3232` is signed, configs can come from
+        // external files, and a negative `frequency` inverts the
+        // lattice traversal direction. The predicate already rejects
+        // it; this test locks in the rejection so a future drive-by
+        // that loosens `check_positive` to `value == ZERO` fails loud.
+        let mut cfg = WorldConfig::default_archipelago();
+        cfg.frequency = -Q3232::ONE;
+        assert!(matches!(
+            generate_archipelago(&cfg, 0).unwrap_err(),
+            GenerationError::InvalidThresholds { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_negative_gain() {
+        // Per PR #170 review: a negative `gain` amplifies rather than
+        // attenuates successive fbm octaves, causing the output to
+        // diverge instead of converge. Same lock-in rationale as
+        // `rejects_negative_frequency`.
+        let mut cfg = WorldConfig::default_archipelago();
+        cfg.gain = -Q3232::ONE;
+        assert!(matches!(
+            generate_archipelago(&cfg, 0).unwrap_err(),
+            GenerationError::InvalidThresholds { .. }
+        ));
+    }
+
+    #[test]
     fn world_config_default_matches_default_archipelago() {
         assert_eq!(WorldConfig::default(), WorldConfig::default_archipelago());
     }

--- a/crates/beast-world/src/config.rs
+++ b/crates/beast-world/src/config.rs
@@ -63,6 +63,15 @@ pub struct WorldConfig {
     pub forest_threshold: Q3232,
 }
 
+impl Default for WorldConfig {
+    /// Delegates to [`WorldConfig::default_archipelago`] so generic
+    /// code that uses `T: Default` or `..Default::default()`
+    /// struct-update syntax works.
+    fn default() -> Self {
+        Self::default_archipelago()
+    }
+}
+
 impl WorldConfig {
     /// A reasonable default config for a 64×64 archipelago.
     ///

--- a/crates/beast-world/src/lib.rs
+++ b/crates/beast-world/src/lib.rs
@@ -37,8 +37,11 @@
 //!
 //! 1. **Elevation** = sum of 4 octaves of value noise, normalised to
 //!    `[-1, 1]`. Higher = more land.
-//! 2. **Moisture** = single octave of independent value noise (uses a
-//!    different `octave_seed`).
+//! 2. **Moisture** = sum of `config.octaves` octaves of value noise
+//!    (same fBm shape as elevation, with a different per-channel
+//!    seed derived deterministically from the world `seed` via
+//!    `splitmix64(seed ^ MAGIC)` — only the world `seed` needs to
+//!    be persisted to reproduce both channels).
 //! 3. **Latitude** = `|y / height - 0.5| * 2`, in `[0, 1]` — 0 at the
 //!    equator, 1 at the poles. Used to gate tundra.
 //! 4. **Classification**:

--- a/crates/beast-world/src/noise.rs
+++ b/crates/beast-world/src/noise.rs
@@ -32,18 +32,11 @@
 /// `Xoshiro256PlusPlus::seed_from_u64` so behaviour is consistent
 /// with the rest of the project's PRNG infrastructure.
 #[inline]
-fn splitmix64(mut x: u64) -> u64 {
+pub(crate) fn splitmix64(mut x: u64) -> u64 {
     x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
     x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
     x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
     x ^ (x >> 31)
-}
-
-/// Crate-internal re-export of [`splitmix64`] for callers that need
-/// to derive related-but-decorrelated seeds. Pure function.
-#[inline]
-pub(crate) fn splitmix64_pub(x: u64) -> u64 {
-    splitmix64(x)
 }
 
 /// Deterministic value at integer corner `(ix, iy)` in `[-1, 1]`.
@@ -92,6 +85,16 @@ fn smoothstep(t: f64) -> f64 {
 ///
 /// `octave_seed` is mixed in so multiple octaves drawn from the same
 /// world seed remain decorrelated.
+///
+/// # Coordinate range
+///
+/// The internal corner hash reinterprets each integer coordinate as
+/// a `u64` via two's complement. Within roughly `±2^31` (the range
+/// the archipelago generator uses, with frequency ≤ 64) this is
+/// collision-free. Callers that pass arbitrary `i64`-magnitude
+/// coordinates (e.g., raw tile indices in a much larger world) may
+/// hit hash collisions between very-large-positive and small-
+/// negative coordinates and should normalise their input first.
 #[inline]
 pub fn value_noise_2d(seed: u64, octave_seed: u64, x: f64, y: f64) -> f64 {
     let ix = x.floor() as i64;
@@ -121,6 +124,12 @@ pub fn value_noise_2d(seed: u64, octave_seed: u64, x: f64, y: f64) -> f64 {
 /// `2.0`). `gain` is the per-octave amplitude multiplier (typical
 /// `0.5`). Output is normalised to `[-1, 1]` based on the maximum
 /// possible amplitude sum.
+///
+/// # Coordinate range
+///
+/// Inherits the same `±2^31` coordinate-hash safety bound as
+/// [`value_noise_2d`]. Callers passing arbitrary `i64`-scale
+/// coordinates should normalise first.
 pub fn fbm_2d(seed: u64, x: f64, y: f64, octaves: u32, lacunarity: f64, gain: f64) -> f64 {
     let mut sum = 0.0_f64;
     let mut amp = 1.0_f64;

--- a/crates/beast-world/src/noise.rs
+++ b/crates/beast-world/src/noise.rs
@@ -89,12 +89,17 @@ fn smoothstep(t: f64) -> f64 {
 /// # Coordinate range
 ///
 /// The internal corner hash reinterprets each integer coordinate as
-/// a `u64` via two's complement. Within roughly `±2^31` (the range
-/// the archipelago generator uses, with frequency ≤ 64) this is
-/// collision-free. Callers that pass arbitrary `i64`-magnitude
-/// coordinates (e.g., raw tile indices in a much larger world) may
-/// hit hash collisions between very-large-positive and small-
-/// negative coordinates and should normalise their input first.
+/// a `u64` via two's complement. Within roughly `±2^31` this is
+/// collision-free; well-large-positive vs small-negative `i64`
+/// coordinates can alias to the same hash bucket outside that band.
+/// The archipelago generator stays comfortably inside the safe band
+/// (a 64×64 grid scaled by typical `frequency` values produces corner
+/// indices of at most a few hundred), but callers that pass arbitrary
+/// `i64`-magnitude coordinates — e.g., raw tile indices in a much
+/// larger world — should normalise their input into `±2^31` first.
+/// `frequency` itself is unbounded (only `> 0` is enforced by
+/// `validate_config`); the bound here is on the **product** of
+/// `frequency` and the maximum traversed integer coordinate.
 #[inline]
 pub fn value_noise_2d(seed: u64, octave_seed: u64, x: f64, y: f64) -> f64 {
     let ix = x.floor() as i64;


### PR DESCRIPTION
Branched off master. 5 of 10 audit-fixup PRs.

Findings addressed (5/5):
- HIGH: Fixed lib.rs algorithm sketch — moisture is multi-octave fbm (matches code) with deterministic seed derivation documented.
- HIGH: Documented coordinate-range safety on public value_noise_2d and fbm_2d (±2^31 bound).
- MEDIUM: WorldConfig now impls Default delegating to default_archipelago().
- MEDIUM: validate_config check_positive on frequency / gain / lacunarity. 3 new rejection tests.
- LOW: Removed leaky splitmix64_pub wrapper; splitmix64 now pub(crate) directly.

Test plan: 45 tests green, clippy/fmt clean.

Audit refs: tasks #43, #44, #45, #46, #49.