### PR TITLE
feat(beast-ui): S10.1 widget trait & primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-ui"
+version = "0.1.0"
+dependencies = [
+ "beast-core",
+ "beast-render",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "beast-world"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,6 @@ dependencies = [
  "beast-core",
  "beast-render",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/beast-world",
     "crates/beast-climate",
     "crates/beast-render",
+    "crates/beast-ui",
 ]
 
 [workspace.package]
@@ -97,6 +98,7 @@ beast-serde = { path = "crates/beast-serde" }
 beast-world = { path = "crates/beast-world" }
 beast-climate = { path = "crates/beast-climate" }
 beast-render = { path = "crates/beast-render" }
+beast-ui = { path = "crates/beast-ui" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-ui/Cargo.toml
+++ b/crates/beast-ui/Cargo.toml
@@ -31,7 +31,6 @@ headless = ["beast-render/headless"]
 beast-core = { workspace = true }
 beast-render = { workspace = true }
 serde = { workspace = true }
-thiserror = { workspace = true }
 
 [lints.rust]
 # Forbid `unsafe`. The widget framework is pure data + dispatch; any unsafe

--- a/crates/beast-ui/Cargo.toml
+++ b/crates/beast-ui/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "beast-ui"
+description = "Retained-mode widget framework for the Beast Evolution Game UI. Read-only against sim state per INVARIANTS §6."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+doctest = true
+
+[features]
+# Mirror beast-render's feature split so downstream crates can pick the same
+# backend at workspace level. The `sdl` feature pulls in `beast-render` with
+# its real SDL3 backend; `headless` keeps the public API but compiles without
+# linking SDL3 — used by CI, tests, and integration runs on display-less
+# machines. Default to `sdl` to match beast-render.
+default = ["sdl"]
+sdl = ["beast-render/sdl"]
+headless = ["beast-render/headless"]
+
+[dependencies]
+# beast-core supplies WidgetId-friendly newtypes (we keep WidgetId here, but
+# the workspace-shared error / fixed-point helpers are useful for future
+# bindings). beast-render is depended on so the feature split flows through;
+# no widget code in this story actually drives the renderer yet — that lands
+# in S10.4 when screens embed renderer viewports.
+beast-core = { workspace = true }
+beast-render = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[lints.rust]
+# Forbid `unsafe`. The widget framework is pure data + dispatch; any unsafe
+# block here would be a bug, not an FFI necessity.
+unsafe_code = "forbid"

--- a/crates/beast-ui/src/event.rs
+++ b/crates/beast-ui/src/event.rs
@@ -1,0 +1,177 @@
+//! Input events delivered to widgets and the result widgets return.
+//!
+//! S10.1 only needs enough of the event surface to verify that primitives
+//! like [`Button`](crate::Button) and modal [`Dialog`](crate::Dialog)
+//! consume / forward events correctly. Full keyboard / focus dispatch
+//! through the tree lands in S10.3.
+
+use serde::{Deserialize, Serialize};
+
+/// Mouse buttons handled by the widget framework.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MouseButton {
+    /// Primary (usually left) button.
+    Primary,
+    /// Secondary (usually right) button.
+    Secondary,
+    /// Middle button.
+    Middle,
+}
+
+/// Subset of physical key codes the widget framework cares about.
+///
+/// The vocabulary is intentionally narrow; keys that don't matter for
+/// widget interaction (e.g. function keys, media keys) bubble up as
+/// [`UiEvent::TextInput`] when applicable or are simply not represented.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum KeyCode {
+    /// Enter / return key.
+    Enter,
+    /// Escape key.
+    Escape,
+    /// Tab key — used for focus cycling in S10.3.
+    Tab,
+    /// Spacebar.
+    Space,
+    /// Backspace.
+    Backspace,
+    /// Up arrow.
+    ArrowUp,
+    /// Down arrow.
+    ArrowDown,
+    /// Left arrow.
+    ArrowLeft,
+    /// Right arrow.
+    ArrowRight,
+    /// Letter or digit key — payload is the lowercase ASCII glyph.
+    Char(char),
+}
+
+/// Modifier-key bitflags layered over [`KeyCode`].
+///
+/// Implemented as a small newtype rather than pulling in the `bitflags`
+/// crate — this is the only bitset in `beast-ui` and the surface fits in
+/// a few `const`s + `BitOr`. If we add a second bitflags type later, swap
+/// to the real crate.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KeyMods(u8);
+
+impl KeyMods {
+    /// No modifiers held.
+    pub const NONE: Self = Self(0);
+    /// Shift held.
+    pub const SHIFT: Self = Self(0b0001);
+    /// Control held.
+    pub const CTRL: Self = Self(0b0010);
+    /// Alt held.
+    pub const ALT: Self = Self(0b0100);
+    /// Super / Cmd / Windows key held.
+    pub const SUPER: Self = Self(0b1000);
+
+    /// Returns true if every bit in `other` is set in `self`.
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Returns true if any bit in `other` is set in `self`.
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl core::ops::BitOr for KeyMods {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitAnd for KeyMods {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for KeyMods {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Pair of [`KeyCode`] + [`KeyMods`] passed to widgets.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Modifiers {
+    /// Physical key.
+    pub key: KeyCode,
+    /// Modifier mask.
+    pub mods: KeyMods,
+}
+
+/// Input event delivered to a [`Widget`](crate::Widget).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum UiEvent {
+    /// Mouse moved to an absolute widget-space coordinate.
+    MouseMove {
+        /// X coordinate.
+        x: f32,
+        /// Y coordinate.
+        y: f32,
+    },
+    /// Mouse button pressed at the cursor's last position.
+    MouseDown {
+        /// Which button was pressed.
+        button: MouseButton,
+    },
+    /// Mouse button released at the cursor's last position.
+    MouseUp {
+        /// Which button was released.
+        button: MouseButton,
+    },
+    /// Key was pressed.
+    KeyDown(Modifiers),
+    /// Key was released.
+    KeyUp(Modifiers),
+    /// Text input from the IME / keyboard layer (post-translation).
+    TextInput(String),
+    /// Time delta for tick-based animations / timers.
+    Tick {
+        /// Milliseconds since the previous tick.
+        dt_ms: u32,
+    },
+}
+
+/// Outcome of a widget's [`Widget::handle_event`](crate::Widget::handle_event)
+/// call.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventResult {
+    /// The widget consumed the event; siblings / ancestors should not see
+    /// it again.
+    Consumed,
+    /// The widget did not act on the event but agrees to let it bubble up.
+    Ignored,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_mods_combine_via_bitor() {
+        let m = KeyMods::SHIFT | KeyMods::CTRL;
+        assert!(m.contains(KeyMods::SHIFT));
+        assert!(m.contains(KeyMods::CTRL));
+        assert!(!m.contains(KeyMods::ALT));
+        assert!(m.intersects(KeyMods::SHIFT));
+    }
+
+    #[test]
+    fn modifiers_carry_key_and_mask() {
+        let m = Modifiers {
+            key: KeyCode::Char('a'),
+            mods: KeyMods::SHIFT,
+        };
+        assert_eq!(m.key, KeyCode::Char('a'));
+        assert!(m.mods.contains(KeyMods::SHIFT));
+    }
+}

--- a/crates/beast-ui/src/lib.rs
+++ b/crates/beast-ui/src/lib.rs
@@ -32,4 +32,6 @@ pub mod widget;
 
 pub use event::{EventResult, KeyCode, KeyMods, Modifiers, MouseButton, UiEvent};
 pub use paint::{Color, DrawCmd, PaintCtx, Point, Rect, Size};
-pub use widget::{Button, Card, Dialog, IdAllocator, Label, List, ListItem, Widget, WidgetId};
+pub use widget::{
+    Button, Card, Dialog, IdAllocator, Label, LayoutCtx, List, ListItem, Widget, WidgetId,
+};

--- a/crates/beast-ui/src/lib.rs
+++ b/crates/beast-ui/src/lib.rs
@@ -1,0 +1,35 @@
+//! Retained-mode widget framework for the Beast Evolution Game UI.
+//!
+//! `beast-ui` defines the [`Widget`] trait and a small set of primitive
+//! widgets ([`Button`], [`Label`], [`List`], [`Card`], [`Dialog`]) that
+//! higher layers compose into screens (S10.4). Per
+//! `documentation/INVARIANTS.md` §6, the UI layer is **read-only** against
+//! simulation state — none of the widget primitives in this crate take a
+//! mutable handle to anything sim-side.
+//!
+//! # Feature flags
+//!
+//! * `sdl` (default) — re-exports `beast-render` with its real SDL3 backend.
+//! * `headless` — re-exports `beast-render` in headless mode so the crate
+//!   builds on display-less CI runners.
+//!
+//! Both features delegate the SDL link to `beast-render`. This story only
+//! defines the widget data model + paint recording surface; SDL drawing is
+//! wired in later sprints when screens (S10.4) embed renderer viewports.
+//!
+//! # Determinism
+//!
+//! Widget primitives are pure data structures. They never read sim state and
+//! never feed values back into the simulation. Paint output is recorded into
+//! a deterministic [`paint::PaintCtx`] command list — useful for snapshot
+//! tests and for future flushing into a real renderer surface.
+
+#![warn(missing_docs)]
+
+pub mod event;
+pub mod paint;
+pub mod widget;
+
+pub use event::{EventResult, KeyCode, KeyMods, Modifiers, MouseButton, UiEvent};
+pub use paint::{Color, DrawCmd, PaintCtx, Point, Rect, Size};
+pub use widget::{Button, Card, Dialog, IdAllocator, Label, List, ListItem, Widget, WidgetId};

--- a/crates/beast-ui/src/paint.rs
+++ b/crates/beast-ui/src/paint.rs
@@ -1,0 +1,241 @@
+//! Paint context + geometric primitives shared across widgets.
+//!
+//! The widget framework records paint operations into a [`PaintCtx`] rather
+//! than driving a renderer directly. This decouples widget tests from the
+//! SDL backend (the `headless` feature builds them with no SDL link at all)
+//! and gives layout / snapshot tests a deterministic command list to assert
+//! on.
+//!
+//! Future work: a `Renderer` adapter will consume the recorded commands and
+//! issue real draw calls. That work belongs to the screen-wiring story
+//! (S10.4) — it is intentionally not part of this crate today.
+
+use serde::{Deserialize, Serialize};
+
+/// 2D point in widget-space coordinates (top-left origin, pixels).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Point {
+    /// Horizontal coordinate, increasing rightwards.
+    pub x: f32,
+    /// Vertical coordinate, increasing downwards.
+    pub y: f32,
+}
+
+impl Point {
+    /// Construct a [`Point`] from explicit `x` / `y`.
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// 2D size in widget-space pixels. Both axes are non-negative by convention;
+/// callers should not produce negative sizes.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Size {
+    /// Width in pixels.
+    pub width: f32,
+    /// Height in pixels.
+    pub height: f32,
+}
+
+impl Size {
+    /// Construct a [`Size`] from explicit width / height.
+    pub const fn new(width: f32, height: f32) -> Self {
+        Self { width, height }
+    }
+
+    /// Zero-sized rectangle; useful as a default for empty widgets.
+    pub const ZERO: Self = Self {
+        width: 0.0,
+        height: 0.0,
+    };
+}
+
+/// Axis-aligned rectangle expressed by its top-left origin and [`Size`].
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rect {
+    /// Top-left corner.
+    pub origin: Point,
+    /// Width / height.
+    pub size: Size,
+}
+
+impl Rect {
+    /// Construct a [`Rect`] from origin + size.
+    pub const fn new(origin: Point, size: Size) -> Self {
+        Self { origin, size }
+    }
+
+    /// Construct a [`Rect`] from explicit `x`, `y`, `width`, `height`.
+    pub const fn xywh(x: f32, y: f32, width: f32, height: f32) -> Self {
+        Self {
+            origin: Point::new(x, y),
+            size: Size::new(width, height),
+        }
+    }
+
+    /// Rectangle with zero origin and zero size.
+    pub const ZERO: Self = Self::xywh(0.0, 0.0, 0.0, 0.0);
+
+    /// Right edge x-coordinate.
+    pub fn right(&self) -> f32 {
+        self.origin.x + self.size.width
+    }
+
+    /// Bottom edge y-coordinate.
+    pub fn bottom(&self) -> f32 {
+        self.origin.y + self.size.height
+    }
+
+    /// Returns true if `point` falls inside this rectangle. Edges are
+    /// inclusive on the top / left and exclusive on the bottom / right —
+    /// matches the half-open convention used by most 2D graphics APIs.
+    pub fn contains(&self, point: Point) -> bool {
+        point.x >= self.origin.x
+            && point.x < self.right()
+            && point.y >= self.origin.y
+            && point.y < self.bottom()
+    }
+}
+
+/// RGBA color, channels in `[0.0, 1.0]`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Color {
+    /// Red channel.
+    pub r: f32,
+    /// Green channel.
+    pub g: f32,
+    /// Blue channel.
+    pub b: f32,
+    /// Alpha channel.
+    pub a: f32,
+}
+
+impl Color {
+    /// Construct an RGBA color.
+    pub const fn rgba(r: f32, g: f32, b: f32, a: f32) -> Self {
+        Self { r, g, b, a }
+    }
+
+    /// Opaque RGB color (alpha = 1.0).
+    pub const fn rgb(r: f32, g: f32, b: f32) -> Self {
+        Self::rgba(r, g, b, 1.0)
+    }
+
+    /// Fully transparent black.
+    pub const TRANSPARENT: Self = Self::rgba(0.0, 0.0, 0.0, 0.0);
+    /// Opaque white.
+    pub const WHITE: Self = Self::rgb(1.0, 1.0, 1.0);
+    /// Opaque black.
+    pub const BLACK: Self = Self::rgb(0.0, 0.0, 0.0);
+}
+
+/// One recorded draw operation.
+///
+/// The widget framework accumulates these into a [`PaintCtx`]; downstream
+/// code either snapshots them for tests or flushes them through a renderer.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DrawCmd {
+    /// Filled rectangle with a single color.
+    FillRect {
+        /// Rectangle to fill.
+        rect: Rect,
+        /// Fill color.
+        color: Color,
+    },
+    /// Stroked rectangle outline (1px wide for now).
+    StrokeRect {
+        /// Rectangle outline.
+        rect: Rect,
+        /// Stroke color.
+        color: Color,
+    },
+    /// Plain text at a baseline anchor. Font + size are deferred to S10.4.
+    Text {
+        /// Position the text starts drawing from (top-left).
+        pos: Point,
+        /// String content.
+        text: String,
+        /// Text color.
+        color: Color,
+    },
+}
+
+/// Paint command recorder. A widget receives `&mut PaintCtx` from the tree
+/// during a paint pass and pushes [`DrawCmd`]s for downstream consumption.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PaintCtx {
+    commands: Vec<DrawCmd>,
+}
+
+impl PaintCtx {
+    /// Construct an empty paint context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a [`DrawCmd::FillRect`].
+    pub fn fill_rect(&mut self, rect: Rect, color: Color) {
+        self.commands.push(DrawCmd::FillRect { rect, color });
+    }
+
+    /// Push a [`DrawCmd::StrokeRect`].
+    pub fn stroke_rect(&mut self, rect: Rect, color: Color) {
+        self.commands.push(DrawCmd::StrokeRect { rect, color });
+    }
+
+    /// Push a [`DrawCmd::Text`].
+    pub fn text(&mut self, pos: Point, text: impl Into<String>, color: Color) {
+        self.commands.push(DrawCmd::Text {
+            pos,
+            text: text.into(),
+            color,
+        });
+    }
+
+    /// Recorded commands, in push order.
+    pub fn commands(&self) -> &[DrawCmd] {
+        &self.commands
+    }
+
+    /// Move recorded commands out of the context, leaving it empty.
+    pub fn take_commands(&mut self) -> Vec<DrawCmd> {
+        std::mem::take(&mut self.commands)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rect_contains_uses_half_open_edges() {
+        let r = Rect::xywh(10.0, 20.0, 30.0, 40.0);
+        assert!(r.contains(Point::new(10.0, 20.0)), "top-left inclusive");
+        assert!(r.contains(Point::new(39.999, 59.999)), "interior");
+        assert!(
+            !r.contains(Point::new(40.0, 60.0)),
+            "bottom-right exclusive"
+        );
+        assert!(!r.contains(Point::new(9.0, 20.0)), "outside left");
+    }
+
+    #[test]
+    fn paint_ctx_records_commands_in_order() {
+        let mut ctx = PaintCtx::new();
+        ctx.fill_rect(Rect::xywh(0.0, 0.0, 10.0, 10.0), Color::WHITE);
+        ctx.text(Point::new(2.0, 2.0), "hi", Color::BLACK);
+        assert_eq!(ctx.commands().len(), 2);
+        assert!(matches!(ctx.commands()[0], DrawCmd::FillRect { .. }));
+        assert!(matches!(ctx.commands()[1], DrawCmd::Text { .. }));
+    }
+
+    #[test]
+    fn paint_ctx_take_commands_empties_context() {
+        let mut ctx = PaintCtx::new();
+        ctx.fill_rect(Rect::ZERO, Color::WHITE);
+        let cmds = ctx.take_commands();
+        assert_eq!(cmds.len(), 1);
+        assert!(ctx.commands().is_empty());
+    }
+}

--- a/crates/beast-ui/src/widget.rs
+++ b/crates/beast-ui/src/widget.rs
@@ -25,7 +25,12 @@ pub use list::{List, ListItem};
 /// integer ids (entities, sprites, primitives). Allocate via [`IdAllocator`]
 /// — never construct a [`WidgetId`] from a hand-picked literal in non-test
 /// code, since collisions silently break event routing.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+///
+/// Carries serde derives so future widget-tree save/restore work doesn't
+/// hit a breaking change adding them.
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct WidgetId(u32);
 
 impl WidgetId {
@@ -79,6 +84,16 @@ impl Default for IdAllocator {
     }
 }
 
+/// Layout-time context passed to [`Widget::measure`].
+///
+/// S10.1 ships a stub — the real `LayoutCtx` (font metrics, viewport
+/// scale, available DPI) lands with the layout engine in S10.2. Threading
+/// the parameter through the trait now means S10.2 can extend it without
+/// a breaking trait change.
+#[derive(Copy, Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct LayoutCtx {}
+
 /// Retained-mode widget contract.
 ///
 /// Widgets are pure data + pure dispatch. The trait is object-safe so a
@@ -106,9 +121,10 @@ pub trait Widget {
 
     /// Intrinsic minimum + preferred size used by the layout pass.
     ///
-    /// S10.1 returns a single [`Size`]; S10.2 will extend this to handle
-    /// flex-style min / max constraints.
-    fn measure(&self) -> Size;
+    /// S10.1 ignores `ctx` and returns a heuristic [`Size`]; S10.2 will
+    /// fill in [`LayoutCtx`] with font metrics + viewport scale and
+    /// extend the return shape with flex-style min / max constraints.
+    fn measure(&self, ctx: &LayoutCtx) -> Size;
 
     /// Render the widget by pushing draw commands into `ctx`.
     fn paint(&self, ctx: &mut PaintCtx);

--- a/crates/beast-ui/src/widget.rs
+++ b/crates/beast-ui/src/widget.rs
@@ -1,0 +1,152 @@
+//! Widget trait + primitive widgets (Button, Label, List, Card, Dialog).
+//!
+//! See `documentation/systems/23_ui_overview.md` §3.2 for the design spec.
+//! This module is split across submodules per primitive; the trait and
+//! shared id machinery live here.
+
+use crate::event::{EventResult, UiEvent};
+use crate::paint::{PaintCtx, Rect, Size};
+
+mod button;
+mod card;
+mod dialog;
+mod label;
+mod list;
+
+pub use button::Button;
+pub use card::Card;
+pub use dialog::Dialog;
+pub use label::Label;
+pub use list::{List, ListItem};
+
+/// Stable, globally unique identifier for a widget.
+///
+/// Newtype around `u32` to keep widget ids out of lane traffic with other
+/// integer ids (entities, sprites, primitives). Allocate via [`IdAllocator`]
+/// — never construct a [`WidgetId`] from a hand-picked literal in non-test
+/// code, since collisions silently break event routing.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WidgetId(u32);
+
+impl WidgetId {
+    /// Construct a [`WidgetId`] from a raw `u32`. Tests only — production
+    /// code allocates ids through [`IdAllocator::next`].
+    #[doc(hidden)]
+    pub const fn from_raw(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Raw underlying integer.
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+/// Deterministic monotonic id allocator.
+///
+/// Allocates ids in ascending order starting from `1` (id `0` is reserved
+/// for "no id" in tree code). 4 billion widgets per session is well past
+/// any realistic usage; if the counter does wrap, we panic on the next
+/// allocation rather than silently colliding.
+///
+/// `Default` is provided as an alias for [`IdAllocator::new`] so callers
+/// can use either; both start the counter at `1`.
+#[derive(Clone, Debug)]
+pub struct IdAllocator {
+    next: u32,
+}
+
+impl IdAllocator {
+    /// Construct an allocator at id `1`.
+    pub fn new() -> Self {
+        Self { next: 1 }
+    }
+
+    /// Reserve and return the next [`WidgetId`].
+    pub fn allocate(&mut self) -> WidgetId {
+        let id = self.next;
+        self.next = self
+            .next
+            .checked_add(1)
+            .expect("WidgetId allocator overflowed u32::MAX widget ids");
+        WidgetId(id)
+    }
+}
+
+impl Default for IdAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Retained-mode widget contract.
+///
+/// Widgets are pure data + pure dispatch. The trait is object-safe so a
+/// future `WidgetTree` (S10.2) can store children behind `Box<dyn Widget>`
+/// without monomorphisation.
+///
+/// # Determinism
+///
+/// `paint` and `handle_event` must be deterministic functions of widget
+/// state + input. Widget primitives in this crate keep no hidden state
+/// (e.g. internal counters, timers) — anything time-varying lives in the
+/// caller's data binding.
+pub trait Widget {
+    /// Stable id assigned to this widget.
+    fn id(&self) -> WidgetId;
+
+    /// The widget's screen-space bounds. Set by the layout pass; the
+    /// default getter returns the cached bounds and the setter updates
+    /// them.
+    fn bounds(&self) -> Rect;
+
+    /// Update the widget's screen-space bounds. Called by the layout pass
+    /// (S10.2); paint pulls these back out via `bounds()`.
+    fn set_bounds(&mut self, bounds: Rect);
+
+    /// Intrinsic minimum + preferred size used by the layout pass.
+    ///
+    /// S10.1 returns a single [`Size`]; S10.2 will extend this to handle
+    /// flex-style min / max constraints.
+    fn measure(&self) -> Size;
+
+    /// Render the widget by pushing draw commands into `ctx`.
+    fn paint(&self, ctx: &mut PaintCtx);
+
+    /// Process an input event. Returns whether the widget consumed the
+    /// event ([`EventResult::Consumed`]) or wants it to bubble
+    /// ([`EventResult::Ignored`]).
+    fn handle_event(&mut self, event: &UiEvent) -> EventResult;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_allocator_is_monotonic_and_starts_at_one() {
+        let mut a = IdAllocator::new();
+        assert_eq!(a.allocate().raw(), 1);
+        assert_eq!(a.allocate().raw(), 2);
+        assert_eq!(a.allocate().raw(), 3);
+    }
+
+    #[test]
+    fn widget_ids_are_orderable() {
+        let mut a = IdAllocator::new();
+        let first = a.allocate();
+        let second = a.allocate();
+        assert!(first < second);
+    }
+
+    #[test]
+    fn id_allocator_default_matches_new() {
+        let from_new = IdAllocator::new();
+        let from_default = IdAllocator::default();
+        // `next` field is private; both should behave identically when we
+        // pull the first id.
+        let mut a = from_new;
+        let mut b = from_default;
+        assert_eq!(a.allocate(), b.allocate());
+    }
+}

--- a/crates/beast-ui/src/widget/button.rs
+++ b/crates/beast-ui/src/widget/button.rs
@@ -10,7 +10,7 @@
 use crate::event::{EventResult, MouseButton, UiEvent};
 use crate::paint::{Color, PaintCtx, Rect, Size};
 
-use super::{Widget, WidgetId};
+use super::{LayoutCtx, Widget, WidgetId};
 
 /// Button primitive. Stores its label, enabled state, and a press counter
 /// instead of a `Box<dyn FnMut>` callback — this keeps the widget
@@ -95,9 +95,9 @@ impl Widget for Button {
         self.bounds = bounds;
     }
 
-    fn measure(&self) -> Size {
+    fn measure(&self, _ctx: &LayoutCtx) -> Size {
         // Heuristic: 8 px per glyph + 16 px padding, fixed 32 px tall.
-        // Layout (S10.2) will replace this with text metrics.
+        // Layout (S10.2) will replace this with text metrics from `ctx`.
         Size::new(self.label.chars().count() as f32 * 8.0 + 16.0, 32.0)
     }
 
@@ -113,7 +113,7 @@ impl Widget for Button {
         ctx.stroke_rect(self.bounds, Color::BLACK);
         let text_pos =
             crate::paint::Point::new(self.bounds.origin.x + 8.0, self.bounds.origin.y + 8.0);
-        ctx.text(text_pos, self.label.clone(), Color::WHITE);
+        ctx.text(text_pos, self.label.as_str(), Color::WHITE);
     }
 
     fn handle_event(&mut self, event: &UiEvent) -> EventResult {

--- a/crates/beast-ui/src/widget/button.rs
+++ b/crates/beast-ui/src/widget/button.rs
@@ -1,0 +1,234 @@
+//! Pressable button widget.
+//!
+//! Click semantics:
+//!   * `MouseDown` over `bounds()` while enabled → `pressed = true`,
+//!     event consumed.
+//!   * `MouseUp` while `pressed` → fires the on-press callback (a counter
+//!     increment in tests), clears `pressed`, event consumed.
+//!   * Any other input bubbles.
+
+use crate::event::{EventResult, MouseButton, UiEvent};
+use crate::paint::{Color, PaintCtx, Rect, Size};
+
+use super::{Widget, WidgetId};
+
+/// Button primitive. Stores its label, enabled state, and a press counter
+/// instead of a `Box<dyn FnMut>` callback — this keeps the widget
+/// `Clone + Debug + Send` and lets tests assert on observable state
+/// without juggling channel ends.
+#[derive(Clone, Debug)]
+pub struct Button {
+    id: WidgetId,
+    bounds: Rect,
+    label: String,
+    enabled: bool,
+    pressed: bool,
+    press_count: u32,
+    last_cursor_x: f32,
+    last_cursor_y: f32,
+}
+
+impl Button {
+    /// Construct an enabled button with the given label.
+    pub fn new(id: WidgetId, label: impl Into<String>) -> Self {
+        Self {
+            id,
+            bounds: Rect::ZERO,
+            label: label.into(),
+            enabled: true,
+            pressed: false,
+            press_count: 0,
+            last_cursor_x: f32::NAN,
+            last_cursor_y: f32::NAN,
+        }
+    }
+
+    /// Mark the button as disabled. Disabled buttons paint dimmed and
+    /// ignore input.
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Whether the button is currently in the down (pressed) state.
+    pub fn is_pressed(&self) -> bool {
+        self.pressed
+    }
+
+    /// Number of completed press cycles (down → up). Tests use this in
+    /// place of an `on_press` closure.
+    pub fn press_count(&self) -> u32 {
+        self.press_count
+    }
+
+    /// Whether the button is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// The button's label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn cursor_inside_bounds(&self) -> bool {
+        if self.last_cursor_x.is_nan() {
+            return false;
+        }
+        self.bounds.contains(crate::paint::Point::new(
+            self.last_cursor_x,
+            self.last_cursor_y,
+        ))
+    }
+}
+
+impl Widget for Button {
+    fn id(&self) -> WidgetId {
+        self.id
+    }
+
+    fn bounds(&self) -> Rect {
+        self.bounds
+    }
+
+    fn set_bounds(&mut self, bounds: Rect) {
+        self.bounds = bounds;
+    }
+
+    fn measure(&self) -> Size {
+        // Heuristic: 8 px per glyph + 16 px padding, fixed 32 px tall.
+        // Layout (S10.2) will replace this with text metrics.
+        Size::new(self.label.chars().count() as f32 * 8.0 + 16.0, 32.0)
+    }
+
+    fn paint(&self, ctx: &mut PaintCtx) {
+        let bg = if !self.enabled {
+            Color::rgba(0.6, 0.6, 0.6, 1.0)
+        } else if self.pressed {
+            Color::rgba(0.2, 0.4, 0.8, 1.0)
+        } else {
+            Color::rgba(0.3, 0.5, 0.9, 1.0)
+        };
+        ctx.fill_rect(self.bounds, bg);
+        ctx.stroke_rect(self.bounds, Color::BLACK);
+        let text_pos =
+            crate::paint::Point::new(self.bounds.origin.x + 8.0, self.bounds.origin.y + 8.0);
+        ctx.text(text_pos, self.label.clone(), Color::WHITE);
+    }
+
+    fn handle_event(&mut self, event: &UiEvent) -> EventResult {
+        if !self.enabled {
+            return EventResult::Ignored;
+        }
+        match event {
+            UiEvent::MouseMove { x, y } => {
+                self.last_cursor_x = *x;
+                self.last_cursor_y = *y;
+                EventResult::Ignored
+            }
+            UiEvent::MouseDown {
+                button: MouseButton::Primary,
+            } if self.cursor_inside_bounds() => {
+                self.pressed = true;
+                EventResult::Consumed
+            }
+            UiEvent::MouseUp {
+                button: MouseButton::Primary,
+            } if self.pressed => {
+                self.pressed = false;
+                if self.cursor_inside_bounds() {
+                    self.press_count = self.press_count.saturating_add(1);
+                }
+                EventResult::Consumed
+            }
+            _ => EventResult::Ignored,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widget::IdAllocator;
+
+    fn make() -> (Button, IdAllocator) {
+        let mut ids = IdAllocator::new();
+        let mut b = Button::new(ids.allocate(), "click me");
+        b.set_bounds(Rect::xywh(10.0, 20.0, 100.0, 30.0));
+        (b, ids)
+    }
+
+    #[test]
+    fn click_inside_bounds_increments_press_count() {
+        let (mut b, _) = make();
+        b.handle_event(&UiEvent::MouseMove { x: 50.0, y: 35.0 });
+        assert_eq!(
+            b.handle_event(&UiEvent::MouseDown {
+                button: MouseButton::Primary,
+            }),
+            EventResult::Consumed
+        );
+        assert!(b.is_pressed());
+        assert_eq!(
+            b.handle_event(&UiEvent::MouseUp {
+                button: MouseButton::Primary,
+            }),
+            EventResult::Consumed
+        );
+        assert!(!b.is_pressed());
+        assert_eq!(b.press_count(), 1);
+    }
+
+    #[test]
+    fn click_outside_bounds_does_not_press() {
+        let (mut b, _) = make();
+        b.handle_event(&UiEvent::MouseMove { x: 5.0, y: 5.0 });
+        assert_eq!(
+            b.handle_event(&UiEvent::MouseDown {
+                button: MouseButton::Primary,
+            }),
+            EventResult::Ignored
+        );
+        assert_eq!(b.press_count(), 0);
+    }
+
+    #[test]
+    fn disabled_button_ignores_clicks() {
+        let mut ids = IdAllocator::new();
+        let mut b = Button::new(ids.allocate(), "x").with_enabled(false);
+        b.set_bounds(Rect::xywh(0.0, 0.0, 10.0, 10.0));
+        b.handle_event(&UiEvent::MouseMove { x: 5.0, y: 5.0 });
+        let r = b.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Ignored);
+        assert_eq!(b.press_count(), 0);
+    }
+
+    #[test]
+    fn drag_off_cancels_press_without_firing() {
+        let (mut b, _) = make();
+        b.handle_event(&UiEvent::MouseMove { x: 50.0, y: 35.0 });
+        b.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        // Drag the cursor outside the bounds before releasing.
+        b.handle_event(&UiEvent::MouseMove { x: 200.0, y: 300.0 });
+        b.handle_event(&UiEvent::MouseUp {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(b.press_count(), 0, "drag-off should not fire press");
+    }
+
+    #[test]
+    fn paint_emits_fill_stroke_text_in_order() {
+        let (b, _) = make();
+        let mut ctx = PaintCtx::new();
+        b.paint(&mut ctx);
+        let cmds = ctx.commands();
+        assert_eq!(cmds.len(), 3);
+        assert!(matches!(cmds[0], crate::paint::DrawCmd::FillRect { .. }));
+        assert!(matches!(cmds[1], crate::paint::DrawCmd::StrokeRect { .. }));
+        assert!(matches!(cmds[2], crate::paint::DrawCmd::Text { .. }));
+    }
+}

--- a/crates/beast-ui/src/widget/card.rs
+++ b/crates/beast-ui/src/widget/card.rs
@@ -8,7 +8,7 @@
 use crate::event::{EventResult, UiEvent};
 use crate::paint::{Color, PaintCtx, Point, Rect, Size};
 
-use super::{Widget, WidgetId};
+use super::{LayoutCtx, Widget, WidgetId};
 
 const TITLE_BAR_HEIGHT: f32 = 20.0;
 
@@ -78,12 +78,12 @@ impl Widget for Card {
         self.bounds = bounds;
     }
 
-    fn measure(&self) -> Size {
+    fn measure(&self, ctx: &LayoutCtx) -> Size {
         // Title bar plus the bounding box of all child measurements.
         let mut max_w = 0.0_f32;
         let mut total_h = 0.0_f32;
         for child in &self.children {
-            let s = child.measure();
+            let s = child.measure(ctx);
             max_w = max_w.max(s.width);
             total_h += s.height;
         }
@@ -105,7 +105,7 @@ impl Widget for Card {
         ctx.fill_rect(title_rect, Color::rgb(0.85, 0.85, 0.92));
         ctx.text(
             Point::new(self.bounds.origin.x + 4.0, self.bounds.origin.y + 2.0),
-            self.title.clone(),
+            self.title.as_str(),
             Color::BLACK,
         );
         for child in &self.children {
@@ -183,9 +183,10 @@ mod tests {
         let mut ids = IdAllocator::new();
         let mut card = Card::new(ids.allocate(), "x");
         let button = Button::new(ids.allocate(), "wide button label");
-        let measured_button = button.measure();
+        let lc = LayoutCtx::default();
+        let measured_button = button.measure(&lc);
         card.push_child(Box::new(button));
-        let measured = card.measure();
+        let measured = card.measure(&lc);
         assert!(measured.width >= measured_button.width);
         assert!(measured.height >= measured_button.height + TITLE_BAR_HEIGHT);
     }

--- a/crates/beast-ui/src/widget/card.rs
+++ b/crates/beast-ui/src/widget/card.rs
@@ -1,0 +1,192 @@
+//! Container card with a title bar and child widgets.
+//!
+//! S10.1 ships the data model + paint pass. Layout of the children inside
+//! the card is the responsibility of the layout engine in S10.2; for now
+//! the card simply paints its title and forwards events to children
+//! whose bounds the cursor is inside.
+
+use crate::event::{EventResult, UiEvent};
+use crate::paint::{Color, PaintCtx, Point, Rect, Size};
+
+use super::{Widget, WidgetId};
+
+const TITLE_BAR_HEIGHT: f32 = 20.0;
+
+/// Card container. Holds a title and a list of `Box<dyn Widget>` children.
+pub struct Card {
+    id: WidgetId,
+    bounds: Rect,
+    title: String,
+    children: Vec<Box<dyn Widget>>,
+    last_cursor: Option<Point>,
+}
+
+impl Card {
+    /// Construct a card with the given title.
+    pub fn new(id: WidgetId, title: impl Into<String>) -> Self {
+        Self {
+            id,
+            bounds: Rect::ZERO,
+            title: title.into(),
+            children: Vec::new(),
+            last_cursor: None,
+        }
+    }
+
+    /// Append a child widget. Children are stored in declaration order.
+    pub fn push_child(&mut self, child: Box<dyn Widget>) {
+        self.children.push(child);
+    }
+
+    /// Number of children.
+    pub fn child_count(&self) -> usize {
+        self.children.len()
+    }
+
+    /// Title text.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Read-only access to the children (for layout / introspection).
+    pub fn children(&self) -> &[Box<dyn Widget>] {
+        &self.children
+    }
+}
+
+impl std::fmt::Debug for Card {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Card")
+            .field("id", &self.id)
+            .field("title", &self.title)
+            .field("bounds", &self.bounds)
+            .field("children", &self.children.len())
+            .finish()
+    }
+}
+
+impl Widget for Card {
+    fn id(&self) -> WidgetId {
+        self.id
+    }
+
+    fn bounds(&self) -> Rect {
+        self.bounds
+    }
+
+    fn set_bounds(&mut self, bounds: Rect) {
+        self.bounds = bounds;
+    }
+
+    fn measure(&self) -> Size {
+        // Title bar plus the bounding box of all child measurements.
+        let mut max_w = 0.0_f32;
+        let mut total_h = 0.0_f32;
+        for child in &self.children {
+            let s = child.measure();
+            max_w = max_w.max(s.width);
+            total_h += s.height;
+        }
+        Size::new(
+            max_w.max(self.title.chars().count() as f32 * 8.0),
+            TITLE_BAR_HEIGHT + total_h,
+        )
+    }
+
+    fn paint(&self, ctx: &mut PaintCtx) {
+        // Card background + 1px border.
+        ctx.fill_rect(self.bounds, Color::rgb(1.0, 1.0, 1.0));
+        ctx.stroke_rect(self.bounds, Color::BLACK);
+        // Title bar.
+        let title_rect = Rect::new(
+            self.bounds.origin,
+            Size::new(self.bounds.size.width, TITLE_BAR_HEIGHT),
+        );
+        ctx.fill_rect(title_rect, Color::rgb(0.85, 0.85, 0.92));
+        ctx.text(
+            Point::new(self.bounds.origin.x + 4.0, self.bounds.origin.y + 2.0),
+            self.title.clone(),
+            Color::BLACK,
+        );
+        for child in &self.children {
+            child.paint(ctx);
+        }
+    }
+
+    fn handle_event(&mut self, event: &UiEvent) -> EventResult {
+        if let UiEvent::MouseMove { x, y } = event {
+            self.last_cursor = Some(Point::new(*x, *y));
+        }
+        // Forward to children in reverse declaration order so the
+        // last-painted child gets first crack at the event (canonical
+        // top-most-takes-it model).
+        for child in self.children.iter_mut().rev() {
+            // Always forward MouseMove so children can update their own
+            // cursor caches.
+            let inside = matches!(event, UiEvent::MouseMove { .. })
+                || self
+                    .last_cursor
+                    .map(|c| child.bounds().contains(c))
+                    .unwrap_or(false);
+            if inside && child.handle_event(event) == EventResult::Consumed {
+                return EventResult::Consumed;
+            }
+        }
+        EventResult::Ignored
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::MouseButton;
+    use crate::widget::{Button, IdAllocator};
+
+    #[test]
+    fn card_paints_background_border_and_title() {
+        let mut ids = IdAllocator::new();
+        let mut card = Card::new(ids.allocate(), "Stats");
+        card.set_bounds(Rect::xywh(0.0, 0.0, 100.0, 60.0));
+        let mut ctx = PaintCtx::new();
+        card.paint(&mut ctx);
+        // 4 commands: card fill, card stroke, title fill, title text.
+        assert_eq!(ctx.commands().len(), 4);
+    }
+
+    #[test]
+    fn card_forwards_clicks_to_top_most_child() {
+        let mut ids = IdAllocator::new();
+        let mut card = Card::new(ids.allocate(), "host");
+        card.set_bounds(Rect::xywh(0.0, 0.0, 200.0, 200.0));
+
+        let mut top = Button::new(ids.allocate(), "top");
+        top.set_bounds(Rect::xywh(0.0, 30.0, 50.0, 30.0));
+        let mut bottom = Button::new(ids.allocate(), "bottom");
+        bottom.set_bounds(Rect::xywh(0.0, 30.0, 50.0, 30.0));
+        card.push_child(Box::new(bottom));
+        card.push_child(Box::new(top));
+
+        card.handle_event(&UiEvent::MouseMove { x: 25.0, y: 45.0 });
+        let r = card.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Consumed);
+        // Only the *top* button should have registered the press; we
+        // can't peek at it directly because the trait object hides type,
+        // but if both fired the second event would still be Consumed —
+        // which is the contract. So this test pins the bubble-stops-at-
+        // first-Consumed behavior.
+    }
+
+    #[test]
+    fn card_measure_accounts_for_children_and_title() {
+        let mut ids = IdAllocator::new();
+        let mut card = Card::new(ids.allocate(), "x");
+        let button = Button::new(ids.allocate(), "wide button label");
+        let measured_button = button.measure();
+        card.push_child(Box::new(button));
+        let measured = card.measure();
+        assert!(measured.width >= measured_button.width);
+        assert!(measured.height >= measured_button.height + TITLE_BAR_HEIGHT);
+    }
+}

--- a/crates/beast-ui/src/widget/dialog.rs
+++ b/crates/beast-ui/src/widget/dialog.rs
@@ -8,7 +8,7 @@
 use crate::event::{EventResult, UiEvent};
 use crate::paint::{Color, PaintCtx, Point, Rect, Size};
 
-use super::{Card, Widget, WidgetId};
+use super::{Card, LayoutCtx, Widget, WidgetId};
 
 /// Dialog overlay wrapping a [`Card`].
 pub struct Dialog {
@@ -60,19 +60,18 @@ impl Widget for Dialog {
         self.inner.set_bounds(bounds);
     }
 
-    fn measure(&self) -> Size {
-        self.inner.measure()
+    fn measure(&self, ctx: &LayoutCtx) -> Size {
+        self.inner.measure(ctx)
     }
 
     fn paint(&self, ctx: &mut PaintCtx) {
         if self.modal {
-            // Dim the rest of the screen behind the dialog. The screen
-            // bounds aren't known here yet (S10.2 will add a layout-time
-            // viewport hand-off), so for now we paint the scrim using
-            // the dialog's own bounds expanded by a scrim rect at
-            // (-100k, -100k, 200k, 200k). It's overkill in pixel terms
-            // but keeps the recorded command set deterministic. A proper
-            // viewport-relative scrim lands with the WidgetTree.
+            // TODO(S10.2): replace this with a viewport-relative scrim.
+            // The WidgetTree will hand layout a real viewport rect; for
+            // S10.1 we approximate "everything outside the dialog" with
+            // an oversized rect anchored at (-100k, -100k). Overkill in
+            // pixel terms but keeps the recorded command set
+            // deterministic and snapshots stable.
             ctx.fill_rect(
                 Rect::xywh(-100_000.0, -100_000.0, 200_000.0, 200_000.0),
                 Color::rgba(0.0, 0.0, 0.0, 0.4),

--- a/crates/beast-ui/src/widget/dialog.rs
+++ b/crates/beast-ui/src/widget/dialog.rs
@@ -1,0 +1,163 @@
+//! Modal / non-modal dialog overlay.
+//!
+//! When `modal == true`, the dialog consumes any input event whose target
+//! falls *outside* its own bounds — this is what stops widgets behind a
+//! modal dialog from receiving clicks. Non-modal dialogs let everything
+//! bubble.
+
+use crate::event::{EventResult, UiEvent};
+use crate::paint::{Color, PaintCtx, Point, Rect, Size};
+
+use super::{Card, Widget, WidgetId};
+
+/// Dialog overlay wrapping a [`Card`].
+pub struct Dialog {
+    inner: Card,
+    modal: bool,
+    last_cursor: Option<Point>,
+}
+
+impl Dialog {
+    /// Construct a dialog with the given title and modality.
+    pub fn new(id: WidgetId, title: impl Into<String>, modal: bool) -> Self {
+        Self {
+            inner: Card::new(id, title),
+            modal,
+            last_cursor: None,
+        }
+    }
+
+    /// Whether the dialog is modal (eats outside events).
+    pub fn is_modal(&self) -> bool {
+        self.modal
+    }
+
+    /// Append a child widget — delegates to the wrapped [`Card`].
+    pub fn push_child(&mut self, child: Box<dyn Widget>) {
+        self.inner.push_child(child);
+    }
+}
+
+impl std::fmt::Debug for Dialog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dialog")
+            .field("inner", &self.inner)
+            .field("modal", &self.modal)
+            .finish()
+    }
+}
+
+impl Widget for Dialog {
+    fn id(&self) -> WidgetId {
+        self.inner.id()
+    }
+
+    fn bounds(&self) -> Rect {
+        self.inner.bounds()
+    }
+
+    fn set_bounds(&mut self, bounds: Rect) {
+        self.inner.set_bounds(bounds);
+    }
+
+    fn measure(&self) -> Size {
+        self.inner.measure()
+    }
+
+    fn paint(&self, ctx: &mut PaintCtx) {
+        if self.modal {
+            // Dim the rest of the screen behind the dialog. The screen
+            // bounds aren't known here yet (S10.2 will add a layout-time
+            // viewport hand-off), so for now we paint the scrim using
+            // the dialog's own bounds expanded by a scrim rect at
+            // (-100k, -100k, 200k, 200k). It's overkill in pixel terms
+            // but keeps the recorded command set deterministic. A proper
+            // viewport-relative scrim lands with the WidgetTree.
+            ctx.fill_rect(
+                Rect::xywh(-100_000.0, -100_000.0, 200_000.0, 200_000.0),
+                Color::rgba(0.0, 0.0, 0.0, 0.4),
+            );
+        }
+        self.inner.paint(ctx);
+    }
+
+    fn handle_event(&mut self, event: &UiEvent) -> EventResult {
+        if let UiEvent::MouseMove { x, y } = event {
+            self.last_cursor = Some(Point::new(*x, *y));
+        }
+        let inner_result = self.inner.handle_event(event);
+        if inner_result == EventResult::Consumed {
+            return EventResult::Consumed;
+        }
+        // If we're modal and the event targets outside the dialog, eat it
+        // anyway so back-of-stack widgets never see it. MouseMove still
+        // bubbles because it never carries a target point check here —
+        // tests assert on the click-through-modal contract.
+        if self.modal {
+            match event {
+                UiEvent::MouseDown { .. } | UiEvent::MouseUp { .. } => {
+                    let cursor_outside = self
+                        .last_cursor
+                        .map(|c| !self.bounds().contains(c))
+                        .unwrap_or(false);
+                    if cursor_outside {
+                        return EventResult::Consumed;
+                    }
+                }
+                UiEvent::KeyDown(_) | UiEvent::KeyUp(_) | UiEvent::TextInput(_) => {
+                    return EventResult::Consumed;
+                }
+                _ => {}
+            }
+        }
+        EventResult::Ignored
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::MouseButton;
+    use crate::widget::{Button, IdAllocator};
+
+    fn fixture(modal: bool) -> Dialog {
+        let mut ids = IdAllocator::new();
+        let mut dlg = Dialog::new(ids.allocate(), "Confirm", modal);
+        dlg.set_bounds(Rect::xywh(40.0, 40.0, 100.0, 100.0));
+        let mut ok = Button::new(ids.allocate(), "ok");
+        ok.set_bounds(Rect::xywh(50.0, 100.0, 40.0, 20.0));
+        dlg.push_child(Box::new(ok));
+        dlg
+    }
+
+    #[test]
+    fn modal_dialog_eats_outside_clicks() {
+        let mut dlg = fixture(true);
+        dlg.handle_event(&UiEvent::MouseMove { x: 10.0, y: 10.0 });
+        let r = dlg.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Consumed);
+    }
+
+    #[test]
+    fn modal_dialog_lets_inside_clicks_through_to_children() {
+        let mut dlg = fixture(true);
+        // Cursor on the OK button inside the dialog.
+        dlg.handle_event(&UiEvent::MouseMove { x: 60.0, y: 110.0 });
+        let r = dlg.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Consumed);
+    }
+
+    #[test]
+    fn nonmodal_dialog_lets_outside_clicks_bubble() {
+        let mut dlg = fixture(false);
+        dlg.handle_event(&UiEvent::MouseMove { x: 10.0, y: 10.0 });
+        let r = dlg.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Ignored);
+    }
+}

--- a/crates/beast-ui/src/widget/label.rs
+++ b/crates/beast-ui/src/widget/label.rs
@@ -1,0 +1,119 @@
+//! Static text label.
+//!
+//! [`Label`] is the simplest primitive: it holds a string and renders it.
+//! It never consumes events.
+
+use crate::event::{EventResult, UiEvent};
+use crate::paint::{Color, PaintCtx, Point, Rect, Size};
+
+use super::{Widget, WidgetId};
+
+/// Static text widget. Doesn't react to input.
+#[derive(Clone, Debug)]
+pub struct Label {
+    id: WidgetId,
+    bounds: Rect,
+    text: String,
+    color: Color,
+}
+
+impl Label {
+    /// Construct a label with the given text. Bounds default to zero —
+    /// the layout pass (S10.2) is responsible for assigning real bounds.
+    pub fn new(id: WidgetId, text: impl Into<String>) -> Self {
+        Self {
+            id,
+            bounds: Rect::ZERO,
+            text: text.into(),
+            color: Color::BLACK,
+        }
+    }
+
+    /// Override the default text color. Returns `self` for chaining.
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Replace the label's text.
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        self.text = text.into();
+    }
+
+    /// Read the current text.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+impl Widget for Label {
+    fn id(&self) -> WidgetId {
+        self.id
+    }
+
+    fn bounds(&self) -> Rect {
+        self.bounds
+    }
+
+    fn set_bounds(&mut self, bounds: Rect) {
+        self.bounds = bounds;
+    }
+
+    fn measure(&self) -> Size {
+        // S10.2 will replace this with real text metrics. For S10.1 we
+        // just return a constant-height row sized to a heuristic
+        // 8px-per-char estimate so layout tests have *some* signal.
+        Size::new(self.text.chars().count() as f32 * 8.0, 16.0)
+    }
+
+    fn paint(&self, ctx: &mut PaintCtx) {
+        ctx.text(
+            Point::new(self.bounds.origin.x, self.bounds.origin.y),
+            self.text.clone(),
+            self.color,
+        );
+    }
+
+    fn handle_event(&mut self, _event: &UiEvent) -> EventResult {
+        EventResult::Ignored
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::DrawCmd;
+    use crate::widget::IdAllocator;
+
+    #[test]
+    fn label_paints_its_text() {
+        let mut ids = IdAllocator::new();
+        let mut label = Label::new(ids.allocate(), "hello");
+        label.set_bounds(Rect::xywh(2.0, 3.0, 100.0, 16.0));
+        let mut ctx = PaintCtx::new();
+        label.paint(&mut ctx);
+        match &ctx.commands()[0] {
+            DrawCmd::Text { text, pos, .. } => {
+                assert_eq!(text, "hello");
+                assert_eq!(*pos, Point::new(2.0, 3.0));
+            }
+            other => panic!("expected text draw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_ignores_all_events() {
+        let mut ids = IdAllocator::new();
+        let mut label = Label::new(ids.allocate(), "x");
+        let result = label.handle_event(&UiEvent::Tick { dt_ms: 16 });
+        assert_eq!(result, EventResult::Ignored);
+    }
+
+    #[test]
+    fn measure_scales_with_text_length() {
+        let mut ids = IdAllocator::new();
+        let short = Label::new(ids.allocate(), "ab");
+        let long = Label::new(ids.allocate(), "abcdefgh");
+        assert!(long.measure().width > short.measure().width);
+    }
+}

--- a/crates/beast-ui/src/widget/label.rs
+++ b/crates/beast-ui/src/widget/label.rs
@@ -6,7 +6,7 @@
 use crate::event::{EventResult, UiEvent};
 use crate::paint::{Color, PaintCtx, Point, Rect, Size};
 
-use super::{Widget, WidgetId};
+use super::{LayoutCtx, Widget, WidgetId};
 
 /// Static text widget. Doesn't react to input.
 #[derive(Clone, Debug)]
@@ -59,17 +59,17 @@ impl Widget for Label {
         self.bounds = bounds;
     }
 
-    fn measure(&self) -> Size {
-        // S10.2 will replace this with real text metrics. For S10.1 we
-        // just return a constant-height row sized to a heuristic
-        // 8px-per-char estimate so layout tests have *some* signal.
+    fn measure(&self, _ctx: &LayoutCtx) -> Size {
+        // S10.2 will pull font metrics from `ctx`. For S10.1 we just
+        // return a constant-height row sized to a heuristic 8px-per-char
+        // estimate so layout tests have *some* signal.
         Size::new(self.text.chars().count() as f32 * 8.0, 16.0)
     }
 
     fn paint(&self, ctx: &mut PaintCtx) {
         ctx.text(
             Point::new(self.bounds.origin.x, self.bounds.origin.y),
-            self.text.clone(),
+            self.text.as_str(),
             self.color,
         );
     }
@@ -114,6 +114,7 @@ mod tests {
         let mut ids = IdAllocator::new();
         let short = Label::new(ids.allocate(), "ab");
         let long = Label::new(ids.allocate(), "abcdefgh");
-        assert!(long.measure().width > short.measure().width);
+        let lc = LayoutCtx::default();
+        assert!(long.measure(&lc).width > short.measure(&lc).width);
     }
 }

--- a/crates/beast-ui/src/widget/list.rs
+++ b/crates/beast-ui/src/widget/list.rs
@@ -1,0 +1,288 @@
+//! Selectable scrollable list of items.
+//!
+//! S10.1 implements the data model + selection mutation + a basic paint
+//! pass. Real scrolling, virtualization, and filtering land alongside
+//! S10.4 screens; this story keeps the surface minimal so the bestiary
+//! can later replace items + selection without re-allocating the list.
+
+use crate::event::{EventResult, KeyCode, MouseButton, UiEvent};
+use crate::paint::{Color, PaintCtx, Point, Rect, Size};
+
+use super::{Widget, WidgetId};
+
+/// One row in a [`List`]. Concrete payload is generic so callers can store
+/// bestiary entries, faction summaries, etc., without erasing types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ListItem<T> {
+    /// Display label.
+    pub label: String,
+    /// Caller-attached payload retrieved via [`List::selected`].
+    pub payload: T,
+}
+
+impl<T> ListItem<T> {
+    /// Construct a new list item.
+    pub fn new(label: impl Into<String>, payload: T) -> Self {
+        Self {
+            label: label.into(),
+            payload,
+        }
+    }
+}
+
+const ROW_HEIGHT: f32 = 20.0;
+
+/// Selectable list of `ListItem<T>`s.
+#[derive(Clone, Debug)]
+pub struct List<T> {
+    id: WidgetId,
+    bounds: Rect,
+    items: Vec<ListItem<T>>,
+    selected: Option<usize>,
+    last_cursor_y: f32,
+}
+
+impl<T> List<T> {
+    /// Construct an empty list.
+    pub fn new(id: WidgetId) -> Self {
+        Self {
+            id,
+            bounds: Rect::ZERO,
+            items: Vec::new(),
+            selected: None,
+            last_cursor_y: f32::NAN,
+        }
+    }
+
+    /// Replace the entire item set. If the previously selected index is
+    /// out of range it is cleared.
+    pub fn set_items(&mut self, items: Vec<ListItem<T>>) {
+        let len = items.len();
+        self.items = items;
+        if let Some(i) = self.selected {
+            if i >= len {
+                self.selected = None;
+            }
+        }
+    }
+
+    /// Append a single item.
+    pub fn push(&mut self, item: ListItem<T>) {
+        self.items.push(item);
+    }
+
+    /// Currently selected index, if any.
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Currently selected item, if any.
+    pub fn selected(&self) -> Option<&ListItem<T>> {
+        self.selected.and_then(|i| self.items.get(i))
+    }
+
+    /// Set the selected index. Out-of-range values clear the selection
+    /// rather than panicking.
+    pub fn set_selected(&mut self, index: Option<usize>) {
+        self.selected = match index {
+            Some(i) if i < self.items.len() => Some(i),
+            _ => None,
+        };
+    }
+
+    /// Number of items.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// True if the list has zero items.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Borrow the items for read-only iteration.
+    pub fn items(&self) -> &[ListItem<T>] {
+        &self.items
+    }
+
+    fn row_index_at(&self, y: f32) -> Option<usize> {
+        if !self.bounds.contains(Point::new(self.bounds.origin.x, y)) {
+            return None;
+        }
+        let local = y - self.bounds.origin.y;
+        let idx = (local / ROW_HEIGHT).floor() as i64;
+        if idx < 0 {
+            return None;
+        }
+        let idx = idx as usize;
+        if idx < self.items.len() {
+            Some(idx)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: Clone + std::fmt::Debug> Widget for List<T> {
+    fn id(&self) -> WidgetId {
+        self.id
+    }
+
+    fn bounds(&self) -> Rect {
+        self.bounds
+    }
+
+    fn set_bounds(&mut self, bounds: Rect) {
+        self.bounds = bounds;
+    }
+
+    fn measure(&self) -> Size {
+        Size::new(120.0, ROW_HEIGHT * self.items.len() as f32)
+    }
+
+    fn paint(&self, ctx: &mut PaintCtx) {
+        ctx.fill_rect(self.bounds, Color::rgb(0.95, 0.95, 0.95));
+        for (i, item) in self.items.iter().enumerate() {
+            let row_origin = Point::new(
+                self.bounds.origin.x,
+                self.bounds.origin.y + i as f32 * ROW_HEIGHT,
+            );
+            let row_rect = Rect::new(row_origin, Size::new(self.bounds.size.width, ROW_HEIGHT));
+            if Some(i) == self.selected {
+                ctx.fill_rect(row_rect, Color::rgba(0.3, 0.5, 0.9, 0.4));
+            }
+            ctx.text(
+                Point::new(row_origin.x + 4.0, row_origin.y + 2.0),
+                item.label.clone(),
+                Color::BLACK,
+            );
+        }
+    }
+
+    fn handle_event(&mut self, event: &UiEvent) -> EventResult {
+        match event {
+            UiEvent::MouseMove { y, .. } => {
+                self.last_cursor_y = *y;
+                EventResult::Ignored
+            }
+            UiEvent::MouseDown {
+                button: MouseButton::Primary,
+            } => {
+                if let Some(idx) = self.row_index_at(self.last_cursor_y) {
+                    self.selected = Some(idx);
+                    EventResult::Consumed
+                } else {
+                    EventResult::Ignored
+                }
+            }
+            UiEvent::KeyDown(modifiers) => match modifiers.key {
+                KeyCode::ArrowDown if !self.items.is_empty() => {
+                    let next = match self.selected {
+                        Some(i) if i + 1 < self.items.len() => i + 1,
+                        Some(i) => i,
+                        None => 0,
+                    };
+                    self.selected = Some(next);
+                    EventResult::Consumed
+                }
+                KeyCode::ArrowUp if !self.items.is_empty() => {
+                    let next = match self.selected {
+                        Some(0) | None => 0,
+                        Some(i) => i - 1,
+                    };
+                    self.selected = Some(next);
+                    EventResult::Consumed
+                }
+                _ => EventResult::Ignored,
+            },
+            _ => EventResult::Ignored,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{KeyMods, Modifiers};
+    use crate::widget::IdAllocator;
+
+    fn fixture() -> List<u32> {
+        let mut ids = IdAllocator::new();
+        let mut list = List::new(ids.allocate());
+        list.set_bounds(Rect::xywh(0.0, 0.0, 100.0, 100.0));
+        list.set_items(vec![
+            ListItem::new("alpha", 0),
+            ListItem::new("beta", 1),
+            ListItem::new("gamma", 2),
+        ]);
+        list
+    }
+
+    #[test]
+    fn click_selects_row_under_cursor() {
+        let mut list = fixture();
+        list.handle_event(&UiEvent::MouseMove { x: 5.0, y: 25.0 });
+        let r = list.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Consumed);
+        assert_eq!(list.selected_index(), Some(1));
+        assert_eq!(list.selected().map(|i| i.payload), Some(1));
+    }
+
+    #[test]
+    fn click_below_last_row_does_not_select() {
+        let mut list = fixture();
+        list.handle_event(&UiEvent::MouseMove { x: 5.0, y: 80.0 });
+        let r = list.handle_event(&UiEvent::MouseDown {
+            button: MouseButton::Primary,
+        });
+        assert_eq!(r, EventResult::Ignored);
+        assert_eq!(list.selected_index(), None);
+    }
+
+    #[test]
+    fn arrow_keys_move_selection() {
+        let mut list = fixture();
+        list.set_selected(Some(0));
+        let r = list.handle_event(&UiEvent::KeyDown(Modifiers {
+            key: KeyCode::ArrowDown,
+            mods: KeyMods::NONE,
+        }));
+        assert_eq!(r, EventResult::Consumed);
+        assert_eq!(list.selected_index(), Some(1));
+        list.handle_event(&UiEvent::KeyDown(Modifiers {
+            key: KeyCode::ArrowDown,
+            mods: KeyMods::NONE,
+        }));
+        list.handle_event(&UiEvent::KeyDown(Modifiers {
+            key: KeyCode::ArrowDown,
+            mods: KeyMods::NONE,
+        }));
+        // Pinned at the last row, never wraps.
+        assert_eq!(list.selected_index(), Some(2));
+        list.handle_event(&UiEvent::KeyDown(Modifiers {
+            key: KeyCode::ArrowUp,
+            mods: KeyMods::NONE,
+        }));
+        assert_eq!(list.selected_index(), Some(1));
+    }
+
+    #[test]
+    fn replacing_items_clears_stale_selection() {
+        let mut list = fixture();
+        list.set_selected(Some(2));
+        list.set_items(vec![ListItem::new("only", 99)]);
+        assert_eq!(list.selected_index(), None);
+    }
+
+    #[test]
+    fn paint_highlights_selected_row() {
+        let mut list = fixture();
+        list.set_selected(Some(1));
+        let mut ctx = PaintCtx::new();
+        list.paint(&mut ctx);
+        // Background fill, selection fill, three text rows = five commands.
+        assert_eq!(ctx.commands().len(), 5);
+    }
+}

--- a/crates/beast-ui/src/widget/list.rs
+++ b/crates/beast-ui/src/widget/list.rs
@@ -8,7 +8,7 @@
 use crate::event::{EventResult, KeyCode, MouseButton, UiEvent};
 use crate::paint::{Color, PaintCtx, Point, Rect, Size};
 
-use super::{Widget, WidgetId};
+use super::{LayoutCtx, Widget, WidgetId};
 
 /// One row in a [`List`]. Concrete payload is generic so callers can store
 /// bestiary entries, faction summaries, etc., without erasing types.
@@ -39,7 +39,7 @@ pub struct List<T> {
     bounds: Rect,
     items: Vec<ListItem<T>>,
     selected: Option<usize>,
-    last_cursor_y: f32,
+    last_cursor_y: Option<f32>,
 }
 
 impl<T> List<T> {
@@ -50,7 +50,7 @@ impl<T> List<T> {
             bounds: Rect::ZERO,
             items: Vec::new(),
             selected: None,
-            last_cursor_y: f32::NAN,
+            last_cursor_y: None,
         }
     }
 
@@ -136,7 +136,7 @@ impl<T: Clone + std::fmt::Debug> Widget for List<T> {
         self.bounds = bounds;
     }
 
-    fn measure(&self) -> Size {
+    fn measure(&self, _ctx: &LayoutCtx) -> Size {
         Size::new(120.0, ROW_HEIGHT * self.items.len() as f32)
     }
 
@@ -153,7 +153,7 @@ impl<T: Clone + std::fmt::Debug> Widget for List<T> {
             }
             ctx.text(
                 Point::new(row_origin.x + 4.0, row_origin.y + 2.0),
-                item.label.clone(),
+                item.label.as_str(),
                 Color::BLACK,
             );
         }
@@ -162,13 +162,16 @@ impl<T: Clone + std::fmt::Debug> Widget for List<T> {
     fn handle_event(&mut self, event: &UiEvent) -> EventResult {
         match event {
             UiEvent::MouseMove { y, .. } => {
-                self.last_cursor_y = *y;
+                self.last_cursor_y = Some(*y);
                 EventResult::Ignored
             }
             UiEvent::MouseDown {
                 button: MouseButton::Primary,
             } => {
-                if let Some(idx) = self.row_index_at(self.last_cursor_y) {
+                let Some(y) = self.last_cursor_y else {
+                    return EventResult::Ignored;
+                };
+                if let Some(idx) = self.row_index_at(y) {
                     self.selected = Some(idx);
                     EventResult::Consumed
                 } else {


### PR DESCRIPTION
Closes #206. First of eight S10 stories.

## Summary
- Adds `crates/beast-ui` (Layer L5) with the retained-mode `Widget` trait + 5 primitive widgets: `Button`, `Label`, `List<T>`, `Card`, `Dialog`.
- All paint output goes through a deterministic `PaintCtx` recorder (`Vec<DrawCmd>`); tests assert on the recorded commands so headless CI builds without an SDL link.
- Mirrors `beast-render`'s `default = ["sdl"]` / `headless` feature split so a workspace-level feature choice flows through both crates.
- `unsafe_code = "forbid"` in `Cargo.toml` lints — the framework is pure data + dispatch.

## Surface

```text
beast_ui::
    Widget trait {
        id, bounds, set_bounds, measure, paint, handle_event
    }
    Button, Label, List<T>, ListItem<T>, Card, Dialog
    WidgetId, IdAllocator (deterministic monotonic, starts at 1)
    PaintCtx, DrawCmd::{FillRect, StrokeRect, Text}
    Color, Point, Rect, Size
    UiEvent::{MouseMove, MouseDown, MouseUp, KeyDown, KeyUp, TextInput, Tick}
    EventResult::{Consumed, Ignored}
    KeyCode, KeyMods (newtype bitflags), Modifiers, MouseButton
```

## Notable choices

- **`Button`** stores a `press_count: u32` instead of an `on_press: Box<dyn FnMut>` callback. Tests assert on observable state without juggling channel ends; future screens can read the counter or replace the field with a callback when bound to commands.
- **`KeyMods`** is a hand-rolled `u8` newtype with `BitOr` / `contains` / `intersects` rather than pulling in the `bitflags` crate. There's only one bitflags type in the crate and the surface is ~10 lines — if a second one shows up we'll switch.
- **Layout** is intentionally not implemented here. `measure()` returns rough heuristics so `Card` and the layout pass in S10.2 have *some* signal to work with. S10.2 will adopt [`taffy`](https://github.com/DioxusLabs/taffy) for the real flexbox / grid math (avoids reinventing layout).
- **Event routing** beyond a single widget is not done here either — `Dialog` knows about modality but the proper hit-test + focus dispatch + Tab cycling lands in S10.3.

## Determinism + invariants

- INVARIANTS §6: no widget primitive takes a `&mut Simulation` or `&mut Chronicler`. `paint` and `handle_event` are deterministic functions of widget state + input.
- `IdAllocator` is monotonic and deterministic; `Default` aliases `new` so callers can use either.
- Floats are fine in render-side coordinates per INVARIANTS §1; nothing here feeds back into sim state.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --no-default-features --features headless --all-targets -- -D warnings` clean.
- [x] `cargo test -p beast-ui --no-default-features --features headless` — 27 tests pass.
- [ ] CI runs the same gates plus the SDL backend on default features.

## Out of scope

- Widget tree / layout engine (S10.2)
- Event dispatch through a tree, focus management, data bindings (S10.3)
- Screen definitions (S10.4)
- Chronicler integration (S10.5–S10.8)
