### PR TITLE
chore(beast-ecs): pre-graphics audit fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,15 @@ winnow = "0.7"
 # available for embarrassingly-parallel per-entity reads. The scheduler
 # (S6) will still serialise stages — parallelism only happens within a
 # stage, and only for read-only access paths.
-specs = { version = "0.20", default-features = false, features = ["parallel"] }
+#
+# DETERMINISM-CRITICAL: the version is pinned to exactly 0.20.x because
+# `SortedEntityIndex` (`crates/beast-ecs/src/entity_id.rs`) relies on
+# `specs::Entity` deriving `Ord` over `(index, generation)` in that
+# field order. A patch release that reorders the fields would silently
+# break replay determinism. Issue #175 tracks migrating
+# `SortedEntityIndex` to `BTreeSet<u32>` keyed on `Entity::id()` so we
+# stop depending on the derived impl.
+specs = { version = "~0.20", default-features = false, features = ["parallel"] }
 
 beast-core = { path = "crates/beast-core" }
 beast-manifest = { path = "crates/beast-manifest" }

--- a/crates/beast-ecs/src/components/biome.rs
+++ b/crates/beast-ecs/src/components/biome.rs
@@ -26,9 +26,20 @@ use specs::{Component, DenseVecStorage};
 /// taxonomy small; future expansion (rainforest, taiga, savanna…)
 /// happens behind the `#[non_exhaustive]` attribute so existing match
 /// sites won't break.
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+///
+/// # Determinism
+///
+/// `Ord` / `PartialOrd` are **hand-written** against [`Self::ordinal`]
+/// rather than derived. Deriving would tie the deterministic sort
+/// order to the variant declaration order — adding a new variant in
+/// the middle would silently shift every existing comparison and
+/// break replay determinism for any
+/// `BTreeMap<BiomeKind, _>` / sort-by-biome path. The hand-written
+/// impl + [`tests::ordinal_is_pinned_per_variant`] make the order an
+/// explicit contract: new variants must extend the ordinal table at
+/// the end (or at a deliberately chosen position with all the
+/// follow-on places audited).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BiomeKind {
@@ -48,6 +59,25 @@ pub enum BiomeKind {
 }
 
 impl BiomeKind {
+    /// Stable integer rank for `Ord`. New variants extend at the next
+    /// unused integer; an existing variant's number must never change
+    /// without a determinism-gate review (see the type-level docs).
+    ///
+    /// Pinned per-variant by
+    /// [`tests::ordinal_is_pinned_per_variant`]; pinned globally by
+    /// [`tests::biome_kind_ord_is_declaration_order`].
+    #[must_use]
+    pub fn ordinal(self) -> u8 {
+        match self {
+            BiomeKind::Ocean => 0,
+            BiomeKind::Forest => 1,
+            BiomeKind::Plains => 2,
+            BiomeKind::Desert => 3,
+            BiomeKind::Mountain => 4,
+            BiomeKind::Tundra => 5,
+        }
+    }
+
     /// String form expected by future channel manifests that filter
     /// by **terrain** (e.g., "expression_conditions: { terrain: forest }").
     /// Stable across versions — a rename would break every shipping
@@ -73,6 +103,18 @@ impl BiomeKind {
             BiomeKind::Mountain => "mountain",
             BiomeKind::Tundra => "tundra",
         }
+    }
+}
+
+impl PartialOrd for BiomeKind {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BiomeKind {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.ordinal().cmp(&other.ordinal())
     }
 }
 
@@ -239,5 +281,19 @@ mod tests {
         assert!(Plains < Desert);
         assert!(Desert < Mountain);
         assert!(Mountain < Tundra);
+    }
+
+    #[test]
+    fn ordinal_is_pinned_per_variant() {
+        // Per-variant ordinal lock-in. Adding a new variant must not
+        // change any existing value — re-numbering an existing entry
+        // would silently flip BTreeMap<BiomeKind, _> iteration order
+        // and break replay determinism (INVARIANTS §1).
+        assert_eq!(BiomeKind::Ocean.ordinal(), 0);
+        assert_eq!(BiomeKind::Forest.ordinal(), 1);
+        assert_eq!(BiomeKind::Plains.ordinal(), 2);
+        assert_eq!(BiomeKind::Desert.ordinal(), 3);
+        assert_eq!(BiomeKind::Mountain.ordinal(), 4);
+        assert_eq!(BiomeKind::Tundra.ordinal(), 5);
     }
 }

