### PR TITLE
chore(beast-climate): pre-graphics audit fixups

### DIFF
--- a/crates/beast-climate/src/lib.rs
+++ b/crates/beast-climate/src/lib.rs
@@ -158,8 +158,14 @@ pub struct ClimateReading {
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ClimateError {
-    /// `season_period_ticks` was below the four-season minimum.
-    #[error("season_period_ticks must be >= 4; got {0}")]
+    /// `season_period_ticks` was below the four-season minimum or
+    /// not a multiple of four. The triangle wave's quarter
+    /// boundaries (`period/4`, `period/2`, `3*period/4`, `period`)
+    /// only land on integer tick positions when `period % 4 == 0`;
+    /// other periods produce slightly skewed peak/trough positions
+    /// that violate the wave's symmetry contract documented in
+    /// `seasonal_triangle`.
+    #[error("season_period_ticks must be a multiple of 4 and >= 4; got {0}")]
     SeasonPeriodTooSmall(u32),
     /// `abs_latitude` was outside `[0, 1]` — the contract for the
     /// equator-to-pole normalised coordinate. Out-of-range values
@@ -178,15 +184,15 @@ pub enum ClimateError {
 ///
 /// # Panics
 ///
-/// Panics in both debug and release if `season_period < 4`. This
-/// matches the `effective_climate` validation contract — both
-/// entry points reject the same range of bad inputs. Use
-/// [`try_season_at_tick`] for fallible callers.
+/// Panics in both debug and release if `season_period` is below 4
+/// or not a multiple of 4. This matches the `effective_climate`
+/// validation contract — both entry points reject the same range
+/// of bad inputs. Use [`try_season_at_tick`] for fallible callers.
 #[must_use]
 pub fn season_at_tick(tick: u64, season_period: u32) -> Season {
     assert!(
-        season_period >= 4,
-        "season_period must be >= 4; got {season_period}",
+        is_valid_season_period(season_period),
+        "season_period must be a multiple of 4 and >= 4; got {season_period}",
     );
     season_at_tick_unchecked(tick, season_period)
 }
@@ -196,12 +202,22 @@ pub fn season_at_tick(tick: u64, season_period: u32) -> Season {
 ///
 /// # Errors
 ///
-/// * [`ClimateError::SeasonPeriodTooSmall`] when `season_period < 4`.
+/// * [`ClimateError::SeasonPeriodTooSmall`] when `season_period`
+///   is below 4 or not a multiple of 4.
+#[must_use = "the Result reports validation failure — at minimum check it with `?`"]
 pub fn try_season_at_tick(tick: u64, season_period: u32) -> Result<Season, ClimateError> {
-    if season_period < 4 {
+    if !is_valid_season_period(season_period) {
         return Err(ClimateError::SeasonPeriodTooSmall(season_period));
     }
     Ok(season_at_tick_unchecked(tick, season_period))
+}
+
+/// Whether a given `season_period_ticks` value passes the wave-shape
+/// preconditions: at least 4 ticks (one per season) AND a multiple
+/// of 4 so the quarter boundaries land on integer ticks.
+#[inline]
+const fn is_valid_season_period(period: u32) -> bool {
+    period >= 4 && period % 4 == 0
 }
 
 #[inline]
@@ -228,13 +244,13 @@ fn season_at_tick_unchecked(tick: u64, season_period: u32) -> Season {
 ///
 /// # Panics
 ///
-/// Panics if `season_period < 4`. Same contract as
-/// [`season_at_tick`].
+/// Panics if `season_period` is below 4 or not a multiple of 4.
+/// Same contract as [`season_at_tick`].
 #[must_use]
 pub fn next_season_change_tick(tick: u64, season_period: u32) -> u64 {
     assert!(
-        season_period >= 4,
-        "season_period must be >= 4; got {season_period}",
+        is_valid_season_period(season_period),
+        "season_period must be a multiple of 4 and >= 4; got {season_period}",
     );
     let period = u64::from(season_period);
     let phase = tick % period;
@@ -270,7 +286,10 @@ pub fn ticks_until_next_season(tick: u64, season_period: u32) -> u64 {
 /// across cycles. This is the function that satisfies the
 /// closed-cycle invariant.
 fn seasonal_triangle(tick: u64, period: u32) -> Q3232 {
-    assert!(period >= 4, "period must be >= 4; got {period}");
+    assert!(
+        is_valid_season_period(period),
+        "period must be a multiple of 4 and >= 4; got {period}",
+    );
     let period = u64::from(period);
     let phase = tick % period;
     // half_period = period / 2; quarter = period / 4.
@@ -323,10 +342,28 @@ fn seasonal_triangle(tick: u64, period: u32) -> Q3232 {
 ///
 /// Returns the season for downstream UI/labels.
 ///
+/// # Closed-cycle invariant precondition
+///
+/// All temperature / precipitation arithmetic uses Q3232 saturating
+/// ops. The closed-cycle invariant (tick `0` reading equals tick
+/// `period` reading) holds **only when no intermediate operation
+/// saturates**. That requires:
+///
+/// * `base_temp_kelvin` not within `seasonal_temperature_amplitude
+///   + latitude_temperature_lapse` of `Q3232::MAX` / `Q3232::MIN`.
+/// * `base_precipitation` not within `seasonal_precipitation_
+///   amplitude` of `Q3232::MAX` / `Q3232::MIN`.
+///
+/// For physical Kelvin / mm-per-year inputs (200..400 K, 0..3000
+/// mm/yr) these bounds are enormous and the invariant always holds.
+/// Synthetic test inputs near the Q3232 extremes will silently
+/// break the invariant — this is by design (saturating ops are
+/// determinism-preserving but not invariant-preserving).
+///
 /// # Errors
 ///
 /// * [`ClimateError::SeasonPeriodTooSmall`] when
-///   `config.season_period_ticks < 4`.
+///   `config.season_period_ticks` is below 4 or not a multiple of 4.
 /// * [`ClimateError::AbsLatitudeOutOfRange`] when `abs_latitude`
 ///   is outside `[0, 1]`. Out-of-range values would produce
 ///   physically nonsensical (saturated) temperatures, so the model
@@ -339,7 +376,7 @@ pub fn effective_climate(
     abs_latitude: Q3232,
     tick: u64,
 ) -> Result<ClimateReading, ClimateError> {
-    if config.season_period_ticks < 4 {
+    if !is_valid_season_period(config.season_period_ticks) {
         return Err(ClimateError::SeasonPeriodTooSmall(
             config.season_period_ticks,
         ));
@@ -573,6 +610,25 @@ mod tests {
         let err = effective_climate(&cfg, Q3232::from_num(288_i32), Q3232::ZERO, Q3232::ZERO, 0)
             .unwrap_err();
         assert!(matches!(err, ClimateError::SeasonPeriodTooSmall(3)));
+    }
+
+    #[test]
+    fn rejects_season_period_not_multiple_of_four() {
+        // Period = 5 satisfies the >= 4 minimum but the triangle-wave
+        // quarter boundaries don't land on integer ticks (period/4
+        // truncates), producing skewed peak/trough positions. The
+        // pre-audit code accepted this; the new validation rejects.
+        let mut cfg = ClimateConfig::default_mvp();
+        cfg.season_period_ticks = 5;
+        let err = effective_climate(&cfg, Q3232::from_num(288_i32), Q3232::ZERO, Q3232::ZERO, 0)
+            .unwrap_err();
+        assert!(matches!(err, ClimateError::SeasonPeriodTooSmall(5)));
+    }
+
+    #[test]
+    fn try_season_at_tick_rejects_period_not_multiple_of_four() {
+        let err = try_season_at_tick(0, 6).unwrap_err();
+        assert!(matches!(err, ClimateError::SeasonPeriodTooSmall(6)));
     }
 
     #[test]

--- a/crates/beast-climate/src/lib.rs
+++ b/crates/beast-climate/src/lib.rs
@@ -105,7 +105,12 @@ impl Season {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClimateConfig {
     /// Length of one full season cycle in simulation ticks. Default
-    /// `1000`. Must be ≥ 4 (one tick per season minimum).
+    /// `1000`. **Must be a multiple of 4 and at least 4** so the
+    /// triangle wave's quarter boundaries land on integer ticks (one
+    /// tick per season minimum). Validated by every entry point —
+    /// constructing `ClimateConfig` with an invalid value compiles
+    /// but the first call to [`effective_climate`] / [`season_at_tick`]
+    /// returns / panics on [`ClimateError::SeasonPeriodTooSmall`].
     pub season_period_ticks: u32,
     /// Peak temperature deviation from base, in Kelvin (Q3232).
     /// Default `15` — a moderate seasonal swing.
@@ -270,7 +275,10 @@ pub fn next_season_change_tick(tick: u64, season_period: u32) -> u64 {
 ///
 /// # Panics
 ///
-/// Panics if `season_period < 4`.
+/// Delegates to [`next_season_change_tick`], so the same validation
+/// applies: panics if `season_period` is below 4 or not a multiple
+/// of 4 (e.g., `period = 6` panics even though it satisfies
+/// the older `< 4` doc text).
 #[must_use]
 pub fn ticks_until_next_season(tick: u64, season_period: u32) -> u64 {
     next_season_change_tick(tick, season_period) - tick
@@ -304,11 +312,15 @@ fn seasonal_triangle(tick: u64, period: u32) -> Q3232 {
     //   [quarter, quarter+half):  descending arm: +quarter → -quarter
     //   [quarter+half, period): ascending arm: -quarter → 0
     //
-    // For periods not divisible by 4, `period/4` truncates and the
-    // ascending and descending arms have unequal lengths — but the
-    // closed-cycle property at ticks 0 and `period` still holds
-    // exactly (both produce signed = 0). The peak is always at
-    // exactly `phase = quarter`, regardless of divisibility.
+    // The `is_valid_season_period` precondition above guarantees
+    // `period % 4 == 0`, so `period/4` is exact and the ascending
+    // and descending arms have equal length — the wave is symmetric
+    // and the closed-cycle invariant (tick 0 == tick `period` == 0)
+    // is bit-exact, not approximate. Periods not divisible by 4 are
+    // rejected at the entry-point validators (`season_at_tick`,
+    // `effective_climate`, `try_season_at_tick`,
+    // `next_season_change_tick`); this `assert!` catches any new
+    // direct caller before it can produce skewed output.
     let signed: i64 = if phase < quarter {
         // 0 .. quarter
         phase as i64
@@ -349,10 +361,12 @@ fn seasonal_triangle(tick: u64, period: u32) -> Q3232 {
 /// `period` reading) holds **only when no intermediate operation
 /// saturates**. That requires:
 ///
-/// * `base_temp_kelvin` not within `seasonal_temperature_amplitude
-///   + latitude_temperature_lapse` of `Q3232::MAX` / `Q3232::MIN`.
-/// * `base_precipitation` not within `seasonal_precipitation_
-///   amplitude` of `Q3232::MAX` / `Q3232::MIN`.
+/// * `base_temp_kelvin` is not within
+///   `seasonal_temperature_amplitude + latitude_temperature_lapse`
+///   of `Q3232::MAX` / `Q3232::MIN`.
+/// * `base_precipitation` is not within
+///   `seasonal_precipitation_amplitude` of `Q3232::MAX` /
+///   `Q3232::MIN`.
 ///
 /// For physical Kelvin / mm-per-year inputs (200..400 K, 0..3000
 /// mm/yr) these bounds are enormous and the invariant always holds.
@@ -671,6 +685,47 @@ mod tests {
     fn try_season_at_tick_returns_error_on_period_below_four() {
         let err = try_season_at_tick(0, 3).unwrap_err();
         assert!(matches!(err, ClimateError::SeasonPeriodTooSmall(3)));
+    }
+
+    #[test]
+    fn season_at_tick_panics_on_period_not_multiple_of_four() {
+        // Per PR #171 review: lock in that the panic arm fires for
+        // period=6 (>= 4 but not divisible). Without this, a future
+        // refactor that forgot the divisibility check could pass the
+        // existing `period=3` panic test silently.
+        let result = std::panic::catch_unwind(|| season_at_tick(0, 6));
+        assert!(
+            result.is_err(),
+            "expected panic on period=6, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn next_season_change_tick_panics_on_period_not_multiple_of_four() {
+        let result = std::panic::catch_unwind(|| next_season_change_tick(0, 6));
+        assert!(result.is_err(), "expected panic, got {result:?}");
+    }
+
+    #[test]
+    fn ticks_until_next_season_panics_on_period_not_multiple_of_four() {
+        // Delegated to next_season_change_tick — must surface the same
+        // panic. Pre-audit the doc said "Panics if season_period < 4"
+        // and `period = 6` would have produced quietly skewed output;
+        // the new validation lifts that into a panic here.
+        let result = std::panic::catch_unwind(|| ticks_until_next_season(0, 6));
+        assert!(
+            result.is_err(),
+            "expected panic on period=6, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn season_at_tick_panics_on_period_zero() {
+        let result = std::panic::catch_unwind(|| season_at_tick(0, 0));
+        assert!(
+            result.is_err(),
+            "expected panic on period=0, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Branched off master. 6 of 10 audit-fixup PRs.

Findings addressed (3/3):
- MEDIUM: season_period must now be a multiple of 4 (in addition to >= 4). Quarter boundaries only land on integer ticks under that constraint. Centralised in is_valid_season_period().
- MEDIUM: Documented closed-cycle invariant precondition on effective_climate (invariant holds only when no Q3232 saturating op saturates).
- LOW: Added #[must_use] to try_season_at_tick.

Test plan: 27 tests green (24 prior + 2 new + 1 #[must_use] guard), clippy/fmt clean.

Audit refs: tasks #47, #48, #50.