### PR TITLE
feat(beast-render): S9.4 encounter view renderer

### DIFF
--- a/crates/beast-render/Cargo.toml
+++ b/crates/beast-render/Cargo.toml
@@ -62,6 +62,10 @@ required-features = ["sdl"]
 name = "world_map"
 required-features = ["sdl"]
 
+[[example]]
+name = "encounter"
+required-features = ["sdl"]
+
 [[bench]]
 # Pipeline + animation rig + animator-sample benchmarks. Run with
 #   cargo bench -p beast-render --no-default-features --features headless

--- a/crates/beast-render/examples/encounter.rs
+++ b/crates/beast-render/examples/encounter.rs
@@ -1,0 +1,166 @@
+//! S9.4 smoke test: open a window, build a 5-creature encounter scene
+//! against a forest backdrop, and let the user cycle the selected
+//! creature with Tab.
+//!
+//! Controls
+//! --------
+//!
+//! * Tab       — advance the selected creature
+//! * Shift+Tab — go back
+//! * Esc       — quit
+//!
+//! Run with:
+//!   cargo run -p beast-render --example encounter
+
+#[cfg(feature = "sdl")]
+fn main() -> beast_render::Result<()> {
+    use std::collections::BTreeMap;
+
+    use beast_core::Q3232;
+    use beast_interpreter::{LifeStage, ResolvedPhenotype};
+    use beast_render::encounter::{
+        draw_encounter, Backdrop, EncounterEntity, Position2D, Projection,
+    };
+    use beast_render::{compile_blueprint, directive::ColorSpec, Renderer, WindowConfig};
+    use beast_world::BiomeTag;
+    use sdl3::{event::Event, keyboard::Keycode};
+
+    // Five hand-tuned phenotypes so each creature in the scene reads
+    // visibly different. Channel values map roughly to body-plan
+    // archetypes — elastic worm, rigid armor, tall sprinter, etc.
+    let phenotype_specs: [&[(&str, f64)]; 5] = [
+        // 0: elastic worm
+        &[
+            ("elastic_deformation", 0.85),
+            ("structural_rigidity", 0.05),
+            ("mass_density", 0.3),
+            ("metabolic_rate", 0.6),
+        ],
+        // 1: rigid armored
+        &[
+            ("elastic_deformation", 0.05),
+            ("structural_rigidity", 0.85),
+            ("mass_density", 0.7),
+            ("metabolic_rate", 0.3),
+        ],
+        // 2: quadruped sprinter
+        &[
+            ("elastic_deformation", 0.2),
+            ("structural_rigidity", 0.3),
+            ("mass_density", 0.5),
+            ("metabolic_rate", 0.7),
+            ("kinetic_force", 0.7),
+            ("surface_friction", 0.7),
+        ],
+        // 3: bioluminescent
+        &[
+            ("elastic_deformation", 0.3),
+            ("structural_rigidity", 0.4),
+            ("mass_density", 0.4),
+            ("metabolic_rate", 0.5),
+            ("light_emission", 0.8),
+        ],
+        // 4: thermal predator
+        &[
+            ("elastic_deformation", 0.2),
+            ("structural_rigidity", 0.4),
+            ("mass_density", 0.6),
+            ("metabolic_rate", 0.6),
+            ("thermal_output", 0.7),
+            ("kinetic_force", 0.6),
+        ],
+    ];
+
+    let neutral_biome = ColorSpec::rgb(
+        Q3232::from_num(120),
+        Q3232::from_num(0.4_f64),
+        Q3232::from_num(0.5_f64),
+    );
+
+    let blueprints: Vec<_> = phenotype_specs
+        .iter()
+        .enumerate()
+        .map(|(i, channels)| {
+            let mut p = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
+            p.global_channels = channels
+                .iter()
+                .map(|(k, v)| (k.to_string(), Q3232::from_num(*v)))
+                .collect::<BTreeMap<_, _>>();
+            compile_blueprint(&p, &[], neutral_biome, format!("creature_{i}"))
+        })
+        .collect();
+
+    // Position 5 creatures in two rows: 3 in front, 2 in back.
+    let positions: [Position2D; 5] = [
+        Position2D::new(-1.4, -0.4), // front-left
+        Position2D::new(0.0, -0.6),  // front-centre
+        Position2D::new(1.4, -0.4),  // front-right
+        Position2D::new(-0.7, 0.6),  // back-left
+        Position2D::new(0.7, 0.6),   // back-right
+    ];
+
+    let mut renderer = Renderer::new(WindowConfig {
+        title: "beast-render: S9.4 encounter".to_string(),
+        ..Default::default()
+    })?;
+
+    let backdrop = Backdrop::new(BiomeTag::Forest);
+    let projection = Projection::default();
+    let mut selected = 0_usize;
+
+    'mainloop: loop {
+        // Snapshot canvas dims + collect events while no canvas borrow
+        // is live (same idiom as world_map example).
+        let events: Vec<Event> = renderer.event_pump().poll_iter().collect();
+        for event in events {
+            match event {
+                Event::Quit { .. }
+                | Event::KeyDown {
+                    keycode: Some(Keycode::Escape),
+                    ..
+                } => break 'mainloop,
+                Event::KeyDown {
+                    keycode: Some(Keycode::Tab),
+                    keymod,
+                    ..
+                } => {
+                    let len = blueprints.len();
+                    if keymod.contains(sdl3::keyboard::Mod::LSHIFTMOD)
+                        || keymod.contains(sdl3::keyboard::Mod::RSHIFTMOD)
+                    {
+                        selected = (selected + len - 1) % len;
+                    } else {
+                        selected = (selected + 1) % len;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let entities: Vec<EncounterEntity<'_>> = blueprints
+            .iter()
+            .zip(positions.iter())
+            .enumerate()
+            .map(|(i, (bp, pos))| EncounterEntity {
+                id: i as u32,
+                blueprint: bp,
+                position: *pos,
+                selected: i == selected,
+            })
+            .collect();
+
+        let canvas = renderer.canvas();
+        canvas.set_draw_color(sdl3::pixels::Color::RGB(0, 0, 0));
+        canvas.clear();
+        draw_encounter(canvas, &backdrop, &entities, &projection)
+            .map_err(beast_render::RenderError::Sdl)?;
+        renderer.present();
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "sdl"))]
+fn main() {
+    eprintln!("This example requires the `sdl` feature.");
+    std::process::exit(2);
+}

--- a/crates/beast-render/src/encounter.rs
+++ b/crates/beast-render/src/encounter.rs
@@ -77,6 +77,13 @@ impl Backdrop {
 /// 2.5D projection parameters. Hand-tuned to match the design doc's
 /// "2.5D perspective" idiom: y depth → vertical offset + slight x
 /// compression so the scene reads as receding rather than orthographic.
+///
+/// `horizon_fraction` must be kept in sync with [`Backdrop::horizon_fraction`]
+/// so the projection's ground line lands at (slightly below) the
+/// backdrop's horizon line. The defaults agree (0.45 for Backdrop,
+/// projection puts feet at 0.65 = horizon + 0.20). Custom `Backdrop`
+/// values should pair with a matching `Projection` — see the
+/// `entity_feet_land_below_horizon` test for the contract.
 #[derive(Debug, Clone, Copy)]
 pub struct Projection {
     /// Pixels per world-space unit on x.
@@ -87,6 +94,10 @@ pub struct Projection {
     /// Horizontal compression at the back of the scene. 1.0 = no
     /// compression, 0.6 = back rows are 60 % the width of front rows.
     pub depth_x_scale: f32,
+    /// Horizon as a fraction of canvas height; matches the backdrop's
+    /// horizon line so creature feet land just below it. The default
+    /// (0.45) aligns with [`Backdrop::default()`]'s horizon.
+    pub horizon_fraction: f32,
 }
 
 impl Default for Projection {
@@ -95,23 +106,30 @@ impl Default for Projection {
             px_per_unit_x: 120.0,
             px_per_unit_y: 80.0,
             depth_x_scale: 0.6,
+            horizon_fraction: 0.45,
         }
     }
 }
 
 impl Projection {
+    /// 0.20 is the offset between the horizon line and the ground
+    /// line: feet land 20 % of the canvas height below the horizon
+    /// when `pos.y == 0`. Tuned so the encounter slot range
+    /// `[-0.6, 0.6]` keeps creatures within the ground band without
+    /// pushing them off-screen.
+    const GROUND_OFFSET_BELOW_HORIZON: f32 = 0.20;
+
     /// Project an encounter world position to screen-space pixels
     /// (origin top-left). Canvas dims define the centre point.
     ///
     /// Math:
     /// * `screen_x = canvas_w/2 + x * px_per_unit_x * lerp(1, depth_x_scale, y_norm)`
-    /// * `screen_y = ground_y - y * px_per_unit_y`  (where ground_y is
-    ///   slightly below the horizon)
+    /// * `screen_y = ground_y - y * px_per_unit_y` where
+    ///   `ground_y = canvas_h * (horizon_fraction + GROUND_OFFSET_BELOW_HORIZON)`
     ///
-    /// `y_norm` = `(y - y_min) / (y_max - y_min)` clamped to `[0, 1]`,
-    /// where `(y_min, y_max)` come from the entity batch's depth range
-    /// — passed in as `depth_extents` so all entities scale
-    /// consistently.
+    /// `y_norm` is computed by [`normalize_depth`] from the entity
+    /// batch's depth range, so all entities scale consistently.
+    #[must_use]
     pub fn project(
         &self,
         pos: Position2D,
@@ -121,20 +139,29 @@ impl Projection {
     ) -> (f32, f32) {
         let cw = canvas_w as f32;
         let ch = canvas_h as f32;
-        let (y_min, y_max) = depth_extents;
-        let y_norm = if y_max > y_min {
-            ((pos.y - y_min) / (y_max - y_min)).clamp(0.0, 1.0)
-        } else {
-            0.5
-        };
+        let y_norm = normalize_depth(pos.y, depth_extents);
         // Lerp: front (y_norm = 0) keeps full x; back (y_norm = 1)
         // compresses to depth_x_scale.
         let x_scale = 1.0 - (1.0 - self.depth_x_scale) * y_norm;
 
-        let ground_y = ch * 0.65;
+        let ground_y = ch * (self.horizon_fraction + Self::GROUND_OFFSET_BELOW_HORIZON);
         let screen_x = cw * 0.5 + pos.x * self.px_per_unit_x * x_scale;
         let screen_y = ground_y - pos.y * self.px_per_unit_y;
         (screen_x, screen_y)
+    }
+}
+
+/// Normalize a depth value into `[0, 1]` against a depth range. When
+/// `y_max == y_min` (single entity / all entities at the same depth)
+/// returns 0.5 so the projection still produces a sensible compression
+/// rather than a divide-by-zero.
+#[must_use]
+pub fn normalize_depth(y: f32, depth_extents: (f32, f32)) -> f32 {
+    let (y_min, y_max) = depth_extents;
+    if y_max > y_min {
+        ((y - y_min) / (y_max - y_min)).clamp(0.0, 1.0)
+    } else {
+        0.5
     }
 }
 
@@ -142,30 +169,28 @@ impl Projection {
 /// `Vec<usize>` of indices into the original slice; the renderer
 /// iterates this to issue draw calls in the right order. Stable sort
 /// — ties between identical `y` values keep their insertion order.
+///
+/// Uses `f32::total_cmp`, which gives a total order over all f32
+/// values: NaN sorts after every finite value. With back-to-front
+/// reversal that means a NaN-position entity is drawn *first*
+/// (visible-but-rearmost in the depth stack), instead of being
+/// scattered randomly by `partial_cmp.unwrap_or(Equal)`.
+#[must_use]
 pub fn depth_order(entities: &[EncounterEntity<'_>]) -> Vec<usize> {
     let mut indices: Vec<usize> = (0..entities.len()).collect();
-    indices.sort_by(|&a, &b| {
-        // partial_cmp is fine: encounter positions are render-only and
-        // we control inputs. NaN lands at the front.
-        entities[b]
-            .position
-            .y
-            .partial_cmp(&entities[a].position.y)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    indices.sort_by(|&a, &b| entities[b].position.y.total_cmp(&entities[a].position.y));
     indices
 }
 
 /// Compute the depth range `(y_min, y_max)` of an entity batch.
 /// Empty batch → `(0.0, 0.0)`.
+#[must_use]
 pub fn depth_extents(entities: &[EncounterEntity<'_>]) -> (f32, f32) {
     let mut iter = entities.iter().map(|e| e.position.y);
     let Some(first) = iter.next() else {
         return (0.0, 0.0);
     };
-    iter.fold((first, first), |(lo, hi), y| {
-        (if y < lo { y } else { lo }, if y > hi { y } else { hi })
-    })
+    iter.fold((first, first), |(lo, hi), y| (lo.min(y), hi.max(y)))
 }
 
 /// Silhouette pixel size derived from a blueprint's bounding box.
@@ -199,7 +224,8 @@ pub fn silhouette_size(
 #[cfg(feature = "sdl")]
 mod sdl_backend {
     use super::{
-        depth_extents, depth_order, silhouette_size, Backdrop, EncounterEntity, Projection,
+        depth_extents, depth_order, normalize_depth, silhouette_size, Backdrop, EncounterEntity,
+        Projection,
     };
     use crate::world_map::biome_tint;
     use sdl3::pixels::Color;
@@ -218,13 +244,12 @@ mod sdl_backend {
             .fill_rect(Rect::new(0, 0, cw, horizon.max(0) as u32))
             .map_err(|e| e.to_string())?;
 
-        // Ground: biome tint, darkened a touch so creatures contrast.
+        // Ground: biome tint, darkened to 70 % so creatures contrast
+        // against it. Float math + round avoids the readability hit of
+        // `(r as u16 * 7 / 10) as u8`.
         let [r, g, b] = biome_tint(backdrop.biome);
-        canvas.set_draw_color(Color::RGB(
-            (r as u16 * 7 / 10) as u8,
-            (g as u16 * 7 / 10) as u8,
-            (b as u16 * 7 / 10) as u8,
-        ));
+        let darken = |c: u8| ((c as f32) * 0.7).round() as u8;
+        canvas.set_draw_color(Color::RGB(darken(r), darken(g), darken(b)));
         let ground_h = (ch as i32 - horizon).max(0) as u32;
         canvas
             .fill_rect(Rect::new(0, horizon, cw, ground_h))
@@ -248,15 +273,10 @@ mod sdl_backend {
         draw_backdrop(canvas, backdrop)?;
         let (cw, ch) = canvas.output_size().map_err(|e| e.to_string())?;
         let extents = depth_extents(entities);
-        let (y_min, y_max) = extents;
 
         for idx in depth_order(entities) {
             let entity = &entities[idx];
-            let depth_norm = if y_max > y_min {
-                ((entity.position.y - y_min) / (y_max - y_min)).clamp(0.0, 1.0)
-            } else {
-                0.5
-            };
+            let depth_norm = normalize_depth(entity.position.y, extents);
             let (sx, sy) = projection.project(entity.position, cw, ch, extents);
             let (w_px, h_px) = silhouette_size(entity.blueprint, projection, depth_norm);
 
@@ -316,10 +336,17 @@ mod sdl_backend {
     }
 
     fn silhouette_tint(blueprint: &crate::blueprint::CreatureBlueprint) -> [u8; 3] {
-        // Pick the first global material's base colour; convert HSV
-        // (Q3232) to RGB via a lossy approximation. For the smoke-test
-        // silhouette this only needs to be visually distinguishable —
-        // exact colour science waits for the procedural-mesh path.
+        // Pick the first global / per-volume material's base colour;
+        // convert HSV (Q3232) to RGB via a lossy approximation. For
+        // the smoke-test silhouette this only needs to be visually
+        // distinguishable — exact colour science waits for the
+        // procedural-mesh path.
+        //
+        // `MaterialTarget::Detail` is intentionally skipped — those
+        // are surface-detail materials (spike colour, plate colour,
+        // etc.), not the creature body's overall tint. Wiring them
+        // through the silhouette would require resolving the detail's
+        // host volume first; that lands with the mesh path.
         let global = blueprint.materials.iter().find(|m| {
             matches!(
                 m.target,
@@ -372,8 +399,11 @@ mod sdl_backend {
     }
 }
 
+// `draw_encounter` is the only public draw-call; `draw_backdrop` is
+// an implementation detail it calls internally. Keeping it crate-
+// private avoids leaking it as part of the public API surface.
 #[cfg(feature = "sdl")]
-pub use sdl_backend::{draw_backdrop, draw_encounter};
+pub use sdl_backend::draw_encounter;
 
 // ---------------------------------------------------------------------------
 // Pure tests
@@ -545,5 +575,68 @@ mod tests {
         let bd = Backdrop::new(BiomeTag::Forest);
         assert_eq!(bd.biome, BiomeTag::Forest);
         assert!(bd.horizon_fraction > 0.0 && bd.horizon_fraction < 0.5);
+    }
+
+    #[test]
+    fn projection_default_horizon_matches_backdrop() {
+        let proj = Projection::default();
+        let bd = Backdrop::new(BiomeTag::Forest);
+        assert!(approx(proj.horizon_fraction, bd.horizon_fraction));
+    }
+
+    #[test]
+    fn entity_feet_land_below_horizon_at_default_settings() {
+        // The projection's ground line must fall below (greater
+        // screen-y than) the backdrop's horizon line — otherwise feet
+        // render above the horizon, which reads as floating creatures.
+        let proj = Projection::default();
+        let bd = Backdrop::new(BiomeTag::Forest);
+        let canvas_h: u32 = 720;
+        let horizon_y = (canvas_h as f32) * bd.horizon_fraction;
+        // Entity at y=0 — projection puts its feet on the ground
+        // line. Feet must be below the horizon line.
+        let (_, feet_y) = proj.project(Position2D::new(0.0, 0.0), 1280, canvas_h, (0.0, 0.0));
+        assert!(
+            feet_y > horizon_y,
+            "feet_y {feet_y} must be below horizon_y {horizon_y}"
+        );
+    }
+
+    #[test]
+    fn depth_order_nan_entity_sorts_to_back() {
+        // `f32::total_cmp` orders NaN after every finite value; with
+        // back-to-front reversal that means a NaN-position entity is
+        // drawn first (rearmost in the depth stack). Test pins this
+        // contract — `partial_cmp.unwrap_or(Equal)` would scatter the
+        // NaN entity into an unspecified position.
+        let bp = dummy_blueprint();
+        let entities = [
+            entity(0, 0.0, -0.5, &bp),
+            entity(1, 0.0, f32::NAN, &bp),
+            entity(2, 0.0, 0.5, &bp),
+        ];
+        let order = depth_order(&entities);
+        // NaN sorts after all finite values; reversed → it's drawn
+        // first. Then 0.5 (back), then -0.5 (front).
+        assert_eq!(
+            order[0], 1,
+            "NaN entity should be drawn first; got {order:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_depth_clamps_to_unit_range() {
+        let extents = (-1.0, 1.0);
+        assert!(approx(normalize_depth(0.0, extents), 0.5));
+        assert!(approx(normalize_depth(-1.0, extents), 0.0));
+        assert!(approx(normalize_depth(1.0, extents), 1.0));
+        // Beyond the extent range clamps:
+        assert!(approx(normalize_depth(-99.0, extents), 0.0));
+        assert!(approx(normalize_depth(99.0, extents), 1.0));
+    }
+
+    #[test]
+    fn normalize_depth_handles_zero_extent() {
+        assert!(approx(normalize_depth(42.0, (5.0, 5.0)), 0.5));
     }
 }

--- a/crates/beast-render/src/encounter.rs
+++ b/crates/beast-render/src/encounter.rs
@@ -1,0 +1,549 @@
+//! Encounter-view renderer (S9.4).
+//!
+//! Draws a small 2.5D scene — typically the 5-creature encounter view —
+//! by mapping the encounter's world-space y axis to a vertical screen
+//! offset, scaling the x axis to 0.6 of the natural pixel ratio, and
+//! drawing entities back-to-front so creatures further back are
+//! occluded by closer ones.
+//!
+//! The module is split into a *pure* surface (projection math, depth
+//! ordering, [`Position2D`], [`EncounterEntity`], [`Backdrop`]) that
+//! compiles and tests without SDL, and an SDL-only backend that draws
+//! silhouettes + a selection ring + a backdrop strip. CI exercises the
+//! pure surface in headless mode; the SDL backend ships a smoke test
+//! at `examples/encounter.rs`.
+//!
+//! See `documentation/systems/10_procgen_visual_pipeline.md` and the
+//! issue body of #184 for the design contract.
+
+use beast_world::BiomeTag;
+
+use crate::blueprint::CreatureBlueprint;
+
+// ---------------------------------------------------------------------------
+// Pure types
+// ---------------------------------------------------------------------------
+
+/// Position in encounter-local world space.
+///
+/// `x` ∈ roughly `[-2, 2]` (typical encounter slot range).
+/// `y` is the depth axis: `y > 0` is further from the camera (drawn
+/// behind), `y < 0` is closer (drawn in front). Floats are fine — the
+/// encounter view is purely render-side, never feeds back into sim
+/// state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Position2D {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Position2D {
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// One entity in the encounter view. Each carries a borrowed
+/// blueprint so the renderer can read the bounding box for silhouette
+/// sizing without owning the data.
+#[derive(Debug, Clone, Copy)]
+pub struct EncounterEntity<'a> {
+    pub id: u32,
+    pub blueprint: &'a CreatureBlueprint,
+    pub position: Position2D,
+    /// True for the active / selected entity; gets a ring underneath.
+    pub selected: bool,
+}
+
+/// Backdrop description: biome tile colour + horizon line position.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Backdrop {
+    pub biome: BiomeTag,
+    /// Horizon as a fraction of the canvas height, `[0, 1]`. 0.5 puts
+    /// the horizon at the vertical centre. Defaults to 0.45 — a touch
+    /// above centre so the ground takes more space than the sky.
+    pub horizon_fraction: f32,
+}
+
+impl Backdrop {
+    pub const fn new(biome: BiomeTag) -> Self {
+        Self {
+            biome,
+            horizon_fraction: 0.45,
+        }
+    }
+}
+
+/// 2.5D projection parameters. Hand-tuned to match the design doc's
+/// "2.5D perspective" idiom: y depth → vertical offset + slight x
+/// compression so the scene reads as receding rather than orthographic.
+#[derive(Debug, Clone, Copy)]
+pub struct Projection {
+    /// Pixels per world-space unit on x.
+    pub px_per_unit_x: f32,
+    /// Pixels per world-space unit on y (depth). Smaller than x so
+    /// depth compresses.
+    pub px_per_unit_y: f32,
+    /// Horizontal compression at the back of the scene. 1.0 = no
+    /// compression, 0.6 = back rows are 60 % the width of front rows.
+    pub depth_x_scale: f32,
+}
+
+impl Default for Projection {
+    fn default() -> Self {
+        Self {
+            px_per_unit_x: 120.0,
+            px_per_unit_y: 80.0,
+            depth_x_scale: 0.6,
+        }
+    }
+}
+
+impl Projection {
+    /// Project an encounter world position to screen-space pixels
+    /// (origin top-left). Canvas dims define the centre point.
+    ///
+    /// Math:
+    /// * `screen_x = canvas_w/2 + x * px_per_unit_x * lerp(1, depth_x_scale, y_norm)`
+    /// * `screen_y = ground_y - y * px_per_unit_y`  (where ground_y is
+    ///   slightly below the horizon)
+    ///
+    /// `y_norm` = `(y - y_min) / (y_max - y_min)` clamped to `[0, 1]`,
+    /// where `(y_min, y_max)` come from the entity batch's depth range
+    /// — passed in as `depth_extents` so all entities scale
+    /// consistently.
+    pub fn project(
+        &self,
+        pos: Position2D,
+        canvas_w: u32,
+        canvas_h: u32,
+        depth_extents: (f32, f32),
+    ) -> (f32, f32) {
+        let cw = canvas_w as f32;
+        let ch = canvas_h as f32;
+        let (y_min, y_max) = depth_extents;
+        let y_norm = if y_max > y_min {
+            ((pos.y - y_min) / (y_max - y_min)).clamp(0.0, 1.0)
+        } else {
+            0.5
+        };
+        // Lerp: front (y_norm = 0) keeps full x; back (y_norm = 1)
+        // compresses to depth_x_scale.
+        let x_scale = 1.0 - (1.0 - self.depth_x_scale) * y_norm;
+
+        let ground_y = ch * 0.65;
+        let screen_x = cw * 0.5 + pos.x * self.px_per_unit_x * x_scale;
+        let screen_y = ground_y - pos.y * self.px_per_unit_y;
+        (screen_x, screen_y)
+    }
+}
+
+/// Sort an entity batch back-to-front (largest `y` first). Returns a
+/// `Vec<usize>` of indices into the original slice; the renderer
+/// iterates this to issue draw calls in the right order. Stable sort
+/// — ties between identical `y` values keep their insertion order.
+pub fn depth_order(entities: &[EncounterEntity<'_>]) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..entities.len()).collect();
+    indices.sort_by(|&a, &b| {
+        // partial_cmp is fine: encounter positions are render-only and
+        // we control inputs. NaN lands at the front.
+        entities[b]
+            .position
+            .y
+            .partial_cmp(&entities[a].position.y)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    indices
+}
+
+/// Compute the depth range `(y_min, y_max)` of an entity batch.
+/// Empty batch → `(0.0, 0.0)`.
+pub fn depth_extents(entities: &[EncounterEntity<'_>]) -> (f32, f32) {
+    let mut iter = entities.iter().map(|e| e.position.y);
+    let Some(first) = iter.next() else {
+        return (0.0, 0.0);
+    };
+    iter.fold((first, first), |(lo, hi), y| {
+        (if y < lo { y } else { lo }, if y > hi { y } else { hi })
+    })
+}
+
+/// Silhouette pixel size derived from a blueprint's bounding box.
+///
+/// Treats the blueprint's bbox as world units (1 unit ≈ 1 body length),
+/// scales by the projection's x-pixel-per-unit (with depth
+/// compression) for width, and by y-pixel-per-unit for height. Returns
+/// (w_px, h_px) — the silhouette is drawn as a filled rect of this
+/// size, centred on the projected position.
+pub fn silhouette_size(
+    blueprint: &CreatureBlueprint,
+    projection: &Projection,
+    depth_norm: f32,
+) -> (u32, u32) {
+    let bb = &blueprint.metadata.bounding_box;
+    let world_w = (bb.max.x.to_num::<f32>() - bb.min.x.to_num::<f32>()).max(0.5);
+    let world_h = (bb.max.y.to_num::<f32>() - bb.min.y.to_num::<f32>()).max(0.5);
+    let x_scale = 1.0 - (1.0 - projection.depth_x_scale) * depth_norm;
+    let w_px = (world_w * projection.px_per_unit_x * x_scale).clamp(8.0, 256.0);
+    // Depth doesn't compress vertical extent — it shifts vertical
+    // position. Height stays consistent so creatures at different
+    // depths read as the same scale, just offset.
+    let h_px = (world_h * projection.px_per_unit_y).clamp(8.0, 256.0);
+    (w_px.round() as u32, h_px.round() as u32)
+}
+
+// ---------------------------------------------------------------------------
+// SDL backend
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sdl")]
+mod sdl_backend {
+    use super::{
+        depth_extents, depth_order, silhouette_size, Backdrop, EncounterEntity, Projection,
+    };
+    use crate::world_map::biome_tint;
+    use sdl3::pixels::Color;
+    use sdl3::rect::Rect;
+    use sdl3::render::WindowCanvas;
+
+    /// Draw the backdrop: sky strip (slightly tinted neutral) + ground
+    /// fill in biome colour, separated by the horizon line.
+    pub fn draw_backdrop(canvas: &mut WindowCanvas, backdrop: &Backdrop) -> Result<(), String> {
+        let (cw, ch) = canvas.output_size().map_err(|e| e.to_string())?;
+        let horizon = (ch as f32 * backdrop.horizon_fraction).round() as i32;
+
+        // Sky: cool, slightly desaturated.
+        canvas.set_draw_color(Color::RGB(140, 160, 180));
+        canvas
+            .fill_rect(Rect::new(0, 0, cw, horizon.max(0) as u32))
+            .map_err(|e| e.to_string())?;
+
+        // Ground: biome tint, darkened a touch so creatures contrast.
+        let [r, g, b] = biome_tint(backdrop.biome);
+        canvas.set_draw_color(Color::RGB(
+            (r as u16 * 7 / 10) as u8,
+            (g as u16 * 7 / 10) as u8,
+            (b as u16 * 7 / 10) as u8,
+        ));
+        let ground_h = (ch as i32 - horizon).max(0) as u32;
+        canvas
+            .fill_rect(Rect::new(0, horizon, cw, ground_h))
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Draw an entity batch back-to-front, with optional selection
+    /// ring under the active creature(s).
+    ///
+    /// Silhouettes are filled rectangles sized by
+    /// [`super::silhouette_size`]; the eventual procedural mesh path
+    /// from S9.5 will replace the rect with a sprite or mesh draw
+    /// without changing this signature.
+    pub fn draw_encounter(
+        canvas: &mut WindowCanvas,
+        backdrop: &Backdrop,
+        entities: &[EncounterEntity<'_>],
+        projection: &Projection,
+    ) -> Result<(), String> {
+        draw_backdrop(canvas, backdrop)?;
+        let (cw, ch) = canvas.output_size().map_err(|e| e.to_string())?;
+        let extents = depth_extents(entities);
+        let (y_min, y_max) = extents;
+
+        for idx in depth_order(entities) {
+            let entity = &entities[idx];
+            let depth_norm = if y_max > y_min {
+                ((entity.position.y - y_min) / (y_max - y_min)).clamp(0.0, 1.0)
+            } else {
+                0.5
+            };
+            let (sx, sy) = projection.project(entity.position, cw, ch, extents);
+            let (w_px, h_px) = silhouette_size(entity.blueprint, projection, depth_norm);
+
+            // Drop shadow: faint dark ellipse-ish rect under the feet.
+            canvas.set_draw_color(Color::RGBA(0, 0, 0, 80));
+            canvas
+                .fill_rect(Rect::new(
+                    sx as i32 - (w_px as i32) / 2,
+                    sy as i32,
+                    w_px,
+                    (h_px / 6).max(2),
+                ))
+                .map_err(|e| e.to_string())?;
+
+            // Selection ring (drawn before the silhouette so it sits
+            // *behind* the creature's feet, reading as a marker on the
+            // ground).
+            if entity.selected {
+                draw_selection_ring(canvas, sx as i32, sy as i32, w_px)?;
+            }
+
+            // Silhouette: simple filled rect for now. Tinted from the
+            // blueprint's first global material colour if present;
+            // otherwise mid-grey.
+            let tint = silhouette_tint(entity.blueprint);
+            canvas.set_draw_color(Color::RGB(tint[0], tint[1], tint[2]));
+            canvas
+                .fill_rect(Rect::new(
+                    sx as i32 - (w_px as i32) / 2,
+                    sy as i32 - h_px as i32,
+                    w_px,
+                    h_px,
+                ))
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    fn draw_selection_ring(
+        canvas: &mut WindowCanvas,
+        cx: i32,
+        feet_y: i32,
+        width: u32,
+    ) -> Result<(), String> {
+        let ring_w = (width as f32 * 1.3) as u32;
+        let ring_h = (width as f32 * 0.4).max(8.0) as u32;
+        canvas.set_draw_color(Color::RGB(255, 220, 80));
+        canvas
+            .draw_rect(Rect::new(
+                cx - ring_w as i32 / 2,
+                feet_y - ring_h as i32 / 2,
+                ring_w,
+                ring_h,
+            ))
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    fn silhouette_tint(blueprint: &crate::blueprint::CreatureBlueprint) -> [u8; 3] {
+        // Pick the first global material's base colour; convert HSV
+        // (Q3232) to RGB via a lossy approximation. For the smoke-test
+        // silhouette this only needs to be visually distinguishable —
+        // exact colour science waits for the procedural-mesh path.
+        let global = blueprint.materials.iter().find(|m| {
+            matches!(
+                m.target,
+                crate::blueprint::MaterialTarget::Global
+                    | crate::blueprint::MaterialTarget::Volume { .. }
+            )
+        });
+        let Some(mat) = global else {
+            return [120, 120, 120];
+        };
+        // Map hue (0-360) to a coarse RGB by region. Saturation +
+        // value live in [0,1].
+        let hue: f32 = mat
+            .props
+            .base_color
+            .hue
+            .map(|h| h.to_num::<f32>())
+            .unwrap_or(120.0);
+        let s: f32 = mat
+            .props
+            .base_color
+            .saturation
+            .to_num::<f32>()
+            .clamp(0.0, 1.0);
+        let v: f32 = mat.props.base_color.value.to_num::<f32>().clamp(0.0, 1.0);
+        hsv_to_rgb(hue, s, v)
+    }
+
+    fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [u8; 3] {
+        // Standard HSV→RGB; lifted here so the SDL backend doesn't pull
+        // in a colour crate. h in degrees, s/v in [0, 1].
+        let h = h.rem_euclid(360.0);
+        let c = v * s;
+        let h_section = h / 60.0;
+        let x = c * (1.0 - (h_section.rem_euclid(2.0) - 1.0).abs());
+        let (r1, g1, b1) = match h_section as i32 {
+            0 => (c, x, 0.0),
+            1 => (x, c, 0.0),
+            2 => (0.0, c, x),
+            3 => (0.0, x, c),
+            4 => (x, 0.0, c),
+            _ => (c, 0.0, x),
+        };
+        let m = v - c;
+        [
+            ((r1 + m) * 255.0).clamp(0.0, 255.0) as u8,
+            ((g1 + m) * 255.0).clamp(0.0, 255.0) as u8,
+            ((b1 + m) * 255.0).clamp(0.0, 255.0) as u8,
+        ]
+    }
+}
+
+#[cfg(feature = "sdl")]
+pub use sdl_backend::{draw_backdrop, draw_encounter};
+
+// ---------------------------------------------------------------------------
+// Pure tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::animation::{AnimationClip, AnimationSet};
+    use crate::blueprint::{Aabb, BlueprintMetadata, BoneTree, Vec3};
+    use beast_core::Q3232;
+
+    fn approx(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-3
+    }
+
+    fn dummy_blueprint() -> CreatureBlueprint {
+        CreatureBlueprint {
+            skeleton: BoneTree { bones: Vec::new() },
+            volumes: Vec::new(),
+            surfaces: Vec::new(),
+            materials: Vec::new(),
+            effects: Vec::new(),
+            animations: AnimationSet {
+                locomotion: Vec::new(),
+                idle: Vec::new(),
+                damage: AnimationClip {
+                    name: "damage".to_string(),
+                    duration: Q3232::ONE,
+                    looping: false,
+                    bone_tracks: Vec::new(),
+                },
+                death: AnimationClip {
+                    name: "death".to_string(),
+                    duration: Q3232::ONE,
+                    looping: false,
+                    bone_tracks: Vec::new(),
+                },
+            },
+            metadata: BlueprintMetadata {
+                bounding_box: Aabb {
+                    min: Vec3::ZERO,
+                    max: Vec3::new(Q3232::from_num(1), Q3232::from_num(1), Q3232::ZERO),
+                },
+                display_name: "test".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn projection_centres_origin() {
+        let proj = Projection::default();
+        let (sx, sy) = proj.project(Position2D::new(0.0, 0.0), 1280, 720, (-1.0, 1.0));
+        assert!(approx(sx, 640.0));
+        // ground_y = 720 * 0.65 = 468; y=0 puts us right on it.
+        assert!(approx(sy, 468.0));
+    }
+
+    #[test]
+    fn projection_depth_offsets_vertically() {
+        let proj = Projection::default();
+        let front = proj.project(Position2D::new(0.0, -0.5), 1280, 720, (-0.5, 0.5));
+        let back = proj.project(Position2D::new(0.0, 0.5), 1280, 720, (-0.5, 0.5));
+        // Larger y → drawn higher up the screen (smaller screen y).
+        assert!(back.1 < front.1);
+    }
+
+    #[test]
+    fn projection_depth_compresses_x() {
+        let proj = Projection::default();
+        let front_right = proj.project(Position2D::new(1.0, -0.5), 1280, 720, (-0.5, 0.5));
+        let back_right = proj.project(Position2D::new(1.0, 0.5), 1280, 720, (-0.5, 0.5));
+        // Same x, but back row should be closer to centre by depth_x_scale.
+        let centre = 640.0;
+        let front_offset = front_right.0 - centre;
+        let back_offset = back_right.0 - centre;
+        assert!(back_offset.abs() < front_offset.abs());
+        // 0.6 compression at the back: ratio should be ~0.6.
+        let ratio = back_offset / front_offset;
+        assert!(ratio > 0.55 && ratio < 0.65, "depth-x ratio {ratio}");
+    }
+
+    #[test]
+    fn projection_handles_zero_depth_extent() {
+        // All entities at the same y → y_norm defaults to 0.5,
+        // projection still produces a finite position.
+        let proj = Projection::default();
+        let (sx, sy) = proj.project(Position2D::new(0.5, 0.0), 1280, 720, (0.0, 0.0));
+        assert!(sx.is_finite());
+        assert!(sy.is_finite());
+    }
+
+    fn entity(id: u32, x: f32, y: f32, bp: &CreatureBlueprint) -> EncounterEntity<'_> {
+        EncounterEntity {
+            id,
+            blueprint: bp,
+            position: Position2D::new(x, y),
+            selected: false,
+        }
+    }
+
+    #[test]
+    fn depth_order_sorts_back_to_front() {
+        let bp = dummy_blueprint();
+        let entities = [
+            entity(0, 0.0, -0.5, &bp), // closest
+            entity(1, 0.0, 0.5, &bp),  // furthest
+            entity(2, 0.0, 0.0, &bp),  // middle
+        ];
+        let order = depth_order(&entities);
+        // Index 1 (y=0.5) first, then 2 (y=0.0), then 0 (y=-0.5).
+        assert_eq!(order, vec![1, 2, 0]);
+    }
+
+    #[test]
+    fn depth_order_is_stable_for_ties() {
+        let bp = dummy_blueprint();
+        let entities = [
+            entity(0, 0.0, 0.0, &bp),
+            entity(1, 0.0, 0.0, &bp),
+            entity(2, 0.0, 0.0, &bp),
+        ];
+        let order = depth_order(&entities);
+        // Ties → insertion order preserved.
+        assert_eq!(order, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn depth_extents_handles_empty_batch() {
+        let extents: (f32, f32) = depth_extents(&[]);
+        assert_eq!(extents, (0.0, 0.0));
+    }
+
+    #[test]
+    fn depth_extents_finds_min_max() {
+        let bp = dummy_blueprint();
+        let entities = [
+            entity(0, 0.0, -1.5, &bp),
+            entity(1, 0.0, 0.7, &bp),
+            entity(2, 0.0, -0.2, &bp),
+        ];
+        let (lo, hi) = depth_extents(&entities);
+        assert!(approx(lo, -1.5));
+        assert!(approx(hi, 0.7));
+    }
+
+    #[test]
+    fn silhouette_size_clamps_to_min_when_blueprint_is_tiny() {
+        // A blueprint with a degenerate bbox should still produce a
+        // visible silhouette; test pins the floor at 8 px.
+        let bp = dummy_blueprint();
+        let proj = Projection::default();
+        let (w, h) = silhouette_size(&bp, &proj, 0.0);
+        assert!(w >= 8 && h >= 8);
+    }
+
+    #[test]
+    fn silhouette_size_compresses_with_depth() {
+        let bp = dummy_blueprint();
+        let proj = Projection::default();
+        let (w_front, _) = silhouette_size(&bp, &proj, 0.0);
+        let (w_back, _) = silhouette_size(&bp, &proj, 1.0);
+        // Back row narrower than front row by depth_x_scale.
+        assert!(w_back < w_front, "{w_back} >= {w_front}");
+    }
+
+    #[test]
+    fn backdrop_default_horizon_is_above_centre() {
+        let bd = Backdrop::new(BiomeTag::Forest);
+        assert_eq!(bd.biome, BiomeTag::Forest);
+        assert!(bd.horizon_fraction > 0.0 && bd.horizon_fraction < 0.5);
+    }
+}

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -44,12 +44,19 @@ pub mod sprite;
 // SDL drawing entry points (`draw_archipelago`, `draw_creature_glyphs`).
 pub mod world_map;
 
+// Encounter-view renderer: 2.5D projection + depth ordering + (under
+// `sdl`) the SDL drawing entry points (`draw_backdrop`, `draw_encounter`).
+pub mod encounter;
+
 pub use animation::{
     rig_animations, AnimationClip, AnimationSet, Animator, BoneRotation, BoneTrack, Easing,
     Keyframe, LocomotionStyle, PoseFrame,
 };
 pub use blueprint::CreatureBlueprint;
 pub use directive::{ColorSpec, DirectiveParams, VisualDirective};
+pub use encounter::{
+    depth_extents, depth_order, silhouette_size, Backdrop, EncounterEntity, Position2D, Projection,
+};
 pub use error::{RenderError, Result};
 pub use pipeline::compile_blueprint;
 pub use renderer::{Renderer, WindowConfig};

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -55,7 +55,8 @@ pub use animation::{
 pub use blueprint::CreatureBlueprint;
 pub use directive::{ColorSpec, DirectiveParams, VisualDirective};
 pub use encounter::{
-    depth_extents, depth_order, silhouette_size, Backdrop, EncounterEntity, Position2D, Projection,
+    depth_extents, depth_order, normalize_depth, silhouette_size, Backdrop, EncounterEntity,
+    Position2D, Projection,
 };
 pub use error::{RenderError, Result};
 pub use pipeline::compile_blueprint;


### PR DESCRIPTION
Closes #184. **Concludes the S9 sprint.**

## Summary
Encounter-view renderer. 2.5D projection (y depth → vertical offset + 0.6 horizontal compression at the back), back-to-front draw order, biome-tinted backdrop with horizon strip, and a selection ring under the active creature.

### Pure layer (compiles without SDL)
- \`Position2D { x, y }\` — encounter-local space, floats.
- \`EncounterEntity<'a> { id, blueprint: &CreatureBlueprint, position, selected }\` — borrowed blueprint so the renderer reads bbox without owning data.
- \`Backdrop { biome, horizon_fraction }\` — biome tile colour + horizon position.
- \`Projection { px_per_unit_x, px_per_unit_y, depth_x_scale }\` with \`project()\` mapping world position → screen pixels using the entity batch's depth extents.
- \`depth_order(entities) -> Vec<usize>\` — stable back-to-front sort by y.
- \`depth_extents(entities) -> (f32, f32)\` — min/max scan.
- \`silhouette_size(blueprint, projection, depth_norm) -> (u32, u32)\` — from the blueprint's metadata bbox, with depth compression on width but not height (so creatures at different depths read as the same scale, just offset).

### SDL layer (\`#[cfg(feature = "sdl")]\`)
- \`draw_backdrop(canvas, &Backdrop)\` — sky strip + ground fill (biome tint, darkened 30%).
- \`draw_encounter(canvas, &Backdrop, &[EncounterEntity], &Projection)\` — calls \`draw_backdrop\`, then for each entity in depth order: drop-shadow rect, selection ring (if \`selected\`), tinted silhouette rect. HSV→RGB conversion lifted inline so the SDL backend doesn't pull in a colour crate.

### Smoke test
\`examples/encounter.rs\` — 5 hand-tuned phenotypes compiled through the visual pipeline, positioned in two rows (3 in front, 2 in back) on a forest backdrop. Tab cycles selection forward, Shift+Tab back, Esc quits.

\`\`\`bash
cargo run -p beast-render --example encounter
\`\`\`

## Determinism / invariants
- INVARIANTS §1: \`Position2D\` / \`Projection\` use f32 because render code is the one place floats are allowed. The renderer reads \`&[EncounterEntity]\` and never writes back to sim state.
- INVARIANTS §6: Selection state lives entirely in render-side code (the example's \`selected: usize\`), never persisted.

## Caveats / future work
- **Procedural mesh rendering**: silhouette is a filled rect with HSV-derived tint. The eventual mesh path layered on top of \`CreatureBlueprint\` doesn't change the \`draw_encounter\` signature — it replaces the filled-rect branch in the SDL backend.
- **Frame-time bench** (\`bench_encounter_5_creatures\`) is tracked separately as #202 — depends on this PR landing.
- **Selection ring shape**: current ring is a hollow rect. An ellipse via \`draw_lines\` would read better; deferred until the renderer adds a primitives layer.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings\`
- [x] \`cargo clippy -p beast-render --all-targets -- -D warnings\` (sdl backend)
- [x] \`cargo test -p beast-render --no-default-features --features headless\` — 53 lib + 9 animation + 6 pipeline + 4 random_creatures + 3 sprite = 75 tests pass
- [x] \`cargo test --workspace --exclude beast-render --all-targets --locked\` — workspace green
- [x] \`cargo build -p beast-render --example encounter\` — links the SDL backend
- [ ] Manual: \`cargo run -p beast-render --example encounter\` shows 5 silhouettes, Tab cycles selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)