### PR TITLE
chore(beast-genome): pre-graphics audit fixes

### DIFF
--- a/crates/beast-genome/src/error.rs
+++ b/crates/beast-genome/src/error.rs
@@ -56,6 +56,17 @@ pub enum GenomeError {
         /// Offending tag, as `u64`.
         tag: u64,
     },
+
+    /// A genome accumulated more than `u32::MAX` genes — the
+    /// `Modifier::target_gene_index` field can no longer address every
+    /// gene. Practically impossible at MVP gene counts; the variant
+    /// exists so `Genome::validate` can return an error rather than
+    /// panic via `expect()`.
+    #[error("genome size {len} exceeds u32::MAX — Modifier::target_gene_index can't address it")]
+    GenomeTooLarge {
+        /// The offending gene count.
+        len: usize,
+    },
 }
 
 /// Convenience `Result` alias for genome-crate errors.

--- a/crates/beast-genome/src/genome.rs
+++ b/crates/beast-genome/src/genome.rs
@@ -174,9 +174,8 @@ impl Genome {
                 });
             }
 
-            let src_u32 = u32::try_from(src_idx).expect(
-                "genome size exceeds u32::MAX — Modifier::target_gene_index can't address this",
-            );
+            let src_u32 =
+                u32::try_from(src_idx).map_err(|_| GenomeError::GenomeTooLarge { len })?;
             for m in &gene.regulatory {
                 if (m.target_gene_index as usize) >= len {
                     return Err(GenomeError::ModifierIndexOutOfBounds {

--- a/crates/beast-genome/src/mutation.rs
+++ b/crates/beast-genome/src/mutation.rs
@@ -127,6 +127,18 @@ pub fn mutate_regulatory(
 /// count (`original_len`) stable.
 pub fn apply_mutations(genome: &mut Genome, current_tick: TickCounter, rng: &mut Prng) {
     let original_len = genome.genes.len();
+    // Bounds check once, then cheap-cast inside the per-creature
+    // loop. `Genome::validate` already caps `genes.len()` at
+    // `u32::MAX` (the `GenomeTooLarge` error path), so this is a
+    // belt-and-braces assertion rather than a runtime check we
+    // expect to ever fire — but turning the per-iteration
+    // `expect()` into a one-time `debug_assert!` keeps the hot
+    // path branch-free in release. See PR #174 review for context.
+    debug_assert!(
+        original_len <= u32::MAX as usize,
+        "Genome::validate must reject genomes with > u32::MAX genes \
+         before they reach apply_mutations"
+    );
     // Split-borrow the genome so `params` can be borrowed
     // immutably while `genes` is borrowed mutably — avoids the
     // 272-byte `GenomeParams` clone that the previous revision
@@ -136,8 +148,10 @@ pub fn apply_mutations(genome: &mut Genome, current_tick: TickCounter, rng: &mut
     let Genome { params, genes } = genome;
     for (i, gene) in genes.iter_mut().take(original_len).enumerate() {
         mutate_point(gene, params, rng);
-        // Safe cast: `Genome::validate` caps genome length at `u32::MAX`.
-        let source = u32::try_from(i).expect("genome length exceeds u32::MAX");
+        // `i < original_len <= u32::MAX` from the debug_assert above,
+        // so the truncating cast is lossless. Avoids per-iteration
+        // try_from + expect on every creature, every tick.
+        let source = i as u32;
         mutate_regulatory(gene, source, original_len, params, rng);
     }
     mutate_duplicate(genome, current_tick, rng);

--- a/crates/beast-genome/src/mutation.rs
+++ b/crates/beast-genome/src/mutation.rs
@@ -32,6 +32,7 @@ pub fn mutate_point(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng)
     mutate_silencing(gene, params, rng);
 }
 
+/// Drift `effect.magnitude` by N(0, σ), reflect-clamped to `[0, 1]`.
 fn mutate_magnitude(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() < params.point_mutation_rate {
         let delta = gaussian_q3232(rng, Q3232::ZERO, params.point_mutation_sigma);
@@ -39,6 +40,8 @@ fn mutate_magnitude(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng)
     }
 }
 
+/// Drift every channel-vector entry by N(0, σ); intentionally unbounded
+/// (clamping happens downstream in the interpreter).
 fn mutate_channels(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() < params.channel_shift_rate {
         for ch in &mut gene.effect.channel {
@@ -48,6 +51,8 @@ fn mutate_channels(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) 
     }
 }
 
+/// Drift `body_site.surface_vs_internal` and `body_site.body_region`
+/// independently by N(0, σ), each reflect-clamped to `[0, 1]`.
 fn mutate_body_site(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() < params.body_site_drift_rate {
         let delta_s = gaussian_q3232(rng, Q3232::ZERO, params.body_site_drift_sigma);
@@ -59,6 +64,7 @@ fn mutate_body_site(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng)
     }
 }
 
+/// Flip `enabled` (gene silencing toggle) with probability `silencing_toggle_rate`.
 fn mutate_silencing(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() < params.silencing_toggle_rate {
         gene.enabled = !gene.enabled;
@@ -121,17 +127,27 @@ pub fn mutate_regulatory(
 /// count (`original_len`) stable.
 pub fn apply_mutations(genome: &mut Genome, current_tick: TickCounter, rng: &mut Prng) {
     let original_len = genome.genes.len();
-    let params = genome.params.clone();
-    for i in 0..original_len {
-        mutate_point(&mut genome.genes[i], &params, rng);
+    // Split-borrow the genome so `params` can be borrowed
+    // immutably while `genes` is borrowed mutably — avoids the
+    // 272-byte `GenomeParams` clone that the previous revision
+    // paid on every creature, every tick. Soundness: this is the
+    // textbook field-disjoint-borrow pattern; rustc allows it
+    // because the two fields are stored in disjoint memory.
+    let Genome { params, genes } = genome;
+    for (i, gene) in genes.iter_mut().take(original_len).enumerate() {
+        mutate_point(gene, params, rng);
         // Safe cast: `Genome::validate` caps genome length at `u32::MAX`.
         let source = u32::try_from(i).expect("genome length exceeds u32::MAX");
-        mutate_regulatory(&mut genome.genes[i], source, original_len, &params, rng);
+        mutate_regulatory(gene, source, original_len, params, rng);
     }
     mutate_duplicate(genome, current_tick, rng);
     mutate_duplication_rate(genome, rng);
 }
 
+/// With probability `regulatory_add_rate`, push a new [`Modifier`]
+/// onto `gene.regulatory` targeting a uniformly random other gene.
+/// No-ops when `genome_len < 2` (the only valid target is `source`
+/// itself, and self-loops are forbidden by [`Genome::validate`]).
 fn try_add_modifier(
     gene: &mut TraitGene,
     source: u32,
@@ -162,6 +178,8 @@ fn try_add_modifier(
     });
 }
 
+/// With probability `regulatory_remove_rate`, drop a uniformly random
+/// existing [`Modifier`] from `gene.regulatory`. No-op on empty lists.
 fn try_remove_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() >= params.regulatory_remove_rate {
         return;
@@ -174,6 +192,10 @@ fn try_remove_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Pr
     gene.regulatory.remove(idx);
 }
 
+/// With probability `regulatory_mutate_rate`, drift a uniformly chosen
+/// modifier's `strength` by N(0, σ) reflect-clamped to `[-1, 1]`, and
+/// independently with probability `regulatory_effect_type_flip_prob`
+/// swap its `effect_type` for one of the other two variants.
 fn try_mutate_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Prng) {
     if rng.next_q3232_unit() >= params.regulatory_mutate_rate {
         return;
@@ -193,6 +215,7 @@ fn try_mutate_modifier(gene: &mut TraitGene, params: &GenomeParams, rng: &mut Pr
     }
 }
 
+/// Uniformly draw one of the three [`ModifierEffect`] variants.
 fn draw_effect_type(rng: &mut Prng) -> ModifierEffect {
     match rng.gen_range_u64(0, 3) {
         0 => ModifierEffect::Activate,

--- a/crates/beast-genome/src/save.rs
+++ b/crates/beast-genome/src/save.rs
@@ -77,13 +77,14 @@ pub enum SaveLoadError {
     /// The hex-formatted fingerprints are included so the mismatch is
     /// diagnosable from a log paste without needing the original file.
     #[error(
-        "registry fingerprint mismatch: save was written against registry {actual}, current registry is {expected}"
+        "registry fingerprint mismatch: save was written against registry \
+         {saved_fingerprint}, current registry is {current_fingerprint}"
     )]
     RegistryMismatch {
-        /// Hex of the active registry's fingerprint.
-        expected: String,
-        /// Hex of the fingerprint stored in the save.
-        actual: String,
+        /// Hex of the registry the save was written against.
+        saved_fingerprint: String,
+        /// Hex of the registry the simulation is currently using.
+        current_fingerprint: String,
     },
 
     /// The genome payload passed deserialization but failed structural
@@ -132,8 +133,8 @@ pub fn load_genome_from_json(
     let current = registry.fingerprint();
     if current != envelope.registry_fingerprint {
         return Err(SaveLoadError::RegistryMismatch {
-            expected: current.to_hex(),
-            actual: envelope.registry_fingerprint.to_hex(),
+            saved_fingerprint: envelope.registry_fingerprint.to_hex(),
+            current_fingerprint: current.to_hex(),
         });
     }
 

--- a/crates/beast-genome/src/starter.rs
+++ b/crates/beast-genome/src/starter.rs
@@ -121,7 +121,8 @@ pub struct StarterGeneSpec {
 /// Only `Serialize` is derived — `Deserialize` would require
 /// owning every `&'static str`, which is out of scope for a static
 /// blueprint. Tooling that needs to *read* spec JSON should
-/// deserialise into a separate owned-string mirror type.
+/// deserialise into a separate owned-string mirror type. Issue
+/// #173 tracks the design.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct StarterSpec {
     /// Snake-case identifier, also used as the species name.
@@ -877,6 +878,12 @@ mod tests {
         // The unification refactor that collapses `BiomeTag` and
         // `BiomeKind` (tracked in the S8 epic) will replace this
         // hand-maintained mirror with a real type lock-in.
+        //
+        // Issue #172 tracks the cross-test against
+        // `beast_ecs::components::BiomeKind` (requires a
+        // `BiomeKind::ALL` const + dev-dep on beast-ecs). Until that
+        // lands, this test catches typos in starter `home_biome_tag`
+        // values but not BiomeKind renames or new variants.
         const KNOWN: &[&str] = &["ocean", "forest", "plains", "desert", "mountain", "tundra"];
         for spec in STARTER_SPECIES {
             assert!(


### PR DESCRIPTION
Pre-graphics rust-reviewer audit pass for `beast-genome`. Each finding from the audit is addressed below with a one-line summary; full rationale is in the commit message.

## Findings addressed

| # | Severity | Summary |
|---|---|---|
| #51 | LOW | `SaveLoadError::RegistryMismatch` field naming was swap-prone; renamed `expected`/`actual` → `saved_fingerprint`/`current_fingerprint`. |
| #52 | MEDIUM (perf) | `apply_mutations` cloned `GenomeParams` (~272 B) per creature per tick. Replaced with split-borrow over `Genome { params, genes }`. |
| #53 | MEDIUM | `starter` cross-test against `BiomeKind` is hand-maintained; documented gap and opened #172 to lock it in via `BiomeKind::ALL`. |
| #58 | LOW | `q()` helper hex-bits annotation gap; resolved during audit (no code change needed beyond docs already in place). |
| #59 | MEDIUM | `Genome::validate` previously `expect()`-panicked on the impossible `genome.len() > u32::MAX` case. Now returns `GenomeError::GenomeTooLarge { len }`. |
| #61 | LOW | `StarterSpec` `Deserialize` gap is real (would require an owned-string mirror type). Opened #173 to track; doc-comment now points to the issue. |
| #62 | LOW | Private hot-path mutation helpers gained brief one-line docs. |

## Test plan

- [x] `cargo test -p beast-genome --lib` — 87 / 87 pass
- [x] `cargo clippy -p beast-genome --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] CI green on master

## Followups (not in this PR)

- #172 — wire `BiomeKind::ALL` through dev-dep on `beast-ecs` so the starter biome cross-test is real
- #173 — design owned-string mirror for `StarterSpec` deserialize
