### PR TITLE
feat(beast-render): S9.6 animation rigging substage

### DIFF
--- a/crates/beast-render/Cargo.toml
+++ b/crates/beast-render/Cargo.toml
@@ -51,6 +51,10 @@ tempfile = { workspace = true }
 name = "window"
 required-features = ["sdl"]
 
+[[example]]
+name = "animation"
+required-features = ["sdl"]
+
 [lints.rust]
 # Forbid `unsafe { ... }` blocks unless they carry a `// SAFETY:` comment
 # explaining the FFI invariant. We use `deny` rather than `forbid` so a

--- a/crates/beast-render/examples/animation.rs
+++ b/crates/beast-render/examples/animation.rs
@@ -1,0 +1,120 @@
+//! S9.6 smoke test: render one creature looping its walk cycle as a
+//! stick-figure overlay.
+//!
+//! Bones are drawn as lines — for each bone we project its rest pose
+//! into 2D screen space, then add the per-tick rotation delta from
+//! [`beast_render::animation::Animator::sample`]. This is the
+//! minimum-viable visualiser: enough to confirm the rig is alive,
+//! deferring "real" mesh rendering to S9.4.
+//!
+//! Run with:
+//!   cargo run -p beast-render --example animation
+
+#[cfg(feature = "sdl")]
+fn main() -> beast_render::Result<()> {
+    use std::collections::BTreeMap;
+
+    use beast_core::{BodySite, Q3232};
+    use beast_interpreter::{LifeStage, ResolvedPhenotype};
+    use beast_render::{compile_blueprint, directive::ColorSpec, Animator, Renderer, WindowConfig};
+    use sdl3::{event::Event, keyboard::Keycode, pixels::Color};
+
+    // Build a "quadruped walker" phenotype so we get a 4-limb skeleton
+    // and the QuadrupedWalk locomotion style.
+    let mut phenotype = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
+    let channels: BTreeMap<String, Q3232> = [
+        ("elastic_deformation", 0.2_f64),
+        ("structural_rigidity", 0.2),
+        ("mass_density", 0.5),
+        ("metabolic_rate", 0.6),
+        ("surface_friction", 0.9),
+        ("kinetic_force", 0.7),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), Q3232::from_num(v)))
+    .collect();
+    phenotype.global_channels = channels;
+
+    let blueprint = compile_blueprint(
+        &phenotype,
+        &[],
+        ColorSpec::rgb(
+            Q3232::from_num(120),
+            Q3232::from_num(0.4_f64),
+            Q3232::from_num(0.5_f64),
+        ),
+        "demo",
+    );
+
+    let walk_clip = &blueprint
+        .animations
+        .locomotion
+        .first()
+        .ok_or_else(|| beast_render::RenderError::Sdl("no walk clip".into()))?;
+    let animator = Animator::new(walk_clip);
+
+    let _ = phenotype; // tagged so the borrow doesn't outlive blueprint
+    let _ = BodySite::Global; // import side-effect to silence unused warning
+
+    let mut renderer = Renderer::new(WindowConfig {
+        title: "beast-render: S9.6 animation demo".to_string(),
+        ..Default::default()
+    })?;
+
+    let start = std::time::Instant::now();
+    'mainloop: loop {
+        for event in renderer.event_pump().poll_iter() {
+            if matches!(
+                event,
+                Event::Quit { .. }
+                    | Event::KeyDown {
+                        keycode: Some(Keycode::Escape),
+                        ..
+                    }
+            ) {
+                break 'mainloop;
+            }
+        }
+
+        let elapsed = start.elapsed().as_secs_f32();
+        let pose = animator.sample(Q3232::from_num(elapsed));
+
+        let canvas = renderer.canvas();
+        canvas.set_draw_color(Color::RGB(20, 24, 32));
+        canvas.clear();
+
+        // Draw each bone as a line. Origin is the screen centre; each
+        // bone-id maps to a horizontal slot so motion is visible.
+        canvas.set_draw_color(Color::RGB(220, 220, 240));
+        let cx: i32 = 640;
+        let cy: i32 = 360;
+        for (i, bone) in blueprint.skeleton.bones.iter().enumerate() {
+            let rotation_deg = pose
+                .bone_rotations
+                .iter()
+                .find(|r| r.bone_id == bone.id)
+                .map(|r| r.rotation.to_num::<f32>())
+                .unwrap_or(0.0);
+            let length: f32 = bone.length.to_num::<f32>() * 60.0;
+            let theta = rotation_deg.to_radians();
+            let (sin, cos) = theta.sin_cos();
+            let x0 = cx + (i as i32 * 40) - (blueprint.skeleton.bones.len() as i32 * 20);
+            let y0 = cy;
+            let x1 = x0 + (length * cos) as i32;
+            let y1 = y0 + (length * sin) as i32;
+            canvas
+                .draw_line((x0, y0), (x1, y1))
+                .map_err(|e| beast_render::RenderError::Sdl(e.to_string()))?;
+        }
+
+        renderer.present();
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "sdl"))]
+fn main() {
+    eprintln!("This example requires the `sdl` feature.");
+    std::process::exit(2);
+}

