### PR TITLE
feat(beast-render): S9.2 sprite atlas manifest + parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,9 @@ dependencies = [
  "beast-core",
  "beast-interpreter",
  "sdl3",
+ "serde",
+ "serde_json",
+ "tempfile",
  "thiserror",
 ]
 

--- a/assets/sprites/atlas.json
+++ b/assets/sprites/atlas.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "source": "atlas.png",
+  "entries": [
+    { "id": "biome.ocean",    "x":   0, "y":   0, "w": 32, "h": 32 },
+    { "id": "biome.forest",   "x":  32, "y":   0, "w": 32, "h": 32 },
+    { "id": "biome.plains",   "x":  64, "y":   0, "w": 32, "h": 32 },
+    { "id": "biome.desert",   "x":  96, "y":   0, "w": 32, "h": 32 },
+    { "id": "biome.mountain", "x": 128, "y":   0, "w": 32, "h": 32 },
+    { "id": "biome.tundra",   "x": 160, "y":   0, "w": 32, "h": 32 },
+
+    { "id": "creature.glyph.default",   "x":   0, "y":  32, "w": 16, "h": 16 },
+    { "id": "creature.glyph.grazer",    "x":  16, "y":  32, "w": 16, "h": 16 },
+    { "id": "creature.glyph.omnivore",  "x":  32, "y":  32, "w": 16, "h": 16 },
+    { "id": "creature.glyph.endotherm", "x":  48, "y":  32, "w": 16, "h": 16 },
+
+    { "id": "ui.selection_ring",     "x":   0, "y":  64, "w": 24, "h": 24 },
+    { "id": "ui.encounter.shadow",   "x":  24, "y":  64, "w": 32, "h":  8 }
+  ]
+}

--- a/crates/beast-render/Cargo.toml
+++ b/crates/beast-render/Cargo.toml
@@ -32,12 +32,17 @@ headless = []
 # input contract). Both are pure-Rust deps — no SDL coupling.
 beast-core = { workspace = true }
 beast-interpreter = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dependencies.sdl3]
 workspace = true
 optional = true
 features = ["build-from-source-static"]
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [[example]]
 # `required-features = ["sdl"]` makes cargo refuse to build this binary

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -34,8 +34,13 @@ pub mod blueprint;
 pub mod directive;
 pub(crate) mod pipeline;
 
+// Sprite atlas: id → Rect lookup loaded from a JSON manifest. Pure-Rust;
+// the GPU-upload step lands alongside the SDL renderers in S9.3 / S9.4.
+pub mod sprite;
+
 pub use blueprint::CreatureBlueprint;
 pub use directive::{ColorSpec, DirectiveParams, VisualDirective};
 pub use error::{RenderError, Result};
 pub use pipeline::compile_blueprint;
 pub use renderer::{Renderer, WindowConfig};
+pub use sprite::{AtlasError, Rect, SpriteAtlas, SpriteId};