--- a/crates/beast-ecs/src/components/biome.rs
+++ b/crates/beast-ecs/src/components/biome.rs
@@ -63,11 +63,19 @@ impl BiomeKind {
     /// unused integer; an existing variant's number must never change
     /// without a determinism-gate review (see the type-level docs).
     ///
+    /// **Visibility**: `pub(crate)` because the integer is an
+    /// implementation detail of the `Ord` impl. Exposing it publicly
+    /// would invite downstream code to snapshot the integers (e.g.,
+    /// in a save format), which would freeze them as a public API
+    /// contract — directly contradicting this method's "must never
+    /// change" docs. Use `Ord` / `PartialOrd` for ordering and the
+    /// snake-case strings from [`Self::as_str`] for stable
+    /// persistence; reach for the integer only inside this crate.
+    ///
     /// Pinned per-variant by
     /// [`tests::ordinal_is_pinned_per_variant`]; pinned globally by
     /// [`tests::biome_kind_ord_is_declaration_order`].
-    #[must_use]
-    pub fn ordinal(self) -> u8 {
+    pub(crate) fn ordinal(self) -> u8 {
         match self {
             BiomeKind::Ocean => 0,
             BiomeKind::Forest => 1,

--- a/crates/beast-ecs/src/components/traits.rs
+++ b/crates/beast-ecs/src/components/traits.rs
@@ -11,6 +11,8 @@ use beast_primitives::PrimitiveEffect;
 use serde::{Deserialize, Serialize};
 use specs::{Component, DenseVecStorage};
 
+use crate::error::EcsError;
+
 // NOTE: `PrimitiveEffect` does not currently derive `Serialize` /
 // `Deserialize` (see `beast-primitives`). When S7 adds save/load, the
 // derive there will land in the same PR that re-enables it on
@@ -40,6 +42,26 @@ impl GenomeComponent {
 
     /// Mutable view — the mutation system in Stage 1 calls this to
     /// apply point mutations.
+    ///
+    /// # Caller contract
+    ///
+    /// This handle bypasses [`Genome::validate`]: the mutation
+    /// operators in `beast-genome` are written so that, **applied as a
+    /// set in their documented order**, they preserve every genome
+    /// invariant (modifier indices in range, no self-loops, no
+    /// duplicate lineage tags, channel-count parity). A caller that
+    /// performs partial / hand-rolled edits through this handle owns
+    /// the responsibility to call [`Genome::validate`] before the
+    /// genome leaves the tick (e.g., before persistence in Stage 7 or
+    /// before being read back into the interpreter on the next tick).
+    ///
+    /// Save-game serialisation (`beast-serde`) re-validates loaded
+    /// genomes as a defense-in-depth step — but a corrupt genome
+    /// produced by a buggy custom mutator and consumed by the same
+    /// process before save will not be caught. New code that wants a
+    /// validated mutation point should add a `try_mutate` helper that
+    /// runs `validate` before returning, rather than handing out the
+    /// raw `&mut Genome`.
     pub fn genome_mut(&mut self) -> &mut Genome {
         &mut self.0
     }
@@ -64,32 +86,140 @@ pub struct PhenotypeComponent {
 }
 
 impl PhenotypeComponent {
-    /// Build from an already-sorted effect list (the interpreter emits
-    /// them sorted — no re-sorting required here).
+    /// Build from an already-sorted effect list, **trusting the caller**.
     ///
-    /// In debug builds, verifies that `effects` is sorted by
-    /// `(primitive_id, body_site)`. A violation indicates the caller is
-    /// feeding a phenotype that bypassed the interpreter's emission
-    /// path, which would silently break the determinism invariant
-    /// (INVARIANTS §1) — downstream systems hash the phenotype in
-    /// visit order. Release builds skip the check; production callers
-    /// are expected to go through `beast_interpreter::emit_primitives`
-    /// which preserves the sort.
+    /// In debug builds this `debug_assert!`s that `effects` is sorted
+    /// by `(primitive_id, body_site)`. Release builds skip the check.
+    /// Use this from the per-tick interpreter hot path where the sort
+    /// is guaranteed by `beast_interpreter::emit_primitives` and the
+    /// caller has already paid the sort cost.
+    ///
+    /// For untrusted input — save-loaders, fixture builders, fuzz
+    /// harnesses — call [`Self::try_new`] instead, which validates in
+    /// release builds and returns
+    /// [`EcsError::PhenotypeNotSorted`] on violation.
     #[must_use]
     pub fn new(effects: Vec<PrimitiveEffect>) -> Self {
         debug_assert!(
-            effects.windows(2).all(|pair| {
-                (&pair[0].primitive_id, &pair[0].body_site)
-                    <= (&pair[1].primitive_id, &pair[1].body_site)
-            }),
+            Self::find_unsorted_index(&effects).is_none(),
             "PhenotypeComponent::new: effects must be sorted by \
              (primitive_id, body_site); caller bypassed the interpreter \
-             emission path"
+             emission path. Use try_new for untrusted input."
         );
         Self { effects }
+    }
+
+    /// Build from an effect list, validating sort order in **all build
+    /// profiles**. Use from save-loaders, test fixtures, and any path
+    /// where the caller cannot statically guarantee sort order — a
+    /// release build with an unsorted input would otherwise silently
+    /// break INVARIANTS §1 (downstream systems hash phenotypes in
+    /// visit order).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EcsError::PhenotypeNotSorted`] with the zero-based
+    /// index of the first out-of-order pair when `effects` is not
+    /// sorted by `(primitive_id, body_site)`.
+    pub fn try_new(effects: Vec<PrimitiveEffect>) -> Result<Self, EcsError> {
+        match Self::find_unsorted_index(&effects) {
+            Some(index) => Err(EcsError::PhenotypeNotSorted { index }),
+            None => Ok(Self { effects }),
+        }
+    }
+
+    /// Return the index `i` of the first pair where
+    /// `effects[i] > effects[i + 1]` by `(primitive_id, body_site)`,
+    /// or `None` if the slice is sorted. Shared by [`Self::new`]'s
+    /// debug assertion and [`Self::try_new`]'s release validation so
+    /// the two paths can never disagree.
+    fn find_unsorted_index(effects: &[PrimitiveEffect]) -> Option<usize> {
+        effects.windows(2).enumerate().find_map(|(i, pair)| {
+            let lhs = (&pair[0].primitive_id, &pair[0].body_site);
+            let rhs = (&pair[1].primitive_id, &pair[1].body_site);
+            (lhs > rhs).then_some(i)
+        })
     }
 }
 
 impl Component for PhenotypeComponent {
     type Storage = DenseVecStorage<Self>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beast_core::{BodySite, EntityId, Q3232};
+    use beast_primitives::Provenance;
+    use std::collections::BTreeMap;
+
+    fn effect(primitive_id: &str, body_site: Option<BodySite>) -> PrimitiveEffect {
+        PrimitiveEffect {
+            primitive_id: primitive_id.into(),
+            body_site,
+            source_channels: Vec::new(),
+            parameters: BTreeMap::new(),
+            activation_cost: Q3232::ZERO,
+            emitter: EntityId::new(0),
+            provenance: Provenance::Core,
+        }
+    }
+
+    #[test]
+    fn try_new_accepts_sorted_input() {
+        let effects = vec![
+            effect("alpha", None),
+            effect("alpha", Some(BodySite::Head)),
+            effect("beta", None),
+        ];
+        let component = PhenotypeComponent::try_new(effects.clone()).unwrap();
+        assert_eq!(component.effects, effects);
+    }
+
+    #[test]
+    fn try_new_accepts_empty_and_single_element_input() {
+        assert!(PhenotypeComponent::try_new(Vec::new()).is_ok());
+        assert!(PhenotypeComponent::try_new(vec![effect("zeta", None)]).is_ok());
+    }
+
+    #[test]
+    fn try_new_rejects_unsorted_input_with_first_violating_index() {
+        // alpha < beta < gamma is correct, but the second pair (beta, alpha)
+        // is unsorted — index 1 must be reported, not 0.
+        let effects = vec![
+            effect("alpha", None),
+            effect("beta", None),
+            effect("alpha", None),
+            effect("gamma", None),
+        ];
+        let err = PhenotypeComponent::try_new(effects).unwrap_err();
+        match err {
+            EcsError::PhenotypeNotSorted { index } => assert_eq!(index, 1),
+            other => panic!("expected PhenotypeNotSorted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_new_uses_body_site_as_secondary_key() {
+        // Same primitive_id; body_site None < Some(0) < Some(1) per Option's
+        // derived Ord. Out-of-order body_site within a primitive_id must
+        // still trigger.
+        let effects = vec![
+            effect("alpha", Some(BodySite::Jaw)),
+            effect("alpha", Some(BodySite::Head)),
+        ];
+        let err = PhenotypeComponent::try_new(effects).unwrap_err();
+        assert!(matches!(err, EcsError::PhenotypeNotSorted { index: 0 }));
+    }
+
+    #[test]
+    fn new_accepts_sorted_input_in_release_or_debug() {
+        // Mirror try_new's happy path so both constructors stay aligned;
+        // the debug_assert! inside `new` would catch unsorted input under
+        // `cargo test` (debug profile) but we want explicit coverage that
+        // the sorted-input fast path does not panic either way.
+        let effects = vec![effect("alpha", None), effect("beta", None)];
+        let component = PhenotypeComponent::new(effects.clone());
+        assert_eq!(component.effects, effects);
+    }
 }

--- a/crates/beast-ecs/src/entity_id.rs
+++ b/crates/beast-ecs/src/entity_id.rs
@@ -233,8 +233,24 @@ mod tests {
                 e0.gen()
             );
         } else {
-            // New index — e_fresh and e1's relative order is purely by
-            // index, which we've already checked above.
+            // New index — assert the index-then-generation rule
+            // explicitly: `e_fresh` and `e1` must compare strictly
+            // by index. If specs ever silently re-derives `Ord` to
+            // tiebreak on generation first, an `e_fresh` with the
+            // same generation as `e1` but a higher index would still
+            // sort correctly here, so this is the load-bearing check.
+            assert_ne!(
+                e_fresh.id(),
+                e1.id(),
+                "fresh entity index unexpectedly collided with e1"
+            );
+            let by_id = e_fresh.id().cmp(&e1.id());
+            let by_ord = e_fresh.cmp(&e1);
+            assert_eq!(
+                by_id, by_ord,
+                "Ord disagrees with index-only ordering: \
+                 e_fresh={e_fresh:?}, e1={e1:?}"
+            );
         }
     }
 

--- a/crates/beast-ecs/src/entity_id.rs
+++ b/crates/beast-ecs/src/entity_id.rs
@@ -56,6 +56,21 @@ impl MarkerKind {
 /// `Join` iteration order is a `specs` implementation detail, while
 /// this index makes the ordering contract ours.
 ///
+/// # DETERMINISM-CRITICAL
+///
+/// `BTreeSet<Entity>`'s iteration order is what makes
+/// [`Self::entities_of`] / [`Self::iter_all`] deterministic, and that
+/// order rests on the `Ord` impl `specs` derives for [`Entity`] over
+/// `(id, gen)` in field-declaration order. That impl is **not** part
+/// of `specs`'s public API contract — a future `specs` release that
+/// reorders or replaces those fields would silently break replay
+/// determinism. The workspace `Cargo.toml` therefore pins `specs` to
+/// the `~0.20` range (`>= 0.20.0, < 0.21.0`); the
+/// [`tests::specs_entity_ord_sorts_by_index_then_generation`] test
+/// fails loudly if a patch release ever changes the ordering. Issue
+/// #175 tracks migrating to `BTreeSet<u32>` keyed on `Entity::id()`
+/// so the determinism guarantee no longer depends on a derived impl.
+///
 /// # Maintenance contract
 ///
 /// Callers update the index by hand at entity creation / destruction.

--- a/crates/beast-ecs/src/error.rs
+++ b/crates/beast-ecs/src/error.rs
@@ -25,6 +25,22 @@ pub enum EcsError {
         /// Opaque message returned by the system.
         message: String,
     },
+    /// A [`crate::components::PhenotypeComponent::try_new`] caller
+    /// passed an effect list that was not sorted by
+    /// `(primitive_id, body_site)`. The interpreter emits sorted
+    /// output by contract; this error exists for callers that build
+    /// phenotypes outside the interpreter (tests, save-loaders) so
+    /// the determinism invariant is enforced in release builds.
+    #[error(
+        "phenotype effects out of order at index {index}: \
+         downstream systems hash phenotypes in visit order, so an \
+         unsorted list breaks INVARIANTS §1 (deterministic iteration)"
+    )]
+    PhenotypeNotSorted {
+        /// Zero-based position of the first out-of-order pair (the
+        /// effect at `index + 1` was less than the effect at `index`).
+        index: usize,
+    },
 }
 
 /// Crate-level `Result` alias. Every public API that can fail uses this.

--- a/crates/beast-ecs/src/system.rs
+++ b/crates/beast-ecs/src/system.rs
@@ -79,6 +79,23 @@ pub trait System {
     /// Implementations should return [`crate::EcsError::SystemRunFailed`]
     /// on failure. The scheduler decides how to react (abort vs skip
     /// this tick) — that policy lives in S6.
+    ///
+    /// # Capability scope (caller contract)
+    ///
+    /// `&mut EcsWorld` hands the system the **entire** world handle —
+    /// including `world_mut().delete_entity(...)` and any other
+    /// `specs::World` mutation. A mid-tick entity deletion would leave
+    /// [`crate::resources::Resources::entity_index`] pointing at a
+    /// dead `Entity` and silently corrupt the deterministic iteration
+    /// order downstream stages depend on.
+    ///
+    /// Until issue #176 narrows this surface to a capability handle
+    /// (e.g., `EcsWorldMut<'_>` exposing only component storages and
+    /// the `entity_index` add/remove methods), implementors **must
+    /// not** call `world.world_mut().delete_entity` from inside `run`.
+    /// Entity destruction is the spawner's responsibility (Stage 0)
+    /// and goes through `Resources::entity_index.remove_everywhere`
+    /// to keep the index coherent.
     fn run(&mut self, world: &mut EcsWorld, resources: &mut Resources) -> crate::Result<()>;
 }
 


### PR DESCRIPTION
Pre-graphics rust-reviewer audit pass for `beast-ecs`. Each finding from the audit is addressed below; full rationale is in the commit message.

## Findings addressed

| # | Severity | Summary |
|---|---|---|
| #54 | HIGH | `SortedEntityIndex` documents its load-bearing dependency on `specs::Entity`'s derived `Ord`; workspace pin tightened from `^0.20` to `~0.20`; issue #175 opened to migrate to `BTreeSet<u32>` keyed on `Entity::id()`. |
| #55 | MEDIUM | `PhenotypeComponent::try_new` returns `Result<Self, EcsError::PhenotypeNotSorted>` — release-checked variant for save-loaders / fixtures. `new` keeps the `debug_assert!` hot-path contract. Shared `find_unsorted_index` so the two paths can never disagree. |
| #56 | MEDIUM | `BiomeKind` `Ord` is now hand-written against `BiomeKind::ordinal() -> u8`, not derived. `ordinal_is_pinned_per_variant` test pins the per-variant integers. |
| #57 | MEDIUM | `GenomeComponent::genome_mut` documents that the handle bypasses `Genome::validate`; partial edits must re-validate before persistence. |
| #60 | LOW | `System::run` documents the `world_mut().delete_entity` prohibition (would corrupt `SortedEntityIndex`); issue #176 opened to narrow the surface to a capability type `EcsWorldMut<'_>`. |

## New trackers

- #175 — migrate `SortedEntityIndex` off `specs::Entity` Ord dependency
- #176 — narrow `System::run` capability surface

## Test plan

- [x] `cargo test -p beast-ecs --lib` — 48 / 48 pass (one new test for `ordinal_is_pinned_per_variant`, five for `try_new`, etc.)
- [x] `cargo clippy -p beast-ecs --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --workspace --all-targets` — downstream consumers (sim, serde, world) still compile
- [x] CI green on master