--- a/crates/beast-render/examples/animation.rs
+++ b/crates/beast-render/examples/animation.rs
@@ -14,7 +14,7 @@
 fn main() -> beast_render::Result<()> {
     use std::collections::BTreeMap;
 
-    use beast_core::{BodySite, Q3232};
+    use beast_core::Q3232;
     use beast_interpreter::{LifeStage, ResolvedPhenotype};
     use beast_render::{compile_blueprint, directive::ColorSpec, Animator, Renderer, WindowConfig};
     use sdl3::{event::Event, keyboard::Keycode, pixels::Color};
@@ -52,9 +52,6 @@ fn main() -> beast_render::Result<()> {
         .first()
         .ok_or_else(|| beast_render::RenderError::Sdl("no walk clip".into()))?;
     let animator = Animator::new(walk_clip);
-
-    let _ = phenotype; // tagged so the borrow doesn't outlive blueprint
-    let _ = BodySite::Global; // import side-effect to silence unused warning
 
     let mut renderer = Renderer::new(WindowConfig {
         title: "beast-render: S9.6 animation demo".to_string(),

--- a/crates/beast-render/src/animation.rs
+++ b/crates/beast-render/src/animation.rs
@@ -1,0 +1,732 @@
+//! Animation rigging — substage 6 of the visual pipeline.
+//!
+//! Generates an [`AnimationSet`] from a skeleton + resolved phenotype,
+//! and provides an [`Animator`] that samples a clip at a given `t` to
+//! produce a per-bone [`PoseFrame`].
+//!
+//! # Numeric contract
+//!
+//! All keyframe values are stored as [`Q3232`] (rotation in degrees,
+//! local time in seconds, scale in unitless multipliers) for the same
+//! reason the rest of the pipeline is fixed-point: a determinism test
+//! across processes / platforms must produce byte-identical blueprint
+//! hashes, and IEEE-754 float bit patterns are not guaranteed across
+//! every platform we'll eventually run on.
+//!
+//! Renderers consume `Q3232::to_num::<f32>()` at sample time. The float
+//! conversion happens *outside* the determinism boundary — by then
+//! we've already verified the blueprint hash matches.
+//!
+//! See `documentation/systems/10_procgen_visual_pipeline.md` §4.6 for
+//! the authoritative algorithm.
+
+use beast_core::Q3232;
+use beast_interpreter::ResolvedPhenotype;
+
+use crate::blueprint::{Bone, BoneTag, BoneTree};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// All animations rigged for one creature.
+///
+/// Lists are ordered: locomotion clips by speed (walk first, run
+/// second), then idle clips, then a single damage and death clip.
+/// Iteration of any list is deterministic by index.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnimationSet {
+    pub locomotion: Vec<AnimationClip>,
+    pub idle: Vec<AnimationClip>,
+    pub damage: AnimationClip,
+    pub death: AnimationClip,
+}
+
+/// One clip — a named, looping-or-one-shot bundle of per-bone keyframe
+/// tracks. `duration` is in seconds (Q32.32).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnimationClip {
+    pub name: String,
+    pub duration: Q3232,
+    pub looping: bool,
+    pub bone_tracks: Vec<BoneTrack>,
+}
+
+/// A track: an ordered list of keyframes for one bone.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BoneTrack {
+    pub bone_id: u32,
+    pub keyframes: Vec<Keyframe>,
+}
+
+/// Single keyframe.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Keyframe {
+    /// Local clip time in seconds.
+    pub time: Q3232,
+    /// Rotation delta from rest, in degrees.
+    pub rotation: Q3232,
+    /// Squash / stretch along the bone axis (1.0 = no change).
+    pub scale: Q3232,
+    /// Easing curve from this keyframe to the next.
+    pub easing: Easing,
+}
+
+/// Easing curve between two keyframes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Easing {
+    Linear,
+    EaseIn,
+    EaseOut,
+    EaseInOut,
+}
+
+/// Locomotion style picked by [`pick_locomotion_style`] from the
+/// phenotype's channel ratios.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LocomotionStyle {
+    /// Snake / worm undulation. Spine bones oscillate in a travelling
+    /// sinusoid; limbs (if any) hang.
+    SinuousWave,
+    /// Armored / segmented scuttle. Spine is mostly rigid; limbs lift
+    /// in lock-step.
+    SegmentedScuttle,
+    /// Four-legged walk. Limb pairs alternate (front-left + rear-right
+    /// then front-right + rear-left).
+    QuadrupedWalk,
+    /// Two-legged walk. Limbs alternate.
+    BipedWalk,
+}
+
+// ---------------------------------------------------------------------------
+// Pose sampling
+// ---------------------------------------------------------------------------
+
+/// Per-bone pose at one moment in time. `bone_rotations` is sorted by
+/// `bone_id`; the renderer applies the deltas relative to each bone's
+/// rest pose stored on the [`BoneTree`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PoseFrame {
+    pub bone_rotations: Vec<BoneRotation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoneRotation {
+    pub bone_id: u32,
+    /// Rotation delta from rest, in degrees.
+    pub rotation: Q3232,
+    /// Scale (1.0 = unchanged).
+    pub scale: Q3232,
+}
+
+/// Lightweight clip-sampling helper. Constructed by the renderer with
+/// the chosen clip index; calling [`Self::sample`] produces a deterministic
+/// [`PoseFrame`] for any input `t` in seconds.
+#[derive(Debug, Clone, Copy)]
+pub struct Animator<'clip> {
+    clip: &'clip AnimationClip,
+}
+
+impl<'clip> Animator<'clip> {
+    pub fn new(clip: &'clip AnimationClip) -> Self {
+        Self { clip }
+    }
+
+    /// Sample the clip at `t` seconds. If `clip.looping` is true, `t`
+    /// wraps modulo `clip.duration`; otherwise `t` clamps to
+    /// `[0, duration]`.
+    pub fn sample(&self, t: Q3232) -> PoseFrame {
+        let t_local = if self.clip.looping {
+            modulo_q3232(t, self.clip.duration)
+        } else {
+            t.clamp(Q3232::ZERO, self.clip.duration)
+        };
+
+        let bone_rotations: Vec<BoneRotation> = self
+            .clip
+            .bone_tracks
+            .iter()
+            .map(|track| sample_track(track, t_local))
+            .collect();
+
+        PoseFrame { bone_rotations }
+    }
+}
+
+fn sample_track(track: &BoneTrack, t: Q3232) -> BoneRotation {
+    if track.keyframes.is_empty() {
+        return BoneRotation {
+            bone_id: track.bone_id,
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+        };
+    }
+    if track.keyframes.len() == 1 {
+        let kf = &track.keyframes[0];
+        return BoneRotation {
+            bone_id: track.bone_id,
+            rotation: kf.rotation,
+            scale: kf.scale,
+        };
+    }
+
+    // Find the keyframe pair (a, b) such that a.time <= t <= b.time.
+    // Keyframes are sorted by time at rig-time, so a linear scan is
+    // fine for ≤16 keyframes per track.
+    let last_idx = track.keyframes.len() - 1;
+    if t <= track.keyframes[0].time {
+        let kf = &track.keyframes[0];
+        return BoneRotation {
+            bone_id: track.bone_id,
+            rotation: kf.rotation,
+            scale: kf.scale,
+        };
+    }
+    if t >= track.keyframes[last_idx].time {
+        let kf = &track.keyframes[last_idx];
+        return BoneRotation {
+            bone_id: track.bone_id,
+            rotation: kf.rotation,
+            scale: kf.scale,
+        };
+    }
+
+    let mut a_idx = 0;
+    for i in 0..last_idx {
+        if track.keyframes[i].time <= t && t <= track.keyframes[i + 1].time {
+            a_idx = i;
+            break;
+        }
+    }
+    let a = &track.keyframes[a_idx];
+    let b = &track.keyframes[a_idx + 1];
+
+    let span = b.time.saturating_sub(a.time);
+    let raw_alpha = if span == Q3232::ZERO {
+        Q3232::ZERO
+    } else {
+        // Saturating divide via subtraction: alpha = (t - a.time) / span.
+        // Q3232 has its own division operator (saturating).
+        (t.saturating_sub(a.time)) / span
+    };
+    let alpha = apply_easing(raw_alpha, a.easing);
+
+    BoneRotation {
+        bone_id: track.bone_id,
+        rotation: lerp_q3232(a.rotation, b.rotation, alpha),
+        scale: lerp_q3232(a.scale, b.scale, alpha),
+    }
+}
+
+fn lerp_q3232(a: Q3232, b: Q3232, alpha: Q3232) -> Q3232 {
+    a.saturating_add(b.saturating_sub(a).saturating_mul(alpha))
+}
+
+fn modulo_q3232(value: Q3232, divisor: Q3232) -> Q3232 {
+    if divisor <= Q3232::ZERO {
+        return Q3232::ZERO;
+    }
+    let q = value / divisor;
+    // Floor-toward-zero is fine here because clip timing is always
+    // positive in practice; we still guard with abs to handle edge
+    // cases without UB.
+    let q_floor: i64 = q.to_num::<i64>();
+    value.saturating_sub(divisor.saturating_mul(Q3232::from_num(q_floor)))
+}
+
+fn apply_easing(alpha: Q3232, easing: Easing) -> Q3232 {
+    match easing {
+        Easing::Linear => alpha,
+        // Quadratic ease curves give a "soft" feel without trigonometry.
+        // EaseIn:  alpha^2
+        // EaseOut: 1 - (1 - alpha)^2 = alpha * (2 - alpha)
+        // EaseInOut: 2*a^2 (a<0.5) | 1 - 2*(1-a)^2 (a>=0.5)
+        Easing::EaseIn => alpha.saturating_mul(alpha),
+        Easing::EaseOut => alpha.saturating_mul(Q3232::from_num(2).saturating_sub(alpha)),
+        Easing::EaseInOut => {
+            let half = Q3232::from_num(0.5_f64);
+            if alpha < half {
+                Q3232::from_num(2)
+                    .saturating_mul(alpha)
+                    .saturating_mul(alpha)
+            } else {
+                let inv = Q3232::ONE.saturating_sub(alpha);
+                Q3232::ONE
+                    .saturating_sub(Q3232::from_num(2).saturating_mul(inv).saturating_mul(inv))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Locomotion-style decision
+// ---------------------------------------------------------------------------
+
+const CH_ELASTIC_DEFORMATION: &str = "elastic_deformation";
+const CH_STRUCTURAL_RIGIDITY: &str = "structural_rigidity";
+const CH_METABOLIC_RATE: &str = "metabolic_rate";
+
+fn ch(phenotype: &ResolvedPhenotype, name: &str) -> Q3232 {
+    phenotype
+        .global_channels
+        .get(name)
+        .copied()
+        .unwrap_or(Q3232::ZERO)
+}
+
+/// Pick a locomotion style from channel ratios + skeleton topology.
+///
+/// Tie-break is deterministic via the explicit branch order.
+pub fn pick_locomotion_style(
+    skeleton: &BoneTree,
+    phenotype: &ResolvedPhenotype,
+) -> LocomotionStyle {
+    let elasticity = ch(phenotype, CH_ELASTIC_DEFORMATION);
+    let rigidity = ch(phenotype, CH_STRUCTURAL_RIGIDITY);
+
+    if elasticity > Q3232::from_num(0.6_f64) {
+        LocomotionStyle::SinuousWave
+    } else if rigidity > Q3232::from_num(0.6_f64) {
+        LocomotionStyle::SegmentedScuttle
+    } else {
+        let limb_count = skeleton
+            .bones
+            .iter()
+            .filter(|b| b.tags.contains(&BoneTag::Limb))
+            .count();
+        if limb_count >= 4 {
+            LocomotionStyle::QuadrupedWalk
+        } else {
+            LocomotionStyle::BipedWalk
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public rig entry point
+// ---------------------------------------------------------------------------
+
+/// Substage 6: build the animation set for a skeleton + phenotype.
+///
+/// Returns walk + run locomotion clips for the chosen
+/// [`LocomotionStyle`], one idle (breathing pulse, frequency scaled by
+/// metabolic rate), one damage clip, one death clip.
+pub fn rig_animations(skeleton: &BoneTree, phenotype: &ResolvedPhenotype) -> AnimationSet {
+    let style = pick_locomotion_style(skeleton, phenotype);
+    let metabolic = ch(phenotype, CH_METABOLIC_RATE);
+
+    let walk = build_locomotion_clip(skeleton, style, /*speed=*/ Q3232::ONE, "walk");
+    let run = build_locomotion_clip(skeleton, style, /*speed=*/ Q3232::from_num(2), "run");
+    let idle = build_idle_clip(skeleton, metabolic);
+    let damage = build_damage_clip(skeleton);
+    let death = build_death_clip(skeleton);
+
+    AnimationSet {
+        locomotion: vec![walk, run],
+        idle: vec![idle],
+        damage,
+        death,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Clip builders
+// ---------------------------------------------------------------------------
+
+fn core_bones(skeleton: &BoneTree) -> impl Iterator<Item = &Bone> {
+    skeleton
+        .bones
+        .iter()
+        .filter(|b| b.tags.contains(&BoneTag::Core))
+}
+
+fn limb_bones(skeleton: &BoneTree) -> impl Iterator<Item = &Bone> {
+    skeleton
+        .bones
+        .iter()
+        .filter(|b| b.tags.contains(&BoneTag::Limb))
+}
+
+fn build_locomotion_clip(
+    skeleton: &BoneTree,
+    style: LocomotionStyle,
+    speed: Q3232,
+    name: &str,
+) -> AnimationClip {
+    // Total clip duration in seconds — faster speed = shorter clip.
+    let duration = Q3232::from_num(2).saturating_mul(Q3232::ONE / speed.max(Q3232::ONE));
+    let mut tracks = Vec::new();
+
+    match style {
+        LocomotionStyle::SinuousWave => {
+            // Each core bone gets a sinusoidal swing offset by its
+            // index. Approximated with two keyframes per quarter-cycle
+            // (5 keyframes total spanning duration), so the
+            // determinism contract doesn't need a real sin().
+            for (i, bone) in core_bones(skeleton).enumerate() {
+                let phase = Q3232::from_num(i as u32).saturating_mul(Q3232::from_num(15));
+                tracks.push(BoneTrack {
+                    bone_id: bone.id,
+                    keyframes: sinusoid_keyframes(duration, Q3232::from_num(20), phase),
+                });
+            }
+        }
+        LocomotionStyle::SegmentedScuttle => {
+            // Spine stays rigid; limbs lift in lock-step.
+            for bone in limb_bones(skeleton) {
+                tracks.push(BoneTrack {
+                    bone_id: bone.id,
+                    keyframes: stride_keyframes(duration, /*phase_offset=*/ Q3232::ZERO),
+                });
+            }
+        }
+        LocomotionStyle::QuadrupedWalk | LocomotionStyle::BipedWalk => {
+            // Alternating limb pairs. Even-index limbs phase 0, odd
+            // phase 0.5.
+            for (i, bone) in limb_bones(skeleton).enumerate() {
+                let phase_offset = if i % 2 == 0 {
+                    Q3232::ZERO
+                } else {
+                    Q3232::from_num(0.5_f64)
+                };
+                tracks.push(BoneTrack {
+                    bone_id: bone.id,
+                    keyframes: stride_keyframes(duration, phase_offset),
+                });
+            }
+        }
+    }
+
+    AnimationClip {
+        name: format!("{name}_{:?}", style).to_lowercase(),
+        duration,
+        looping: true,
+        bone_tracks: tracks,
+    }
+}
+
+fn build_idle_clip(skeleton: &BoneTree, metabolic: Q3232) -> AnimationClip {
+    // Period: 1s baseline at metabolic_rate=0; 0.4s at metabolic=1.
+    let metabolic = metabolic.clamp(Q3232::ZERO, Q3232::ONE);
+    let period = Q3232::ONE.saturating_sub(metabolic.saturating_mul(Q3232::from_num(0.6_f64)));
+
+    let mut tracks = Vec::new();
+    for bone in core_bones(skeleton) {
+        // Tiny breathing scale animation: 1.0 -> 1.05 -> 1.0.
+        tracks.push(BoneTrack {
+            bone_id: bone.id,
+            keyframes: vec![
+                Keyframe {
+                    time: Q3232::ZERO,
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::ONE,
+                    easing: Easing::EaseInOut,
+                },
+                Keyframe {
+                    time: period.saturating_mul(Q3232::from_num(0.5_f64)),
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::from_num(1.05_f64),
+                    easing: Easing::EaseInOut,
+                },
+                Keyframe {
+                    time: period,
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::ONE,
+                    easing: Easing::Linear,
+                },
+            ],
+        });
+    }
+    AnimationClip {
+        name: "idle".to_string(),
+        duration: period,
+        looping: true,
+        bone_tracks: tracks,
+    }
+}
+
+fn build_damage_clip(skeleton: &BoneTree) -> AnimationClip {
+    // Quick recoil: every core bone twists by -8° at t=0.05s, returns
+    // to rest at t=0.2s.
+    let mut tracks = Vec::new();
+    for bone in core_bones(skeleton) {
+        tracks.push(BoneTrack {
+            bone_id: bone.id,
+            keyframes: vec![
+                Keyframe {
+                    time: Q3232::ZERO,
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::ONE,
+                    easing: Easing::EaseOut,
+                },
+                Keyframe {
+                    time: Q3232::from_num(0.05_f64),
+                    rotation: Q3232::from_num(-8),
+                    scale: Q3232::ONE,
+                    easing: Easing::EaseIn,
+                },
+                Keyframe {
+                    time: Q3232::from_num(0.2_f64),
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::ONE,
+                    easing: Easing::Linear,
+                },
+            ],
+        });
+    }
+    AnimationClip {
+        name: "damage".to_string(),
+        duration: Q3232::from_num(0.2_f64),
+        looping: false,
+        bone_tracks: tracks,
+    }
+}
+
+fn build_death_clip(skeleton: &BoneTree) -> AnimationClip {
+    // Slow tilt: every core bone rotates 90° over 1.2s and stays.
+    let mut tracks = Vec::new();
+    for bone in core_bones(skeleton) {
+        tracks.push(BoneTrack {
+            bone_id: bone.id,
+            keyframes: vec![
+                Keyframe {
+                    time: Q3232::ZERO,
+                    rotation: Q3232::ZERO,
+                    scale: Q3232::ONE,
+                    easing: Easing::EaseIn,
+                },
+                Keyframe {
+                    time: Q3232::from_num(1.2_f64),
+                    rotation: Q3232::from_num(90),
+                    scale: Q3232::ONE,
+                    easing: Easing::Linear,
+                },
+            ],
+        });
+    }
+    AnimationClip {
+        name: "death".to_string(),
+        duration: Q3232::from_num(1.2_f64),
+        looping: false,
+        bone_tracks: tracks,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Keyframe-pattern helpers
+// ---------------------------------------------------------------------------
+
+/// Five-keyframe sinusoid approximation: starts at 0, peaks at +amp at
+/// quarter, returns to 0 at half, troughs at -amp at three-quarters,
+/// back to 0 at end. `phase` shifts the rotation magnitude (degrees).
+fn sinusoid_keyframes(duration: Q3232, amplitude: Q3232, phase: Q3232) -> Vec<Keyframe> {
+    let q = duration.saturating_mul(Q3232::from_num(0.25_f64));
+    let amp_with_phase = amplitude.saturating_add(phase);
+    vec![
+        Keyframe {
+            time: Q3232::ZERO,
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: q,
+            rotation: amp_with_phase,
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: q.saturating_mul(Q3232::from_num(2)),
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: q.saturating_mul(Q3232::from_num(3)),
+            rotation: amp_with_phase.saturating_mul(Q3232::from_num(-1)),
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: duration,
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+            easing: Easing::Linear,
+        },
+    ]
+}
+
+/// Stride keyframes: lift at 25%, plant at 75%, recover by end.
+/// `phase_offset` in [0, 1) shifts the entire pattern along the clip.
+fn stride_keyframes(duration: Q3232, phase_offset: Q3232) -> Vec<Keyframe> {
+    let phase_t = phase_offset.saturating_mul(duration);
+    let lift = Q3232::from_num(30);
+    let plant = Q3232::from_num(-20);
+    vec![
+        Keyframe {
+            time: phase_t,
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+            easing: Easing::EaseIn,
+        },
+        Keyframe {
+            time: wrap_time(
+                phase_t.saturating_add(duration.saturating_mul(Q3232::from_num(0.25_f64))),
+                duration,
+            ),
+            rotation: lift,
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: wrap_time(
+                phase_t.saturating_add(duration.saturating_mul(Q3232::from_num(0.75_f64))),
+                duration,
+            ),
+            rotation: plant,
+            scale: Q3232::ONE,
+            easing: Easing::EaseInOut,
+        },
+        Keyframe {
+            time: duration,
+            rotation: Q3232::ZERO,
+            scale: Q3232::ONE,
+            easing: Easing::Linear,
+        },
+    ]
+}
+
+fn wrap_time(t: Q3232, duration: Q3232) -> Q3232 {
+    if t > duration {
+        t.saturating_sub(duration)
+    } else {
+        t
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linear_keyframes() -> Vec<Keyframe> {
+        vec![
+            Keyframe {
+                time: Q3232::ZERO,
+                rotation: Q3232::ZERO,
+                scale: Q3232::ONE,
+                easing: Easing::Linear,
+            },
+            Keyframe {
+                time: Q3232::ONE,
+                rotation: Q3232::from_num(10),
+                scale: Q3232::ONE,
+                easing: Easing::Linear,
+            },
+        ]
+    }
+
+    fn one_track_clip() -> AnimationClip {
+        AnimationClip {
+            name: "test".to_string(),
+            duration: Q3232::ONE,
+            looping: false,
+            bone_tracks: vec![BoneTrack {
+                bone_id: 7,
+                keyframes: linear_keyframes(),
+            }],
+        }
+    }
+
+    #[test]
+    fn sample_at_zero_returns_first_keyframe() {
+        let clip = one_track_clip();
+        let pose = Animator::new(&clip).sample(Q3232::ZERO);
+        assert_eq!(pose.bone_rotations.len(), 1);
+        assert_eq!(pose.bone_rotations[0].bone_id, 7);
+        assert_eq!(pose.bone_rotations[0].rotation, Q3232::ZERO);
+    }
+
+    #[test]
+    fn sample_at_duration_returns_last_keyframe() {
+        let clip = one_track_clip();
+        let pose = Animator::new(&clip).sample(Q3232::ONE);
+        assert_eq!(pose.bone_rotations[0].rotation, Q3232::from_num(10));
+    }
+
+    #[test]
+    fn linear_lerp_at_midpoint_is_halfway() {
+        let clip = one_track_clip();
+        let pose = Animator::new(&clip).sample(Q3232::from_num(0.5_f64));
+        assert_eq!(pose.bone_rotations[0].rotation, Q3232::from_num(5));
+    }
+
+    #[test]
+    fn looping_clip_wraps_t_modulo_duration() {
+        let mut clip = one_track_clip();
+        clip.looping = true;
+        let a = Animator::new(&clip).sample(Q3232::from_num(0.25_f64));
+        let b = Animator::new(&clip).sample(Q3232::from_num(1.25_f64));
+        assert_eq!(a, b, "looping clip must wrap t");
+    }
+
+    #[test]
+    fn non_looping_clip_clamps_t_above_duration() {
+        let clip = one_track_clip();
+        let a = Animator::new(&clip).sample(Q3232::ONE);
+        let b = Animator::new(&clip).sample(Q3232::from_num(5));
+        assert_eq!(a, b, "non-looping clip must clamp t");
+    }
+
+    #[test]
+    fn empty_track_returns_rest_pose() {
+        let clip = AnimationClip {
+            name: "empty".to_string(),
+            duration: Q3232::ONE,
+            looping: false,
+            bone_tracks: vec![BoneTrack {
+                bone_id: 0,
+                keyframes: Vec::new(),
+            }],
+        };
+        let pose = Animator::new(&clip).sample(Q3232::ZERO);
+        assert_eq!(pose.bone_rotations[0].rotation, Q3232::ZERO);
+        assert_eq!(pose.bone_rotations[0].scale, Q3232::ONE);
+    }
+
+    #[test]
+    fn single_keyframe_track_returns_that_pose_for_any_t() {
+        let clip = AnimationClip {
+            name: "stuck".to_string(),
+            duration: Q3232::ONE,
+            looping: false,
+            bone_tracks: vec![BoneTrack {
+                bone_id: 0,
+                keyframes: vec![Keyframe {
+                    time: Q3232::from_num(0.3_f64),
+                    rotation: Q3232::from_num(45),
+                    scale: Q3232::from_num(1.2_f64),
+                    easing: Easing::Linear,
+                }],
+            }],
+        };
+        let a = Animator::new(&clip).sample(Q3232::ZERO);
+        let b = Animator::new(&clip).sample(Q3232::ONE);
+        assert_eq!(a, b);
+        assert_eq!(a.bone_rotations[0].rotation, Q3232::from_num(45));
+    }
+
+    #[test]
+    fn ease_in_alpha_zero_and_one_match_linear() {
+        // Easing must be identity at endpoints.
+        assert_eq!(apply_easing(Q3232::ZERO, Easing::EaseIn), Q3232::ZERO);
+        assert_eq!(apply_easing(Q3232::ONE, Easing::EaseIn), Q3232::ONE);
+        assert_eq!(apply_easing(Q3232::ZERO, Easing::EaseOut), Q3232::ZERO);
+        assert_eq!(apply_easing(Q3232::ONE, Easing::EaseOut), Q3232::ONE);
+        assert_eq!(apply_easing(Q3232::ZERO, Easing::EaseInOut), Q3232::ZERO);
+        assert_eq!(apply_easing(Q3232::ONE, Easing::EaseInOut), Q3232::ONE);
+    }
+}

--- a/crates/beast-render/src/animation.rs
+++ b/crates/beast-render/src/animation.rs
@@ -24,6 +24,18 @@ use beast_core::Q3232;
 use beast_interpreter::ResolvedPhenotype;
 
 use crate::blueprint::{Bone, BoneTag, BoneTree};
+use crate::channels::{ch, CH_ELASTIC_DEFORMATION, CH_METABOLIC_RATE, CH_STRUCTURAL_RIGIDITY};
+
+// ---------------------------------------------------------------------------
+// ANIMATION NUMERIC INVARIANT
+// ---------------------------------------------------------------------------
+//
+// All `Q3232::from_num(<decimal>_f64)` calls below are compile-time
+// design-doc-derived constants — see the matching block in
+// `pipeline.rs` for the full rationale. New f64 literals here must be
+// constants, not values that flow from sim state.
+//
+// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Types
@@ -191,13 +203,15 @@ fn sample_track(track: &BoneTrack, t: Q3232) -> BoneRotation {
         };
     }
 
-    let mut a_idx = 0;
-    for i in 0..last_idx {
-        if track.keyframes[i].time <= t && t <= track.keyframes[i + 1].time {
-            a_idx = i;
-            break;
-        }
-    }
+    // partition_point returns the first index whose time is strictly
+    // greater than `t`; subtract one to get the predecessor (`a`). The
+    // `t <= keyframes[0].time` and `t >= keyframes[last].time` guards
+    // above mean partition_point can't return 0 or `len`, so the
+    // saturating_sub is defensive but not strictly necessary.
+    let a_idx = track
+        .keyframes
+        .partition_point(|kf| kf.time <= t)
+        .saturating_sub(1);
     let a = &track.keyframes[a_idx];
     let b = &track.keyframes[a_idx + 1];
 
@@ -261,18 +275,6 @@ fn apply_easing(alpha: Q3232, easing: Easing) -> Q3232 {
 // ---------------------------------------------------------------------------
 // Locomotion-style decision
 // ---------------------------------------------------------------------------
-
-const CH_ELASTIC_DEFORMATION: &str = "elastic_deformation";
-const CH_STRUCTURAL_RIGIDITY: &str = "structural_rigidity";
-const CH_METABOLIC_RATE: &str = "metabolic_rate";
-
-fn ch(phenotype: &ResolvedPhenotype, name: &str) -> Q3232 {
-    phenotype
-        .global_channels
-        .get(name)
-        .copied()
-        .unwrap_or(Q3232::ZERO)
-}
 
 /// Pick a locomotion style from channel ratios + skeleton topology.
 ///
@@ -359,15 +361,19 @@ fn build_locomotion_clip(
 
     match style {
         LocomotionStyle::SinuousWave => {
-            // Each core bone gets a sinusoidal swing offset by its
-            // index. Approximated with two keyframes per quarter-cycle
-            // (5 keyframes total spanning duration), so the
-            // determinism contract doesn't need a real sin().
+            // Each core bone gets a sinusoidal swing of equal
+            // amplitude, time-shifted by its index so the spine
+            // ripples like a travelling wave. 0.1 of clip duration
+            // per bone gives a roughly visible undulation; clamped
+            // to <1.0 so the offset wraps within one cycle.
+            const PHASE_PER_BONE: f64 = 0.1;
             for (i, bone) in core_bones(skeleton).enumerate() {
-                let phase = Q3232::from_num(i as u32).saturating_mul(Q3232::from_num(15));
+                let raw_fraction =
+                    Q3232::from_num(i as u32).saturating_mul(Q3232::from_num(PHASE_PER_BONE));
+                let phase_fraction = raw_fraction.clamp(Q3232::ZERO, Q3232::from_num(0.9_f64));
                 tracks.push(BoneTrack {
                     bone_id: bone.id,
-                    keyframes: sinusoid_keyframes(duration, Q3232::from_num(20), phase),
+                    keyframes: sinusoid_keyframes(duration, Q3232::from_num(20), phase_fraction),
                 });
             }
         }
@@ -516,44 +522,46 @@ fn build_death_clip(skeleton: &BoneTree) -> AnimationClip {
 // Keyframe-pattern helpers
 // ---------------------------------------------------------------------------
 
-/// Five-keyframe sinusoid approximation: starts at 0, peaks at +amp at
-/// quarter, returns to 0 at half, troughs at -amp at three-quarters,
-/// back to 0 at end. `phase` shifts the rotation magnitude (degrees).
-fn sinusoid_keyframes(duration: Q3232, amplitude: Q3232, phase: Q3232) -> Vec<Keyframe> {
+/// Five-keyframe sinusoid approximation: starts at 0, peaks at
+/// +amplitude at quarter-cycle, returns to 0 at half, troughs at
+/// -amplitude at three-quarters, back to 0 at end.
+///
+/// `phase_fraction` shifts the *time* of every keyframe by
+/// `phase_fraction * duration`, then wraps modulo duration. This is
+/// the travelling-wave behaviour the design doc calls for: every bone
+/// in the spine sees the same amplitude, only offset in time so the
+/// whole spine ripples.
+fn sinusoid_keyframes(duration: Q3232, amplitude: Q3232, phase_fraction: Q3232) -> Vec<Keyframe> {
     let q = duration.saturating_mul(Q3232::from_num(0.25_f64));
-    let amp_with_phase = amplitude.saturating_add(phase);
-    vec![
-        Keyframe {
-            time: Q3232::ZERO,
-            rotation: Q3232::ZERO,
+    let phase_t = phase_fraction.saturating_mul(duration);
+    // Times in the unshifted clip, paired with their target rotation.
+    let pattern = [
+        (Q3232::ZERO, Q3232::ZERO),
+        (q, amplitude),
+        (q.saturating_mul(Q3232::from_num(2)), Q3232::ZERO),
+        (
+            q.saturating_mul(Q3232::from_num(3)),
+            amplitude.saturating_mul(Q3232::from_num(-1)),
+        ),
+        (duration, Q3232::ZERO),
+    ];
+
+    let mut keyframes: Vec<Keyframe> = pattern
+        .iter()
+        .map(|(t, rotation)| Keyframe {
+            time: wrap_time(t.saturating_add(phase_t), duration),
+            rotation: *rotation,
             scale: Q3232::ONE,
             easing: Easing::EaseInOut,
-        },
-        Keyframe {
-            time: q,
-            rotation: amp_with_phase,
-            scale: Q3232::ONE,
-            easing: Easing::EaseInOut,
-        },
-        Keyframe {
-            time: q.saturating_mul(Q3232::from_num(2)),
-            rotation: Q3232::ZERO,
-            scale: Q3232::ONE,
-            easing: Easing::EaseInOut,
-        },
-        Keyframe {
-            time: q.saturating_mul(Q3232::from_num(3)),
-            rotation: amp_with_phase.saturating_mul(Q3232::from_num(-1)),
-            scale: Q3232::ONE,
-            easing: Easing::EaseInOut,
-        },
-        Keyframe {
-            time: duration,
-            rotation: Q3232::ZERO,
-            scale: Q3232::ONE,
-            easing: Easing::Linear,
-        },
-    ]
+        })
+        .collect();
+    // Re-sort by time so the keyframe list stays monotonic after the
+    // phase wrap. Stable sort + Q3232::Ord both deterministic.
+    keyframes.sort_by(|a, b| a.time.cmp(&b.time));
+    if let Some(last) = keyframes.last_mut() {
+        last.easing = Easing::Linear;
+    }
+    keyframes
 }
 
 /// Stride keyframes: lift at 25%, plant at 75%, recover by end.
@@ -728,5 +736,57 @@ mod tests {
         assert_eq!(apply_easing(Q3232::ONE, Easing::EaseOut), Q3232::ONE);
         assert_eq!(apply_easing(Q3232::ZERO, Easing::EaseInOut), Q3232::ZERO);
         assert_eq!(apply_easing(Q3232::ONE, Easing::EaseInOut), Q3232::ONE);
+    }
+
+    #[test]
+    fn ease_in_out_is_continuous_at_half() {
+        // Both branches of EaseInOut converge on 0.5 at α = 0.5.
+        let half = Q3232::from_num(0.5_f64);
+        assert_eq!(apply_easing(half, Easing::EaseInOut), half);
+    }
+
+    #[test]
+    fn ease_in_out_below_half_is_lower_than_linear() {
+        // Quadratic ease-in: 2α² < α for α in (0, 0.5).
+        let alpha = Q3232::from_num(0.25_f64);
+        let eased = apply_easing(alpha, Easing::EaseInOut);
+        assert!(
+            eased < alpha,
+            "EaseInOut at α=0.25 should be below 0.25, got {eased:?}"
+        );
+    }
+
+    #[test]
+    fn ease_in_out_above_half_is_higher_than_linear() {
+        // Quadratic ease-out: 1 - 2(1-α)² > α for α in (0.5, 1).
+        let alpha = Q3232::from_num(0.75_f64);
+        let eased = apply_easing(alpha, Easing::EaseInOut);
+        assert!(
+            eased > alpha,
+            "EaseInOut at α=0.75 should be above 0.75, got {eased:?}"
+        );
+    }
+
+    #[test]
+    fn sinusoid_keyframes_phase_zero_starts_at_origin() {
+        let kfs = sinusoid_keyframes(Q3232::ONE, Q3232::from_num(20), Q3232::ZERO);
+        assert_eq!(kfs[0].time, Q3232::ZERO);
+        assert_eq!(kfs[0].rotation, Q3232::ZERO);
+    }
+
+    #[test]
+    fn sinusoid_keyframes_amplitude_constant_across_phases() {
+        // Phase shifts must NOT scale the amplitude — every phase
+        // should produce the same min/max rotation, just at different
+        // times in the clip.
+        let amp = Q3232::from_num(20);
+        let no_phase = sinusoid_keyframes(Q3232::ONE, amp, Q3232::ZERO);
+        let half_phase = sinusoid_keyframes(Q3232::ONE, amp, Q3232::from_num(0.5_f64));
+        let max_no_phase = no_phase.iter().map(|k| k.rotation).max().unwrap();
+        let max_half_phase = half_phase.iter().map(|k| k.rotation).max().unwrap();
+        assert_eq!(
+            max_no_phase, max_half_phase,
+            "phase shift must not change amplitude"
+        );
     }
 }

--- a/crates/beast-render/src/blueprint.rs
+++ b/crates/beast-render/src/blueprint.rs
@@ -28,6 +28,9 @@ pub struct CreatureBlueprint {
     pub surfaces: Vec<SurfaceDetail>,
     pub materials: Vec<MaterialRegion>,
     pub effects: Vec<AttachedEffect>,
+    /// Animation rig — locomotion / idle / damage / death clips. See
+    /// [`crate::animation`].
+    pub animations: crate::animation::AnimationSet,
     pub metadata: BlueprintMetadata,
 }
 

--- a/crates/beast-render/src/channels.rs
+++ b/crates/beast-render/src/channels.rs
@@ -1,0 +1,27 @@
+//! Shared channel-id constants for the visual pipeline.
+//!
+//! `pipeline.rs` and `animation.rs` both look channels up by string id.
+//! Keeping the strings in one place stops one file's rename from
+//! silently turning into a `Q3232::ZERO` lookup in the other.
+
+use beast_core::Q3232;
+use beast_interpreter::ResolvedPhenotype;
+
+pub(crate) const CH_ELASTIC_DEFORMATION: &str = "elastic_deformation";
+pub(crate) const CH_STRUCTURAL_RIGIDITY: &str = "structural_rigidity";
+pub(crate) const CH_MASS_DENSITY: &str = "mass_density";
+pub(crate) const CH_METABOLIC_RATE: &str = "metabolic_rate";
+pub(crate) const CH_SURFACE_FRICTION: &str = "surface_friction";
+pub(crate) const CH_KINETIC_FORCE: &str = "kinetic_force";
+pub(crate) const CH_LIGHT_EMISSION: &str = "light_emission";
+pub(crate) const CH_CHEMICAL_OUTPUT: &str = "chemical_output";
+pub(crate) const CH_THERMAL_OUTPUT: &str = "thermal_output";
+
+/// Read a global channel value, defaulting to `Q3232::ZERO` when absent.
+pub(crate) fn ch(phenotype: &ResolvedPhenotype, name: &str) -> Q3232 {
+    phenotype
+        .global_channels
+        .get(name)
+        .copied()
+        .unwrap_or(Q3232::ZERO)
+}

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) mod renderer;
 // keep substage helpers from leaking into anyone's API.
 pub mod animation;
 pub mod blueprint;
+pub(crate) mod channels;
 pub mod directive;
 pub(crate) mod pipeline;
 

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod renderer;
 // see the IR + output types. `pipeline` itself is crate-private — its
 // only public surface is [`compile_blueprint`] re-exported below — to
 // keep substage helpers from leaking into anyone's API.
+pub mod animation;
 pub mod blueprint;
 pub mod directive;
 pub(crate) mod pipeline;
@@ -38,6 +39,10 @@ pub(crate) mod pipeline;
 // the GPU-upload step lands alongside the SDL renderers in S9.3 / S9.4.
 pub mod sprite;
 
+pub use animation::{
+    rig_animations, AnimationClip, AnimationSet, Animator, BoneRotation, BoneTrack, Easing,
+    Keyframe, LocomotionStyle, PoseFrame,
+};
 pub use blueprint::CreatureBlueprint;
 pub use directive::{ColorSpec, DirectiveParams, VisualDirective};
 pub use error::{RenderError, Result};

--- a/crates/beast-render/src/pipeline.rs
+++ b/crates/beast-render/src/pipeline.rs
@@ -53,32 +53,16 @@ use crate::directive::{
 // throughout. Reviewers: any new f64 literal in this module should be a
 // design-doc-derived constant; flag any value that comes from sim state.
 //
-// ---------------------------------------------------------------------------
-// Channel id literals
-// ---------------------------------------------------------------------------
-//
-// The pipeline reads phenotype channels by string id. The id strings are
-// declared up front so a typo turns into a compile error rather than a
-// silent zero. They mirror the canonical channel manifest naming.
+// Channel id literals + the `ch()` helper live in `crate::channels` so
+// `animation.rs` and this module read the same constants. A rename of
+// any channel id is a single-file edit; a typo turns into a compile
+// error rather than a silent zero.
 
-const CH_ELASTIC_DEFORMATION: &str = "elastic_deformation";
-const CH_STRUCTURAL_RIGIDITY: &str = "structural_rigidity";
-const CH_MASS_DENSITY: &str = "mass_density";
-const CH_METABOLIC_RATE: &str = "metabolic_rate";
-const CH_SURFACE_FRICTION: &str = "surface_friction";
-const CH_KINETIC_FORCE: &str = "kinetic_force";
-const CH_LIGHT_EMISSION: &str = "light_emission";
-const CH_CHEMICAL_OUTPUT: &str = "chemical_output";
-const CH_THERMAL_OUTPUT: &str = "thermal_output";
-
-/// Read a global channel value, defaulting to `Q3232::ZERO` when absent.
-fn ch(phenotype: &ResolvedPhenotype, name: &str) -> Q3232 {
-    phenotype
-        .global_channels
-        .get(name)
-        .copied()
-        .unwrap_or(Q3232::ZERO)
-}
+use crate::channels::{
+    ch, CH_CHEMICAL_OUTPUT, CH_ELASTIC_DEFORMATION, CH_KINETIC_FORCE, CH_LIGHT_EMISSION,
+    CH_MASS_DENSITY, CH_METABOLIC_RATE, CH_STRUCTURAL_RIGIDITY, CH_SURFACE_FRICTION,
+    CH_THERMAL_OUTPUT,
+};
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/crates/beast-render/src/pipeline.rs
+++ b/crates/beast-render/src/pipeline.rs
@@ -106,6 +106,7 @@ pub fn compile_blueprint(
     let surfaces = apply_surface_details(&volumes, &directives);
     let materials = assign_materials(&volumes, &directives, &biome_color);
     let effects = attach_effects(&volumes, phenotype);
+    let animations = crate::animation::rig_animations(&skeleton, phenotype);
 
     let metadata = BlueprintMetadata {
         bounding_box: bounding_box_for(&skeleton, &volumes),
@@ -118,6 +119,7 @@ pub fn compile_blueprint(
         surfaces,
         materials,
         effects,
+        animations,
         metadata,
     }
 }

--- a/crates/beast-render/tests/animation_test.rs
+++ b/crates/beast-render/tests/animation_test.rs
@@ -1,0 +1,218 @@
+//! S9.6 acceptance tests for animation rigging.
+//!
+//! Unit tests for the lerp / easing / sample primitives live alongside
+//! the implementation in `src/animation.rs`. These integration tests
+//! cover the higher-level contract:
+//!
+//! * `compile_blueprint` produces a non-empty [`AnimationSet`] for the
+//!   pipeline's three reference phenotype profiles (elastic worm,
+//!   rigid armored, generic biped).
+//! * Locomotion-style selection picks the right variant for each
+//!   phenotype.
+//! * `Animator::sample` is byte-deterministic across calls.
+
+use std::collections::BTreeMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use beast_core::{BodySite, Q3232};
+use beast_interpreter::{LifeStage, ResolvedPhenotype};
+use beast_render::animation::{rig_animations, Animator, LocomotionStyle};
+use beast_render::directive::{ColorSpec, DirectiveParams, Inflate, VisualDirective};
+use beast_render::{compile_blueprint, CreatureBlueprint};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn phenotype_with(channels: &[(&str, f64)]) -> ResolvedPhenotype {
+    let mut p = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
+    let map: BTreeMap<String, Q3232> = channels
+        .iter()
+        .map(|(name, value)| (name.to_string(), Q3232::from_num(*value)))
+        .collect();
+    p.global_channels = map;
+    p
+}
+
+fn elastic_worm() -> ResolvedPhenotype {
+    phenotype_with(&[
+        ("elastic_deformation", 0.85),
+        ("structural_rigidity", 0.05),
+        ("mass_density", 0.3),
+        ("metabolic_rate", 0.6),
+        ("surface_friction", 0.2),
+    ])
+}
+
+fn rigid_armored() -> ResolvedPhenotype {
+    phenotype_with(&[
+        ("elastic_deformation", 0.05),
+        ("structural_rigidity", 0.85),
+        ("mass_density", 0.7),
+        ("metabolic_rate", 0.3),
+        ("surface_friction", 0.6),
+    ])
+}
+
+fn quadruped_walker() -> ResolvedPhenotype {
+    // Mid elasticity / rigidity + high friction → fall-through to
+    // limb-count branch with ≥4 limbs.
+    phenotype_with(&[
+        ("elastic_deformation", 0.2),
+        ("structural_rigidity", 0.2),
+        ("mass_density", 0.5),
+        ("metabolic_rate", 0.6),
+        ("surface_friction", 0.9),
+        ("kinetic_force", 0.7),
+    ])
+}
+
+fn neutral_biome() -> ColorSpec {
+    ColorSpec::rgb(
+        Q3232::from_num(120_i32),
+        Q3232::from_num(0.4_f64),
+        Q3232::from_num(0.5_f64),
+    )
+}
+
+fn no_directives() -> Vec<VisualDirective> {
+    Vec::new()
+}
+
+fn one_inflate_directive() -> Vec<VisualDirective> {
+    vec![VisualDirective {
+        id: 0,
+        body_region: BodySite::Core,
+        params: DirectiveParams::Inflate(Inflate {
+            scale: Q3232::from_num(1.1_f64),
+        }),
+        priority: 0,
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn elastic_worm_picks_sinuous_wave_locomotion() {
+    let phenotype = elastic_worm();
+    let bp = compile_blueprint(
+        &phenotype,
+        &no_directives(),
+        neutral_biome(),
+        "elastic_worm",
+    );
+    let style = beast_render::animation::pick_locomotion_style(&bp.skeleton, &phenotype);
+    assert_eq!(style, LocomotionStyle::SinuousWave);
+}
+
+#[test]
+fn rigid_armored_picks_segmented_scuttle() {
+    let phenotype = rigid_armored();
+    let bp = compile_blueprint(
+        &phenotype,
+        &no_directives(),
+        neutral_biome(),
+        "rigid_armored",
+    );
+    let style = beast_render::animation::pick_locomotion_style(&bp.skeleton, &phenotype);
+    assert_eq!(style, LocomotionStyle::SegmentedScuttle);
+}
+
+#[test]
+fn quadruped_walker_picks_quadruped_walk() {
+    let phenotype = quadruped_walker();
+    let bp = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "quadruped");
+    let style = beast_render::animation::pick_locomotion_style(&bp.skeleton, &phenotype);
+    assert_eq!(style, LocomotionStyle::QuadrupedWalk);
+}
+
+#[test]
+fn rigged_animation_set_is_never_empty() {
+    let cases = [elastic_worm(), rigid_armored(), quadruped_walker()];
+    for phenotype in cases {
+        let bp = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "fixture");
+        let anim = &bp.animations;
+        assert!(
+            anim.locomotion.len() >= 2,
+            "expected ≥2 locomotion clips (walk+run), got {}",
+            anim.locomotion.len()
+        );
+        assert!(!anim.idle.is_empty(), "expected ≥1 idle clip");
+        assert!(
+            !anim.damage.bone_tracks.is_empty() || !anim.death.bone_tracks.is_empty(),
+            "damage / death clips can't both be empty"
+        );
+    }
+}
+
+#[test]
+fn animator_sample_at_zero_and_duration_is_deterministic() {
+    let bp = compile_blueprint(
+        &elastic_worm(),
+        &no_directives(),
+        neutral_biome(),
+        "fixture",
+    );
+    let walk = &bp.animations.locomotion[0];
+    let animator = Animator::new(walk);
+
+    let pose_a0 = animator.sample(Q3232::ZERO);
+    let pose_a1 = animator.sample(Q3232::ZERO);
+    assert_eq!(pose_a0, pose_a1, "two samples at t=0 must match");
+
+    let pose_b0 = animator.sample(walk.duration);
+    let pose_b1 = animator.sample(walk.duration);
+    assert_eq!(pose_b0, pose_b1, "two samples at t=duration must match");
+}
+
+#[test]
+fn rig_is_byte_deterministic_across_compiles() {
+    fn h<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+    let phenotype = elastic_worm();
+    let a: CreatureBlueprint =
+        compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "fx");
+    let b: CreatureBlueprint =
+        compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "fx");
+    assert_eq!(a.animations, b.animations, "AnimationSet must be equal");
+    assert_eq!(
+        h(&a.animations),
+        h(&b.animations),
+        "AnimationSet hash must match"
+    );
+}
+
+#[test]
+fn directives_do_not_affect_animation_rig() {
+    // Animation depends on skeleton + phenotype only — visual
+    // directives that don't change those should produce an identical
+    // AnimationSet. This guards the substage's input contract.
+    let phenotype = elastic_worm();
+    let with = compile_blueprint(
+        &phenotype,
+        &one_inflate_directive(),
+        neutral_biome(),
+        "fixture",
+    );
+    let without = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "fixture");
+    assert_eq!(
+        with.animations, without.animations,
+        "Inflate directive must not perturb the animation rig"
+    );
+}
+
+#[test]
+fn standalone_rig_matches_pipeline_rig() {
+    // `rig_animations` is exposed publicly so the eventual app crate
+    // can re-rig a creature without re-running the full pipeline. The
+    // result must match what the pipeline produces.
+    let phenotype = elastic_worm();
+    let bp = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "fixture");
+    let standalone = rig_animations(&bp.skeleton, &phenotype);
+    assert_eq!(bp.animations, standalone);
+}

--- a/crates/beast-render/tests/animation_test.rs
+++ b/crates/beast-render/tests/animation_test.rs
@@ -67,6 +67,19 @@ fn quadruped_walker() -> ResolvedPhenotype {
     ])
 }
 
+fn biped_walker() -> ResolvedPhenotype {
+    // Mid elasticity / rigidity + low friction + low speed → limb
+    // potential ≈ (0.1*0.4 + 0.7*0.3 + 0.2*0.3)*6 = 1.74 → limb_count=2.
+    phenotype_with(&[
+        ("elastic_deformation", 0.3),
+        ("structural_rigidity", 0.3),
+        ("mass_density", 0.4),
+        ("metabolic_rate", 0.2),
+        ("surface_friction", 0.1),
+        ("kinetic_force", 0.5),
+    ])
+}
+
 fn neutral_biome() -> ColorSpec {
     ColorSpec::rgb(
         Q3232::from_num(120_i32),
@@ -126,6 +139,14 @@ fn quadruped_walker_picks_quadruped_walk() {
     let bp = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "quadruped");
     let style = beast_render::animation::pick_locomotion_style(&bp.skeleton, &phenotype);
     assert_eq!(style, LocomotionStyle::QuadrupedWalk);
+}
+
+#[test]
+fn biped_walker_picks_biped_walk() {
+    let phenotype = biped_walker();
+    let bp = compile_blueprint(&phenotype, &no_directives(), neutral_biome(), "biped");
+    let style = beast_render::animation::pick_locomotion_style(&bp.skeleton, &phenotype);
+    assert_eq!(style, LocomotionStyle::BipedWalk);
 }
 
 #[test]


### PR DESCRIPTION
Closes #186.

## Summary
Substage 6 of the procedural visual pipeline. \`rig_animations(skeleton, phenotype) -> AnimationSet\` produces locomotion (walk + run), idle, damage, and death clips per the design doc §4.6. \`Animator::sample(t)\` evaluates a clip into a per-bone \`PoseFrame\` deterministically.

### Locomotion-style selection
\`pick_locomotion_style\` picks one of four styles from channel ratios + limb count, matching §4.6:
- \`elasticity > 0.6\` → \`SinuousWave\` (snake / worm undulation)
- \`rigidity > 0.6\` → \`SegmentedScuttle\`
- limb count ≥ 4 → \`QuadrupedWalk\`
- otherwise → \`BipedWalk\`

### Numeric / determinism contract
All keyframe values (time, rotation in degrees, scale) are \`Q3232\`. The renderer reads \`Q3232::to_num::<f32>()\` at sample time, *outside* the blueprint hash boundary. Same skeleton + same phenotype → byte-identical \`AnimationSet\`. The \`rig_is_byte_deterministic_across_compiles\` integration test pins this with a \`Hash\`-based check (matching the S9.5 pattern).

### Files
- \`crates/beast-render/src/animation.rs\` (new, ~700 lines incl. unit tests) — public types + rig + sampler.
- \`crates/beast-render/src/blueprint.rs\` — adds \`animations: AnimationSet\` to \`CreatureBlueprint\`.
- \`crates/beast-render/src/pipeline.rs\` — wires \`rig_animations\` as substage 6 of \`compile_blueprint\`.
- \`crates/beast-render/src/lib.rs\` — module wiring + re-exports.
- \`crates/beast-render/tests/animation_test.rs\` (new) — 7 integration tests.
- \`crates/beast-render/examples/animation.rs\` (new) — SDL stick-figure visualiser. Run with \`cargo run -p beast-render --example animation\`.

### Easing math
Quadratic curves so we don't need \`sin\`/\`cos\` (which are \`f64\`-only on \`Q3232\`):
- EaseIn: \`α²\`
- EaseOut: \`α(2-α)\`
- EaseInOut: \`2α²\` (α<0.5) | \`1 - 2(1-α)²\` (α≥0.5)
\`apply_easing\` is identity at the endpoints, locked by \`ease_in_alpha_zero_and_one_match_linear\`.

## Caveats / future work
- **Sin / cos approximation**: \`SinuousWave\` keyframes use a 5-point ±amplitude approximation (peak / trough / zero) instead of a real sinusoid. Good enough for the smoke test; a future story can swap in a CORDIC or higher-resolution table if the visual quality bites.
- **No special / ability animations** — those land alongside combat in S11 per the issue scope.
- **No inverse kinematics** — forward-kinematic keyframes only, per the DoD.
- **Animation example is SDL-only**; the headless backend (CI default) skips it via \`required-features = ["sdl"]\`.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings\`
- [x] \`cargo clippy -p beast-render --all-targets -- -D warnings\` (sdl backend)
- [x] \`cargo test -p beast-render --no-default-features --features headless\` — 25 lib + 8 animation + 6 pipeline + 3 sprite = 42 tests pass
- [x] \`cargo test --workspace --exclude beast-render --all-targets --locked\` — workspace green
- [x] \`cargo build -p beast-render --example animation\` — links the SDL backend
- [ ] Manual: \`cargo run -p beast-render --example animation\` shows stick-figure walk cycle (will run locally but not gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)