### PR TITLE
chore(beast-sim): remove empty tick.rs stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock.bak
 # Claude Code local state (per-machine)
 .claude/*.local.json
 .claude/worktrees
+.claude/scheduled_tasks.lock
 
 # IDE
 .idea/

--- a/crates/beast-sim/src/lib.rs
+++ b/crates/beast-sim/src/lib.rs
@@ -47,7 +47,6 @@ pub mod error;
 pub mod schedule;
 pub mod simulation;
 pub mod spawner;
-pub mod tick;
 
 pub use budget::TickResult;
 pub use determinism::compute_state_hash;

--- a/crates/beast-sim/src/tick.rs
+++ b/crates/beast-sim/src/tick.rs
@@ -1,4 +1,0 @@
-//! Per-tick orchestration (S6 — various).
-//!
-//! Empty stub. `Simulation::tick()` (the function) will land here once
-//! the scheduler (S6.2) is in place.

--- a/documentation/architecture/CRATE_LAYOUT.md
+++ b/documentation/architecture/CRATE_LAYOUT.md
@@ -317,9 +317,8 @@ pub mod entity_id;         // Deterministic entity ID generation
 
 **Modules**:
 ```rust
-pub mod simulation;        // Simulation struct, game loop
+pub mod simulation;        // Simulation struct, game loop, tick orchestration
 pub mod schedule;          // SystemSchedule, system ordering
-pub mod tick;              // Per-tick orchestration
 pub mod budget;            // Performance budget tracking
 pub mod determinism;       // State hash, sorted iteration helper
 ```


### PR DESCRIPTION
Small cleanup: `crates/beast-sim/src/tick.rs` was created in S5.5 (#109) as a placeholder with the comment

> Empty stub. `Simulation::tick()` (the function) will land here once the scheduler (S6.2) is in place.

When S6.2 actually shipped, `Simulation::tick()` was implemented as a method on the `Simulation` struct in `simulation.rs:151`, not in `tick.rs`. The stub was never cleaned up — `pub mod tick;` in `lib.rs` exposed an empty module as part of the crate's public API surface.

## Changes

- Delete `crates/beast-sim/src/tick.rs`.
- Drop the `pub mod tick;` export from `crates/beast-sim/src/lib.rs`.
- Update `documentation/architecture/CRATE_LAYOUT.md` to point readers at `simulation` for tick orchestration (matches reality).
- Add `.claude/scheduled_tasks.lock` to `.gitignore` under the existing "Claude Code local state" block (per-machine session scratch file that snuck in via `git add -A`).

## Test plan

- [x] `cargo test --workspace --all-targets` — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on master
