### PR TITLE
perf(beast-render): S9.8 pipeline + animation criterion benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ version = "0.1.0"
 dependencies = [
  "beast-core",
  "beast-interpreter",
+ "criterion",
  "sdl3",
  "serde",
  "serde_json",

--- a/crates/beast-render/Cargo.toml
+++ b/crates/beast-render/Cargo.toml
@@ -42,6 +42,7 @@ optional = true
 features = ["build-from-source-static"]
 
 [dev-dependencies]
+criterion = { workspace = true }
 tempfile = { workspace = true }
 
 [[example]]
@@ -54,6 +55,13 @@ required-features = ["sdl"]
 [[example]]
 name = "animation"
 required-features = ["sdl"]
+
+[[bench]]
+# Pipeline + animation rig + animator-sample benchmarks. Run with
+#   cargo bench -p beast-render --no-default-features --features headless
+# so the SDL backend doesn't get pulled into the bench harness.
+name = "pipeline_bench"
+harness = false
 
 [lints.rust]
 # Forbid `unsafe { ... }` blocks unless they carry a `// SAFETY:` comment

--- a/crates/beast-render/benches/pipeline_bench.rs
+++ b/crates/beast-render/benches/pipeline_bench.rs
@@ -23,8 +23,8 @@ use beast_core::{BodySite, Prng, Stream, Q3232};
 use beast_interpreter::{LifeStage, ResolvedPhenotype};
 use beast_render::animation::{rig_animations, Animator};
 use beast_render::directive::{
-    AppendageKind, ColorSpec, Colorize, DirectiveParams, Distribution, Inflate, Protrude,
-    ProtrusionShape, SurfaceRegion, TexturePattern, VisualDirective,
+    ColorSpec, Colorize, DirectiveParams, Distribution, Inflate, Protrude, ProtrusionShape,
+    SurfaceRegion, TexturePattern, VisualDirective,
 };
 use beast_render::{compile_blueprint, CreatureBlueprint};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
@@ -106,7 +106,6 @@ fn typical_directives() -> Vec<VisualDirective> {
 }
 
 fn neutral_biome() -> ColorSpec {
-    let _ = AppendageKind::Crest; // anchor the import in case Append is added later
     ColorSpec::rgb(
         Q3232::from_num(120_i32),
         Q3232::from_num(0.4_f64),
@@ -127,13 +126,17 @@ fn bench_compile_blueprint(c: &mut Criterion) {
     // Reuse one phenotype: the bench measures pipeline-only cost, so
     // we don't want phenotype generation showing up in the numbers.
     let phenotype = random_phenotype(&mut rng);
+    // `black_box` is only useful at the optimisation boundary —
+    // wrapping `neutral_biome()` (a pure non-allocating call already
+    // inside the iter closure) and the `"bench"` literal would be
+    // no-ops, so they're not wrapped.
     group.bench_function("typical_phenotype", |b| {
         b.iter(|| {
             let bp: CreatureBlueprint = compile_blueprint(
                 black_box(&phenotype),
                 black_box(&directives),
-                black_box(neutral_biome()),
-                black_box("bench"),
+                neutral_biome(),
+                "bench",
             );
             black_box(bp)
         });
@@ -147,12 +150,8 @@ fn bench_compile_blueprint(c: &mut Criterion) {
         b.iter_batched(
             || random_phenotype(&mut rng),
             |phenotype| {
-                let bp = compile_blueprint(
-                    &phenotype,
-                    black_box(&directives),
-                    black_box(neutral_biome()),
-                    "bench",
-                );
+                let bp =
+                    compile_blueprint(&phenotype, black_box(&directives), neutral_biome(), "bench");
                 black_box(bp)
             },
             BatchSize::SmallInput,

--- a/crates/beast-render/benches/pipeline_bench.rs
+++ b/crates/beast-render/benches/pipeline_bench.rs
@@ -1,0 +1,213 @@
+//! Criterion benchmarks for the visual pipeline + animation rig.
+//!
+//! Run with `cargo bench -p beast-render --no-default-features --features headless`.
+//!
+//! These cover the *headless* surface — the pure-Rust compile +
+//! sampling work that runs offline of SDL3. Render-loop benchmarks
+//! (world-map / encounter scenes) land alongside the renderers in
+//! S9.3 / S9.4 and reuse the harness conventions established here.
+//!
+//! # Pass criteria (S9.8)
+//!
+//! * `bench_compile_blueprint` — < 1 ms per creature on the dev box
+//!   (uncached — same-genotype caching lands when the renderers do).
+//! * `bench_rig_animations` — sub-stage 6 isolated, used to attribute
+//!   pipeline cost to rigging vs the rest.
+//! * `bench_animator_sample` — per-frame cost; should be << 100 µs at
+//!   200 creatures × 60 FPS = 12k samples/sec.
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+
+use beast_core::{BodySite, Prng, Stream, Q3232};
+use beast_interpreter::{LifeStage, ResolvedPhenotype};
+use beast_render::animation::{rig_animations, Animator};
+use beast_render::directive::{
+    AppendageKind, ColorSpec, Colorize, DirectiveParams, Distribution, Inflate, Protrude,
+    ProtrusionShape, SurfaceRegion, TexturePattern, VisualDirective,
+};
+use beast_render::{compile_blueprint, CreatureBlueprint};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+
+const SEED: u64 = 0xBEA5_BEAD_u64;
+const CHANNEL_IDS: &[&str] = &[
+    "elastic_deformation",
+    "structural_rigidity",
+    "mass_density",
+    "metabolic_rate",
+    "surface_friction",
+    "kinetic_force",
+    "light_emission",
+    "chemical_output",
+    "thermal_output",
+];
+
+fn random_phenotype(rng: &mut Prng) -> ResolvedPhenotype {
+    let mut p = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
+    let mut channels = BTreeMap::new();
+    for id in CHANNEL_IDS {
+        channels.insert((*id).to_string(), rng.next_q3232_unit());
+    }
+    p.global_channels = channels;
+    p
+}
+
+fn typical_directives() -> Vec<VisualDirective> {
+    // Representative-sized directive set: 4 directives covering Inflate,
+    // Colorize (with biome-color sentinel), Protrude, and a Crest
+    // appendage. Doesn't go through every variant; for variant
+    // coverage see `random_creatures_test.rs`.
+    vec![
+        VisualDirective {
+            id: 1,
+            body_region: BodySite::Core,
+            params: DirectiveParams::Inflate(Inflate {
+                scale: Q3232::from_num(1.1_f64),
+            }),
+            priority: 5,
+        },
+        VisualDirective {
+            id: 2,
+            body_region: BodySite::Core,
+            params: DirectiveParams::Colorize(Colorize {
+                base_color: ColorSpec::biome_color(
+                    Q3232::from_num(0.6_f64),
+                    Q3232::from_num(0.5_f64),
+                ),
+                emission: None,
+                emission_intensity: Q3232::ZERO,
+                pattern: Some(TexturePattern::Mottled),
+                pattern_color_secondary: None,
+                contrast: Q3232::from_num(0.4_f64),
+            }),
+            priority: 3,
+        },
+        VisualDirective {
+            id: 3,
+            body_region: BodySite::Core,
+            params: DirectiveParams::Protrude(Protrude {
+                shape: ProtrusionShape::Spike,
+                scale: Q3232::from_num(0.4_f64),
+                density: 6,
+                distribution: Distribution::Regular,
+                surface_region: SurfaceRegion::Dorsal,
+            }),
+            priority: 8,
+        },
+        VisualDirective {
+            id: 4,
+            body_region: BodySite::Tail,
+            params: DirectiveParams::Inflate(Inflate {
+                scale: Q3232::from_num(0.9_f64),
+            }),
+            priority: 2,
+        },
+    ]
+}
+
+fn neutral_biome() -> ColorSpec {
+    let _ = AppendageKind::Crest; // anchor the import in case Append is added later
+    ColorSpec::rgb(
+        Q3232::from_num(120_i32),
+        Q3232::from_num(0.4_f64),
+        Q3232::from_num(0.5_f64),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_compile_blueprint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compile_blueprint");
+    group.throughput(Throughput::Elements(1));
+    let mut rng = Prng::from_seed(SEED).split_stream(Stream::Testing);
+    let directives = typical_directives();
+
+    // Reuse one phenotype: the bench measures pipeline-only cost, so
+    // we don't want phenotype generation showing up in the numbers.
+    let phenotype = random_phenotype(&mut rng);
+    group.bench_function("typical_phenotype", |b| {
+        b.iter(|| {
+            let bp: CreatureBlueprint = compile_blueprint(
+                black_box(&phenotype),
+                black_box(&directives),
+                black_box(neutral_biome()),
+                black_box("bench"),
+            );
+            black_box(bp)
+        });
+    });
+
+    // Random phenotype each iter — exercises the channel-driven
+    // branching across the pipeline. `BatchSize::SmallInput` keeps
+    // setup overhead bounded relative to the measurement window.
+    group.bench_function("random_phenotype", |b| {
+        let mut rng = Prng::from_seed(SEED).split_stream(Stream::Testing);
+        b.iter_batched(
+            || random_phenotype(&mut rng),
+            |phenotype| {
+                let bp = compile_blueprint(
+                    &phenotype,
+                    black_box(&directives),
+                    black_box(neutral_biome()),
+                    "bench",
+                );
+                black_box(bp)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_rig_animations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rig_animations");
+    group.throughput(Throughput::Elements(1));
+    let mut rng = Prng::from_seed(SEED).split_stream(Stream::Testing);
+    let phenotype = random_phenotype(&mut rng);
+    let blueprint = compile_blueprint(&phenotype, &typical_directives(), neutral_biome(), "bench");
+
+    group.bench_function("typical", |b| {
+        b.iter(|| {
+            let set = rig_animations(black_box(&blueprint.skeleton), black_box(&phenotype));
+            black_box(set)
+        });
+    });
+    group.finish();
+}
+
+fn bench_animator_sample(c: &mut Criterion) {
+    let mut group = c.benchmark_group("animator_sample");
+    group.throughput(Throughput::Elements(1));
+    let mut rng = Prng::from_seed(SEED).split_stream(Stream::Testing);
+    let phenotype = random_phenotype(&mut rng);
+    let blueprint = compile_blueprint(&phenotype, &typical_directives(), neutral_biome(), "bench");
+    let walk_clip = blueprint
+        .animations
+        .locomotion
+        .first()
+        .expect("walk clip exists");
+    let animator = Animator::new(walk_clip);
+
+    // Sample at clip mid-time so the keyframe-pair lookup actually
+    // runs the lerp branch, not the early-return endpoint case.
+    let mid_t = walk_clip.duration.saturating_mul(Q3232::from_num(0.5_f64));
+
+    group.bench_function("walk_mid_t", |b| {
+        b.iter(|| black_box(animator.sample(black_box(mid_t))));
+    });
+    group.bench_function("walk_t_zero", |b| {
+        b.iter(|| black_box(animator.sample(Q3232::ZERO)));
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_compile_blueprint,
+    bench_rig_animations,
+    bench_animator_sample
+);
+criterion_main!(benches);

--- a/documentation/perf/S9_baseline.md
+++ b/documentation/perf/S9_baseline.md
@@ -16,11 +16,18 @@ will land once the SDL3 system deps are sorted on the runners
 
 ## Pass criteria (S9.8)
 
-| Bench | Threshold | Why |
-|---|---|---|
-| `compile_blueprint/typical_phenotype` | < 1 ms / creature | Story 9.5 budget; lets us re-compile 16 creatures per 60 FPS frame without budget overrun. |
-| `rig_animations/typical` | < 200 µs / creature | 1/5th of `compile_blueprint`; sub-stage 6 attribution. |
-| `animator_sample/walk_mid_t` | < 1 µs / sample | 200 creatures × 60 FPS = 12k samples/sec; 1 µs gives 12 ms/frame headroom. |
+The S9 issue body sets *frame-budget* limits (1 ms / 200 µs / 1 µs).
+Those are the absolute design constraints. The thresholds below are
+**regression gates** — set ~10× the current observed mean so the gate
+catches a pathological 10× regression but tolerates ordinary noise on
+slower CI hardware. If a perf-positive PR drops the mean meaningfully,
+tighten the threshold in the same PR.
+
+| Bench | Frame-budget limit | Regression gate | Why |
+|---|---|---|---|
+| `compile_blueprint/typical_phenotype` | < 1 ms | **< 50 µs** | ~11× current mean; flags any 10× slowdown immediately. |
+| `rig_animations/typical` | < 200 µs | **< 25 µs** | ~12× current mean. |
+| `animator_sample/walk_mid_t` | < 1 µs | **< 2.5 µs** | ~11× current mean. Per-frame 200-creature sample budget = 12 µs total. |
 
 > 16.6 ms / 25 ms p99 frame-time targets from the issue body apply to the
 > SDL render benches (`bench_world_map_200_creatures`,
@@ -29,13 +36,13 @@ will land once the SDL3 system deps are sorted on the runners
 
 ## Baseline (S9.8 dev-box, criterion mean)
 
-| Bench | Mean | p95-ish (high) | Threshold | Headroom |
+| Bench | Mean | p95-ish (high) | Regression gate | Headroom-vs-gate |
 |---|---|---|---|---|
-| `compile_blueprint/typical_phenotype` | **4.55 µs** | 4.61 µs | 1000 µs | ≈ 219× |
-| `compile_blueprint/random_phenotype` | **4.35 µs** | 4.61 µs | 1000 µs | ≈ 230× |
-| `rig_animations/typical` | **2.13 µs** | 2.19 µs | 200 µs | ≈ 94× |
-| `animator_sample/walk_mid_t` | **222 ns** | 226 ns | 1000 ns | ≈ 4.5× |
-| `animator_sample/walk_t_zero` | **48 ns** | 49 ns | 1000 ns | ≈ 21× |
+| `compile_blueprint/typical_phenotype` | **4.55 µs** | 4.61 µs | 50 µs | ≈ 11× |
+| `compile_blueprint/random_phenotype` | **4.35 µs** | 4.61 µs | 50 µs | ≈ 11× |
+| `rig_animations/typical` | **2.13 µs** | 2.19 µs | 25 µs | ≈ 12× |
+| `animator_sample/walk_mid_t` | **222 ns** | 226 ns | 2.5 µs | ≈ 11× |
+| `animator_sample/walk_t_zero` | **48 ns** | 49 ns | 2.5 µs | ≈ 52× |
 
 Taken with `--warm-up-time 1 --measurement-time 2 --sample-size 30` for
 stability without burning a long bench window. Default criterion (5s warm-up,

--- a/documentation/perf/S9_baseline.md
+++ b/documentation/perf/S9_baseline.md
@@ -1,0 +1,72 @@
+# Sprint S9 — Render Pipeline Performance Baseline
+
+> Tracking issue: [#187](https://github.com/BemusedVermin/evolution-simulation/issues/187).
+> Run criterion locally with:
+>
+> ```bash
+> cargo bench -p beast-render --no-default-features --features headless
+> ```
+
+This file records baseline numbers for the headless render pipeline so
+future PRs can regression-check against them. The dev-box numbers below
+are from the machine that authored S9.8 (Windows 11, x86_64-pc-windows-msvc,
+rustc 1.94.1, opt-level=3 + LTO=thin per `[profile.bench]`); CI numbers
+will land once the SDL3 system deps are sorted on the runners
+([#192](https://github.com/BemusedVermin/evolution-simulation/issues/192)).
+
+## Pass criteria (S9.8)
+
+| Bench | Threshold | Why |
+|---|---|---|
+| `compile_blueprint/typical_phenotype` | < 1 ms / creature | Story 9.5 budget; lets us re-compile 16 creatures per 60 FPS frame without budget overrun. |
+| `rig_animations/typical` | < 200 µs / creature | 1/5th of `compile_blueprint`; sub-stage 6 attribution. |
+| `animator_sample/walk_mid_t` | < 1 µs / sample | 200 creatures × 60 FPS = 12k samples/sec; 1 µs gives 12 ms/frame headroom. |
+
+> 16.6 ms / 25 ms p99 frame-time targets from the issue body apply to the
+> SDL render benches (`bench_world_map_200_creatures`,
+> `bench_encounter_5_creatures`); those land alongside the renderers in
+> S9.3 / S9.4 and reuse this file's structure.
+
+## Baseline (S9.8 dev-box, criterion mean)
+
+| Bench | Mean | p95-ish (high) | Threshold | Headroom |
+|---|---|---|---|---|
+| `compile_blueprint/typical_phenotype` | **4.55 µs** | 4.61 µs | 1000 µs | ≈ 219× |
+| `compile_blueprint/random_phenotype` | **4.35 µs** | 4.61 µs | 1000 µs | ≈ 230× |
+| `rig_animations/typical` | **2.13 µs** | 2.19 µs | 200 µs | ≈ 94× |
+| `animator_sample/walk_mid_t` | **222 ns** | 226 ns | 1000 ns | ≈ 4.5× |
+| `animator_sample/walk_t_zero` | **48 ns** | 49 ns | 1000 ns | ≈ 21× |
+
+Taken with `--warm-up-time 1 --measurement-time 2 --sample-size 30` for
+stability without burning a long bench window. Default criterion (5s warm-up,
+10s measurement, 100 samples) reports tighter intervals; run that locally
+when investigating real regressions.
+
+## What's not measured here
+
+* **World-map render frame** (`bench_world_map_200_creatures`) — needs the
+  `WorldMapRenderer` from S9.3. **Tracked as
+  [#TBD-world-map-bench]** when the renderer lands.
+* **Encounter-view render frame** (`bench_encounter_5_creatures`) — needs
+  the `EncounterRenderer` from S9.4. **Tracked as
+  [#TBD-encounter-bench]** when the renderer lands.
+* **Per-tick HUD** (F3 frame-time overlay) — UI affordance, not a CI gate.
+  Will live in `beast-app` when that crate exists.
+
+## How to compare against this baseline
+
+1. Run `cargo bench -p beast-render --no-default-features --features headless`
+   on your local box.
+2. Compare your `time:` line for each bench to this file's `Mean` column.
+3. **Regression policy**:
+   * < 10 % slower → noise, no action.
+   * 10 – 50 % slower → flag in PR description, gather a second sample.
+   * > 50 % slower → block merge until investigated.
+4. **Improvement policy**: speed-ups should also be flagged. If a bench
+   gets 2× faster the threshold may need re-tightening.
+
+## How to update this file
+
+If a perf-positive PR drops the mean meaningfully, update the table in
+the same PR. Keep the threshold column conservative — it's the budget,
+not the current best.


### PR DESCRIPTION
Closes #187.

## Summary
Headless half of the S9.8 perf baseline. Three criterion bench groups in `crates/beast-render/benches/pipeline_bench.rs` plus a baseline doc at `documentation/perf/S9_baseline.md`.

### Benches shipped
| Group | Benches |
|---|---|
| `compile_blueprint` | `typical_phenotype`, `random_phenotype` |
| `rig_animations` | `typical` |
| `animator_sample` | `walk_mid_t`, `walk_t_zero` |

Run with:
\`\`\`bash
cargo bench -p beast-render --no-default-features --features headless
\`\`\`

### Baseline (dev-box, criterion mean)
| Bench | Mean | Threshold | Headroom |
|---|---|---|---|
| `compile_blueprint/typical_phenotype` | **4.55 µs** | 1 ms | ≈ 219× |
| `compile_blueprint/random_phenotype` | **4.35 µs** | 1 ms | ≈ 230× |
| `rig_animations/typical` | **2.13 µs** | 200 µs | ≈ 94× |
| `animator_sample/walk_mid_t` | **222 ns** | 1 µs | ≈ 4.5× |
| `animator_sample/walk_t_zero` | **48 ns** | 1 µs | ≈ 21× |

All headroom comfortable; the pipeline + rig together take ~6.7 µs per creature, so the entire 200-creature world map can re-compile every blueprint in ~1.3 ms, well under the 16.6 ms frame budget — even before any caching.

## What's deliberately not here
- `bench_world_map_200_creatures` and `bench_encounter_5_creatures` from the issue body need the renderers from S9.3 / S9.4. Tracked as **#201** (world-map bench) and **#202** (encounter bench).
- F3 frame-time HUD — UI affordance, lives with `beast-app` when that crate exists.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings`
- [x] `cargo clippy -p beast-render --all-targets -- -D warnings`
- [x] `cargo test -p beast-render --no-default-features --features headless` — 30 lib + 9 animation + 6 pipeline + 4 random_creatures + 3 sprite = 52 tests pass
- [x] `cargo test --workspace --exclude beast-render --all-targets --locked` — workspace green
- [x] `cargo bench -p beast-render --no-default-features --features headless` — see baseline above

🤖 Generated with [Claude Code](https://claude.com/claude-code)