--- a/crates/beast-render/src/sprite.rs
+++ b/crates/beast-render/src/sprite.rs
@@ -1,0 +1,392 @@
+//! Sprite atlas: id → rectangle lookup loaded from a JSON manifest.
+//!
+//! S9.2 ships the *headless* atlas: a parsed, validated manifest that
+//! resolves a [`SpriteId`] to a pixel-space [`Rect`]. The actual
+//! GPU-side texture upload sits on top of the SDL backend and lands in
+//! a follow-up — the world-map and encounter renderers (S9.3 / S9.4)
+//! call into the SDL feature directly when they need to draw.
+//!
+//! # Manifest shape
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "source": "assets/sprites/atlas.png",
+//!   "entries": [
+//!     { "id": "biome.forest", "x": 0,  "y": 0,  "w": 32, "h": 32 },
+//!     { "id": "biome.ocean",  "x": 32, "y": 0,  "w": 32, "h": 32 }
+//!   ]
+//! }
+//! ```
+//!
+//! `version` lets us evolve the schema without silently parsing old
+//! files; today only `1` is accepted. Duplicate ids and zero-area
+//! rectangles fail the load with a typed [`AtlasError`].
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Stable identifier for a sub-image within the atlas.
+///
+/// Identifiers are dotted strings so they're easy to namespace
+/// (`"biome.forest"`, `"creature.glyph.elastic"`). The visual pipeline
+/// and renderers reference sprites only via `SpriteId`; pixel
+/// coordinates live in the manifest, never in code.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SpriteId(pub String);
+
+impl SpriteId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for SpriteId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+/// Pixel-space rectangle. Origin is top-left; `w`/`h` are positive.
+///
+/// `i32` rather than `u32` so the type round-trips through SDL3's
+/// `sdl3::rect::Rect`, which uses signed coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+}
+
+impl Rect {
+    pub const fn new(x: i32, y: i32, w: i32, h: i32) -> Self {
+        Self { x, y, w, h }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest types — the wire format
+// ---------------------------------------------------------------------------
+
+/// One atlas entry as it appears in the JSON manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AtlasEntryWire {
+    id: String,
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+}
+
+/// Full atlas manifest as it appears on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AtlasManifestWire {
+    version: u32,
+    /// Path to the atlas image. Resolved relative to the manifest file.
+    source: String,
+    entries: Vec<AtlasEntryWire>,
+}
+
+const MANIFEST_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum AtlasError {
+    #[error("failed to read atlas manifest at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("invalid JSON in atlas manifest at {path}: {source}")]
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[error(
+        "unsupported atlas manifest version {found} at {path}: only version {} is recognised",
+        MANIFEST_VERSION
+    )]
+    UnsupportedVersion { path: PathBuf, found: u32 },
+
+    #[error("invalid region for sprite `{id}`: w and h must be positive (got {w}x{h})")]
+    InvalidRegion { id: String, w: i32, h: i32 },
+
+    #[error("invalid origin for sprite `{id}`: x and y must be non-negative (got {x},{y})")]
+    InvalidOrigin { id: String, x: i32, y: i32 },
+
+    #[error("duplicate sprite id `{id}` in atlas manifest")]
+    DuplicateId { id: String },
+
+    #[error("empty source path in atlas manifest at {path}")]
+    EmptySource { path: PathBuf },
+
+    #[error("empty sprite id in atlas manifest at {path}")]
+    EmptyId { path: PathBuf },
+}
+
+// ---------------------------------------------------------------------------
+// Public type
+// ---------------------------------------------------------------------------
+
+/// Parsed, validated atlas. Holds id → [`Rect`] lookup + the manifest's
+/// resolved source-image path. GPU-side texture handling is layered on
+/// top of this type by the SDL backend.
+#[derive(Debug, Clone)]
+pub struct SpriteAtlas {
+    /// Path to the source image, resolved relative to the manifest.
+    source_path: PathBuf,
+    /// Lookup table — `BTreeMap` so iteration is deterministic.
+    regions: BTreeMap<SpriteId, Rect>,
+}
+
+impl SpriteAtlas {
+    /// Parse and validate an atlas manifest at `path`. The atlas image
+    /// itself is *not* opened here — that happens at GPU-upload time.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, AtlasError> {
+        let path = path.as_ref();
+        let bytes = fs::read(path).map_err(|source| AtlasError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::parse(&bytes, path)
+    }
+
+    /// Parse an atlas manifest from raw JSON bytes. Path is used purely
+    /// for error reporting + resolving the relative `source` field.
+    pub fn parse(bytes: &[u8], path: impl AsRef<Path>) -> Result<Self, AtlasError> {
+        let path = path.as_ref();
+        let wire: AtlasManifestWire =
+            serde_json::from_slice(bytes).map_err(|source| AtlasError::Json {
+                path: path.to_path_buf(),
+                source,
+            })?;
+
+        if wire.version != MANIFEST_VERSION {
+            return Err(AtlasError::UnsupportedVersion {
+                path: path.to_path_buf(),
+                found: wire.version,
+            });
+        }
+
+        if wire.source.trim().is_empty() {
+            return Err(AtlasError::EmptySource {
+                path: path.to_path_buf(),
+            });
+        }
+        let source_path = path
+            .parent()
+            .map(|p| p.join(&wire.source))
+            .unwrap_or_else(|| PathBuf::from(&wire.source));
+
+        let mut regions = BTreeMap::new();
+        for entry in wire.entries {
+            if entry.id.is_empty() {
+                return Err(AtlasError::EmptyId {
+                    path: path.to_path_buf(),
+                });
+            }
+            if entry.w <= 0 || entry.h <= 0 {
+                return Err(AtlasError::InvalidRegion {
+                    id: entry.id,
+                    w: entry.w,
+                    h: entry.h,
+                });
+            }
+            if entry.x < 0 || entry.y < 0 {
+                return Err(AtlasError::InvalidOrigin {
+                    id: entry.id,
+                    x: entry.x,
+                    y: entry.y,
+                });
+            }
+            let id = SpriteId::new(entry.id.clone());
+            if regions.contains_key(&id) {
+                return Err(AtlasError::DuplicateId { id: entry.id });
+            }
+            regions.insert(id, Rect::new(entry.x, entry.y, entry.w, entry.h));
+        }
+
+        Ok(Self {
+            source_path,
+            regions,
+        })
+    }
+
+    /// Resolved path to the atlas image (absolute or relative to CWD).
+    pub fn source_path(&self) -> &Path {
+        &self.source_path
+    }
+
+    /// Look up a sprite's pixel rectangle.
+    pub fn region(&self, id: &SpriteId) -> Option<Rect> {
+        self.regions.get(id).copied()
+    }
+
+    /// Number of entries in the atlas.
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    /// True iff the atlas has zero entries.
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+
+    /// Iterate `(SpriteId, Rect)` pairs in deterministic order.
+    pub fn iter(&self) -> impl Iterator<Item = (&SpriteId, &Rect)> {
+        self.regions.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_manifest() -> &'static str {
+        r#"{
+            "version": 1,
+            "source": "atlas.png",
+            "entries": [
+                { "id": "biome.forest", "x": 0,  "y": 0,  "w": 32, "h": 32 },
+                { "id": "biome.ocean",  "x": 32, "y": 0,  "w": 32, "h": 32 },
+                { "id": "creature.glyph.default", "x": 0, "y": 32, "w": 16, "h": 16 }
+            ]
+        }"#
+    }
+
+    #[test]
+    fn parses_valid_manifest() {
+        let atlas =
+            SpriteAtlas::parse(fixture_manifest().as_bytes(), "/tmp/atlas.json").expect("parse ok");
+        assert_eq!(atlas.len(), 3);
+        assert_eq!(
+            atlas.region(&SpriteId::from("biome.forest")),
+            Some(Rect::new(0, 0, 32, 32))
+        );
+        assert_eq!(
+            atlas.region(&SpriteId::from("creature.glyph.default")),
+            Some(Rect::new(0, 32, 16, 16))
+        );
+        assert_eq!(atlas.region(&SpriteId::from("does.not.exist")), None);
+    }
+
+    #[test]
+    fn parses_empty_entries_list() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[]}"#;
+        let atlas = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json").expect("parse ok");
+        assert!(atlas.is_empty());
+    }
+
+    #[test]
+    fn rejects_zero_area_rect() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[
+            {"id":"x","x":0,"y":0,"w":0,"h":4}
+        ]}"#;
+        let err =
+            SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json").expect_err("zero w must error");
+        assert!(matches!(err, AtlasError::InvalidRegion { .. }));
+    }
+
+    #[test]
+    fn rejects_negative_origin() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[
+            {"id":"x","x":-1,"y":0,"w":4,"h":4}
+        ]}"#;
+        let err = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json")
+            .expect_err("negative x must error");
+        assert!(matches!(err, AtlasError::InvalidOrigin { .. }));
+    }
+
+    #[test]
+    fn rejects_duplicate_ids() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[
+            {"id":"x","x":0,"y":0,"w":4,"h":4},
+            {"id":"x","x":4,"y":0,"w":4,"h":4}
+        ]}"#;
+        let err = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json")
+            .expect_err("duplicate id must error");
+        assert!(matches!(err, AtlasError::DuplicateId { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[
+            {"id":"","x":0,"y":0,"w":4,"h":4}
+        ]}"#;
+        let err = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json")
+            .expect_err("empty id must error");
+        assert!(matches!(err, AtlasError::EmptyId { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_source_path() {
+        let manifest = r#"{"version":1,"source":"","entries":[]}"#;
+        let err = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json")
+            .expect_err("empty source must error");
+        assert!(matches!(err, AtlasError::EmptySource { .. }));
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let manifest = r#"{"version":99,"source":"a.png","entries":[]}"#;
+        let err = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json")
+            .expect_err("future version must error");
+        assert!(matches!(err, AtlasError::UnsupportedVersion { .. }));
+    }
+
+    #[test]
+    fn rejects_garbage_json() {
+        let err = SpriteAtlas::parse(b"not json", "/tmp/a.json").expect_err("garbage must error");
+        assert!(matches!(err, AtlasError::Json { .. }));
+    }
+
+    #[test]
+    fn iter_is_sorted_by_sprite_id() {
+        let manifest = r#"{"version":1,"source":"a.png","entries":[
+            {"id":"zebra","x":0,"y":0,"w":4,"h":4},
+            {"id":"alpha","x":0,"y":4,"w":4,"h":4},
+            {"id":"mango","x":0,"y":8,"w":4,"h":4}
+        ]}"#;
+        let atlas = SpriteAtlas::parse(manifest.as_bytes(), "/tmp/a.json").expect("parse ok");
+        let ids: Vec<_> = atlas
+            .iter()
+            .map(|(id, _)| id.as_str().to_string())
+            .collect();
+        assert_eq!(ids, ["alpha", "mango", "zebra"]);
+    }
+
+    #[test]
+    fn source_path_is_resolved_relative_to_manifest() {
+        let atlas = SpriteAtlas::parse(fixture_manifest().as_bytes(), "/some/dir/atlas.json")
+            .expect("parse ok");
+        assert_eq!(atlas.source_path(), Path::new("/some/dir/atlas.png"));
+    }
+
+    #[test]
+    fn round_trip_via_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest_path = dir.path().join("atlas.json");
+        std::fs::write(&manifest_path, fixture_manifest()).expect("write");
+        let atlas = SpriteAtlas::load(&manifest_path).expect("load");
+        assert_eq!(atlas.len(), 3);
+        assert_eq!(
+            atlas.region(&SpriteId::from("biome.forest")),
+            Some(Rect::new(0, 0, 32, 32))
+        );
+    }
+}

--- a/crates/beast-render/src/sprite.rs
+++ b/crates/beast-render/src/sprite.rs
@@ -36,9 +36,13 @@ use thiserror::Error;
 /// (`"biome.forest"`, `"creature.glyph.elastic"`). The visual pipeline
 /// and renderers reference sprites only via `SpriteId`; pixel
 /// coordinates live in the manifest, never in code.
+///
+/// The inner field is private so future invariants on the id format
+/// (charset, namespace rules) can be enforced in [`Self::new`] without
+/// breaking callers that wrote the value directly.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SpriteId(pub String);
+pub struct SpriteId(String);
 
 impl SpriteId {
     pub fn new(id: impl Into<String>) -> Self {
@@ -123,11 +127,23 @@ pub enum AtlasError {
     )]
     UnsupportedVersion { path: PathBuf, found: u32 },
 
-    #[error("invalid region for sprite `{id}`: w and h must be positive (got {w}x{h})")]
-    InvalidRegion { id: String, w: i32, h: i32 },
+    #[error("invalid region for sprite `{id}` in {path}: w and h must be positive (got {w}x{h})")]
+    InvalidRegion {
+        path: PathBuf,
+        id: String,
+        w: i32,
+        h: i32,
+    },
 
-    #[error("invalid origin for sprite `{id}`: x and y must be non-negative (got {x},{y})")]
-    InvalidOrigin { id: String, x: i32, y: i32 },
+    #[error(
+        "invalid origin for sprite `{id}` in {path}: x and y must be non-negative (got {x},{y})"
+    )]
+    InvalidOrigin {
+        path: PathBuf,
+        id: String,
+        x: i32,
+        y: i32,
+    },
 
     #[error("duplicate sprite id `{id}` in atlas manifest")]
     DuplicateId { id: String },
@@ -193,6 +209,12 @@ impl SpriteAtlas {
             .map(|p| p.join(&wire.source))
             .unwrap_or_else(|| PathBuf::from(&wire.source));
 
+        // Validation triage order per entry: empty id → non-positive
+        // dimensions → negative origin → duplicate id. The first check
+        // that fails wins; e.g. an entry with both `w=0` and `x=-1`
+        // surfaces `InvalidRegion`. Callers fix one issue at a time, so
+        // a single deterministic error per entry is more useful than a
+        // collected list.
         let mut regions = BTreeMap::new();
         for entry in wire.entries {
             if entry.id.is_empty() {
@@ -202,6 +224,7 @@ impl SpriteAtlas {
             }
             if entry.w <= 0 || entry.h <= 0 {
                 return Err(AtlasError::InvalidRegion {
+                    path: path.to_path_buf(),
                     id: entry.id,
                     w: entry.w,
                     h: entry.h,
@@ -209,16 +232,19 @@ impl SpriteAtlas {
             }
             if entry.x < 0 || entry.y < 0 {
                 return Err(AtlasError::InvalidOrigin {
+                    path: path.to_path_buf(),
                     id: entry.id,
                     x: entry.x,
                     y: entry.y,
                 });
             }
-            let id = SpriteId::new(entry.id.clone());
-            if regions.contains_key(&id) {
+            // Duplicate-id check first so the success path can move
+            // `entry.id` into `SpriteId::new` instead of cloning it.
+            if regions.contains_key(&SpriteId::new(&entry.id)) {
                 return Err(AtlasError::DuplicateId { id: entry.id });
             }
-            regions.insert(id, Rect::new(entry.x, entry.y, entry.w, entry.h));
+            let rect = Rect::new(entry.x, entry.y, entry.w, entry.h);
+            regions.insert(SpriteId::new(entry.id), rect);
         }
 
         Ok(Self {

--- a/crates/beast-render/tests/sprite_test.rs
+++ b/crates/beast-render/tests/sprite_test.rs
@@ -1,0 +1,92 @@
+//! Integration tests for [`SpriteAtlas`].
+//!
+//! These tests are kept separate from the unit tests inside
+//! `src/sprite.rs` because they exercise the *workspace-shipped*
+//! placeholder manifest at `assets/sprites/atlas.json`. The unit tests
+//! cover the parser semantics in isolation; this file's job is to make
+//! sure the asset committed to the repo stays valid.
+
+use beast_render::{Rect, SpriteAtlas, SpriteId};
+
+fn workspace_root() -> std::path::PathBuf {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    crate_dir
+        .ancestors()
+        .nth(2)
+        .expect("workspace root is two levels up from the crate manifest")
+        .to_path_buf()
+}
+
+#[test]
+fn shipped_atlas_loads_and_contains_canonical_biomes() {
+    let path = workspace_root().join("assets/sprites/atlas.json");
+    let atlas = SpriteAtlas::load(&path)
+        .unwrap_or_else(|e| panic!("shipped atlas at {} failed to load: {e}", path.display()));
+
+    // Every BiomeKind must have a matching glyph so the world map
+    // renderer (S9.3) can blanket-tile any generated world.
+    for biome in [
+        "biome.ocean",
+        "biome.forest",
+        "biome.plains",
+        "biome.desert",
+        "biome.mountain",
+        "biome.tundra",
+    ] {
+        let region = atlas.region(&SpriteId::from(biome));
+        assert!(
+            region.is_some(),
+            "shipped atlas is missing required biome glyph `{biome}`"
+        );
+    }
+}
+
+#[test]
+fn shipped_atlas_default_creature_glyph_is_present() {
+    let path = workspace_root().join("assets/sprites/atlas.json");
+    let atlas = SpriteAtlas::load(&path).expect("load");
+    // The world map renderer falls back to `creature.glyph.default`
+    // when a species-specific glyph isn't present. That fallback must
+    // always exist.
+    assert_eq!(
+        atlas
+            .region(&SpriteId::from("creature.glyph.default"))
+            .map(|r| (r.w, r.h)),
+        Some((16, 16))
+    );
+}
+
+#[test]
+fn shipped_atlas_entries_are_non_overlapping_within_rows() {
+    // Defensive check that the placeholder grid layout doesn't drift —
+    // a typo in `assets/sprites/atlas.json` could silently make two
+    // sprites share pixel coordinates and the renderer would draw the
+    // wrong glyph. We're not strict about *all* overlap — sprites in
+    // different rows can share x ranges — only same-y rows.
+    let path = workspace_root().join("assets/sprites/atlas.json");
+    let atlas = SpriteAtlas::load(&path).expect("load");
+
+    let mut rects: Vec<(SpriteId, Rect)> = atlas.iter().map(|(id, r)| (id.clone(), *r)).collect();
+    rects.sort_by_key(|(_, r)| (r.y, r.x));
+
+    for window in rects.windows(2) {
+        let (id_a, ra) = &window[0];
+        let (id_b, rb) = &window[1];
+        if ra.y != rb.y {
+            continue;
+        }
+        let a_right = ra.x + ra.w;
+        assert!(
+            a_right <= rb.x,
+            "atlas entries `{}` and `{}` overlap horizontally on row y={} \
+             ({}..{} vs {}..{})",
+            id_a.as_str(),
+            id_b.as_str(),
+            ra.y,
+            ra.x,
+            a_right,
+            rb.x,
+            rb.x + rb.w,
+        );
+    }
+}

--- a/crates/beast-render/tests/sprite_test.rs
+++ b/crates/beast-render/tests/sprite_test.rs
@@ -8,13 +8,23 @@
 
 use beast_render::{Rect, SpriteAtlas, SpriteId};
 
+/// Walk up from `crates/beast-render` until we find the workspace
+/// root. Asserts that the resolved directory contains a `Cargo.toml`,
+/// so a future move of the crate produces a useful failure instead of
+/// silently pointing at the wrong place.
 fn workspace_root() -> std::path::PathBuf {
     let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    crate_dir
+    let candidate = crate_dir
         .ancestors()
         .nth(2)
         .expect("workspace root is two levels up from the crate manifest")
-        .to_path_buf()
+        .to_path_buf();
+    debug_assert!(
+        candidate.join("Cargo.toml").is_file(),
+        "expected workspace Cargo.toml at {}",
+        candidate.display()
+    );
+    candidate
 }
 
 #[test]
@@ -62,7 +72,12 @@ fn shipped_atlas_entries_are_non_overlapping_within_rows() {
     // a typo in `assets/sprites/atlas.json` could silently make two
     // sprites share pixel coordinates and the renderer would draw the
     // wrong glyph. We're not strict about *all* overlap — sprites in
-    // different rows can share x ranges — only same-y rows.
+    // different rows can share x ranges — only same-y rows. NOTE: the
+    // adjacent-pair sweep below catches neighbour collisions only;
+    // non-adjacent sprites on the same row could still overlap if the
+    // grid drifts wildly. Full O(n²) overlap detection is overkill for
+    // a hand-edited fixture; revisit if the atlas grows past ~50
+    // entries or starts admitting sprites at arbitrary positions.
     let path = workspace_root().join("assets/sprites/atlas.json");
     let atlas = SpriteAtlas::load(&path).expect("load");
 


### PR DESCRIPTION
Closes #188.

## Summary
Headless half of the sprite atlas pipeline. \`SpriteAtlas\` is a parsed, validated id → \`Rect\` lookup loaded from a JSON manifest at \`assets/sprites/atlas.json\`. GPU-side texture upload sits on top of the SDL backend and lands alongside the world-map / encounter renderers in S9.3 / S9.4 — keeping it out here means CI on the headless mode covers the entire S9.2 surface without needing SDL3.

### What's new
- \`crates/beast-render/src/sprite.rs\` — public types (\`SpriteAtlas\`, \`SpriteId\`, \`Rect\`, \`AtlasError\`) + manifest parser.
- \`crates/beast-render/tests/sprite_test.rs\` — integration tests asserting the workspace-shipped placeholder atlas stays valid.
- \`assets/sprites/atlas.json\` — placeholder manifest with the 6 BiomeKind glyphs, 4 creature glyphs (default + 3 starter species from S8.3), and 2 UI overlays (selection ring + encounter shadow).

### Manifest schema
\`\`\`json
{
  "version": 1,
  "source": "atlas.png",
  "entries": [
    { "id": "biome.forest", "x": 0,  "y": 0, "w": 32, "h": 32 }
  ]
}
\`\`\`
- \`version\` lets us evolve the schema; today only \`1\` is accepted.
- \`source\` is the path to the actual PNG; resolved relative to the manifest file.
- Each entry carries an \`id\`, top-left origin, and rectangle size.

### Validation (typed errors via \`AtlasError\`)
| Error | Trigger |
|---|---|
| \`Io\` | Manifest file missing or unreadable |
| \`Json\` | Malformed JSON |
| \`UnsupportedVersion\` | \`version\` ≠ 1 |
| \`EmptySource\` | \`source\` is empty / whitespace |
| \`EmptyId\` | Entry has empty \`id\` |
| \`InvalidRegion\` | \`w ≤ 0\` or \`h ≤ 0\` |
| \`InvalidOrigin\` | \`x < 0\` or \`y < 0\` |
| \`DuplicateId\` | Same \`id\` appears twice |

### Determinism / invariants
- INVARIANTS §1: lookup is backed by \`BTreeMap<SpriteId, Rect>\` so iteration order is sorted, not hash-randomised. The \`iter_is_sorted_by_sprite_id\` unit test pins this.
- INVARIANTS §6: \`SpriteAtlas\` is render-side only. No sim crate depends on it; it's never persisted to a save file.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings\`
- [x] \`cargo clippy -p beast-render --all-targets -- -D warnings\` (sdl backend)
- [x] \`cargo test -p beast-render --no-default-features --features headless\` — 17 lib + 6 pipeline + 3 sprite_test = 26 tests pass
- [x] \`cargo test --workspace --exclude beast-render --all-targets --locked\` — workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)