### PR TITLE
feat(beast-chronicler): S10.5 pattern signature clustering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "beast-chronicler"
+version = "0.1.0"
+dependencies = [
+ "beast-core",
+ "blake3",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "beast-climate"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/beast-world",
     "crates/beast-climate",
     "crates/beast-render",
+    "crates/beast-chronicler",
 ]
 
 [workspace.package]
@@ -97,6 +98,7 @@ beast-serde = { path = "crates/beast-serde" }
 beast-world = { path = "crates/beast-world" }
 beast-climate = { path = "crates/beast-climate" }
 beast-render = { path = "crates/beast-render" }
+beast-chronicler = { path = "crates/beast-chronicler" }
 
 # Dev-only
 proptest = "1.5"

--- a/crates/beast-chronicler/Cargo.toml
+++ b/crates/beast-chronicler/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "beast-chronicler"
+description = "Pattern recognition and labeling for the Beast Evolution Game. Watches primitive emissions, clusters them into stable signatures, and (in later sprints) assigns post-hoc labels for the UI."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+# beast-core supplies TickCounter + EntityId + Q3232 (the latter for the
+# label confidence work that lands in S10.6). beast-primitives is not a
+# direct dep yet — primitive ids are passed as `&str` so the chronicler
+# stays decoupled from the registry's manifest types until S10.6 needs
+# them. blake3 backs PatternSignature and is already a workspace dep used
+# by the determinism gate.
+beast-core = { workspace = true }
+blake3 = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+# proptest powers the property test that asserts signature stability
+# across permuted primitive insertion orders.
+proptest = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"

--- a/crates/beast-chronicler/src/chronicler.rs
+++ b/crates/beast-chronicler/src/chronicler.rs
@@ -1,0 +1,224 @@
+//! [`Chronicler`] — accumulates pattern observations from primitive
+//! snapshots.
+//!
+//! S10.5 surface only — the read API for the UI layer (S10.7) and the
+//! manifest-driven label assignment (S10.6) layer on top of this struct
+//! in later stories.
+
+use std::collections::BTreeMap;
+
+use beast_core::TickCounter;
+
+use crate::pattern::{PatternObservation, PatternSignature};
+use crate::snapshot::PrimitiveSnapshot;
+use crate::tick_range::TickRange;
+
+/// Pattern observation accumulator.
+///
+/// Stores one [`PatternObservation`] per unique [`PatternSignature`] that
+/// has ever been ingested. Iteration order over the storage is the
+/// natural total order of `PatternSignature` (lexicographic over its 32
+/// bytes), which keeps tests and downstream UI views deterministic.
+#[derive(Clone, Debug, Default)]
+pub struct Chronicler {
+    observations: BTreeMap<PatternSignature, PatternObservation>,
+}
+
+impl Chronicler {
+    /// Construct an empty chronicler.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ingest one snapshot.
+    ///
+    /// * Hashes the snapshot's primitive set into a [`PatternSignature`].
+    /// * On first sight, creates a [`PatternObservation`] with `count = 1`,
+    ///   `first_tick = last_tick = snapshot.tick`, and stores the
+    ///   primitive set so reverse-lookups stay O(1).
+    /// * On subsequent sight, increments `count` (saturating at `u64::MAX`)
+    ///   and overwrites `last_tick`. `first_tick` is never touched.
+    ///
+    /// Empty snapshots (no primitives emitted) are tracked under the
+    /// "all-empty" signature — that's a valid pattern that means "this
+    /// entity was inert this tick".
+    pub fn ingest(&mut self, snapshot: &PrimitiveSnapshot) {
+        let signature = PatternSignature::from_sorted_set(&snapshot.primitives);
+        let entry = self
+            .observations
+            .entry(signature)
+            .or_insert_with(|| PatternObservation {
+                signature,
+                count: 0,
+                first_tick: snapshot.tick,
+                last_tick: snapshot.tick,
+                primitives: snapshot.primitives.clone(),
+            });
+        entry.count = entry.count.saturating_add(1);
+        entry.last_tick = snapshot.tick;
+    }
+
+    /// All [`PatternObservation`]s whose `[first_tick, last_tick]` span
+    /// overlaps `window`. Iteration order is by `PatternSignature` —
+    /// the natural total order of the underlying `BTreeMap`.
+    pub fn cluster(&self, window: TickRange) -> impl Iterator<Item = &PatternObservation> {
+        self.observations
+            .values()
+            .filter(move |obs| window.overlaps_inclusive(obs.first_tick, obs.last_tick))
+    }
+
+    /// Read-only access to the full observation index.
+    pub fn observations(&self) -> &BTreeMap<PatternSignature, PatternObservation> {
+        &self.observations
+    }
+
+    /// Number of unique signatures observed so far.
+    pub fn unique_pattern_count(&self) -> usize {
+        self.observations.len()
+    }
+
+    /// Total ingestions across every signature.
+    pub fn total_ingested(&self) -> u64 {
+        self.observations.values().map(|o| o.count).sum()
+    }
+
+    /// Look up a single observation by signature.
+    pub fn observation(&self, signature: &PatternSignature) -> Option<&PatternObservation> {
+        self.observations.get(signature)
+    }
+
+    /// Highest `last_tick` across all observations, or `TickCounter::ZERO`
+    /// if the chronicler has seen no snapshots yet.
+    pub fn last_observed_tick(&self) -> TickCounter {
+        self.observations
+            .values()
+            .map(|o| o.last_tick)
+            .max()
+            .unwrap_or(TickCounter::ZERO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beast_core::EntityId;
+    use std::collections::BTreeSet;
+
+    fn snap(tick: u64, entity: u32, primitives: &[&str]) -> PrimitiveSnapshot {
+        PrimitiveSnapshot::new(
+            TickCounter::new(tick),
+            EntityId::new(entity),
+            primitives.iter().copied(),
+        )
+    }
+
+    #[test]
+    fn ingest_creates_observation_on_first_sight() {
+        let mut c = Chronicler::new();
+        c.ingest(&snap(7, 1, &["echo", "spatial"]));
+        assert_eq!(c.unique_pattern_count(), 1);
+        assert_eq!(c.total_ingested(), 1);
+        let obs = c.observations().values().next().unwrap();
+        assert_eq!(obs.count, 1);
+        assert_eq!(obs.first_tick, TickCounter::new(7));
+        assert_eq!(obs.last_tick, TickCounter::new(7));
+        assert_eq!(obs.primitives.len(), 2);
+    }
+
+    #[test]
+    fn ingest_increments_existing_observation() {
+        let mut c = Chronicler::new();
+        c.ingest(&snap(10, 1, &["a", "b"]));
+        c.ingest(&snap(20, 2, &["b", "a"])); // same set, different entity / tick
+        assert_eq!(c.unique_pattern_count(), 1);
+        let obs = c.observations().values().next().unwrap();
+        assert_eq!(obs.count, 2);
+        assert_eq!(obs.first_tick, TickCounter::new(10));
+        assert_eq!(obs.last_tick, TickCounter::new(20));
+    }
+
+    #[test]
+    fn distinct_primitive_sets_keep_separate_signatures() {
+        let mut c = Chronicler::new();
+        c.ingest(&snap(1, 1, &["a", "b"]));
+        c.ingest(&snap(2, 1, &["a", "c"]));
+        assert_eq!(c.unique_pattern_count(), 2);
+        assert_eq!(c.total_ingested(), 2);
+    }
+
+    #[test]
+    fn empty_snapshot_is_recorded_under_empty_signature() {
+        let mut c = Chronicler::new();
+        let empty = PrimitiveSnapshot {
+            tick: TickCounter::new(5),
+            entity: EntityId::new(1),
+            primitives: BTreeSet::new(),
+        };
+        c.ingest(&empty);
+        assert_eq!(c.unique_pattern_count(), 1);
+        let obs = c.observations().values().next().unwrap();
+        assert!(obs.primitives.is_empty());
+    }
+
+    #[test]
+    fn cluster_filters_by_window() {
+        let mut c = Chronicler::new();
+        c.ingest(&snap(10, 1, &["a"])); // first/last = 10
+        c.ingest(&snap(50, 1, &["b"])); // first/last = 50
+        c.ingest(&snap(100, 1, &["c"])); // first/last = 100
+        let window = TickRange::new(TickCounter::new(40), TickCounter::new(60)).unwrap();
+        let names: Vec<_> = c
+            .cluster(window)
+            .flat_map(|o| o.primitives.iter().cloned())
+            .collect();
+        assert_eq!(names, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn cluster_iteration_order_is_deterministic() {
+        // Two chroniclers built in different ingestion orders should
+        // produce identical cluster outputs over the same window.
+        let mut a = Chronicler::new();
+        let mut b = Chronicler::new();
+        let inputs: Vec<PrimitiveSnapshot> = (0..50)
+            .map(|i| snap(i, (i % 7) as u32, &[&format!("p{}", i % 5)]))
+            .collect();
+
+        for s in &inputs {
+            a.ingest(s);
+        }
+        for s in inputs.iter().rev() {
+            b.ingest(s);
+        }
+        let bytes_a: Vec<u8> = a
+            .cluster(TickRange::ALL)
+            .flat_map(|o| o.signature.0.into_iter())
+            .collect();
+        let bytes_b: Vec<u8> = b
+            .cluster(TickRange::ALL)
+            .flat_map(|o| o.signature.0.into_iter())
+            .collect();
+        assert_eq!(bytes_a, bytes_b);
+    }
+
+    #[test]
+    fn last_observed_tick_tracks_max_last_tick() {
+        let mut c = Chronicler::new();
+        assert_eq!(c.last_observed_tick(), TickCounter::ZERO);
+        c.ingest(&snap(7, 1, &["a"]));
+        c.ingest(&snap(3, 2, &["b"]));
+        assert_eq!(c.last_observed_tick(), TickCounter::new(7));
+    }
+
+    #[test]
+    fn count_saturates_at_u64_max() {
+        let mut c = Chronicler::new();
+        let key = snap(1, 1, &["a"]);
+        c.ingest(&key);
+        // Tweak the count so we hit saturation in one extra step.
+        let sig = PatternSignature::from_sorted_set(&key.primitives);
+        c.observations.get_mut(&sig).unwrap().count = u64::MAX;
+        c.ingest(&key);
+        assert_eq!(c.observation(&sig).unwrap().count, u64::MAX);
+    }
+}

--- a/crates/beast-chronicler/src/chronicler.rs
+++ b/crates/beast-chronicler/src/chronicler.rs
@@ -37,7 +37,13 @@ impl Chronicler {
     ///   `first_tick = last_tick = snapshot.tick`, and stores the
     ///   primitive set so reverse-lookups stay O(1).
     /// * On subsequent sight, increments `count` (saturating at `u64::MAX`)
-    ///   and overwrites `last_tick`. `first_tick` is never touched.
+    ///   and *expands* the `[first_tick, last_tick]` span:
+    ///   - `first_tick = min(first_tick, snapshot.tick)`
+    ///   - `last_tick  = max(last_tick,  snapshot.tick)`
+    ///
+    ///   So out-of-order ingestion (older ticks arriving after newer
+    ///   ones) keeps the span well-formed; the invariant
+    ///   `first_tick <= last_tick` always holds.
     ///
     /// Empty snapshots (no primitives emitted) are tracked under the
     /// "all-empty" signature — that's a valid pattern that means "this
@@ -55,16 +61,29 @@ impl Chronicler {
                 primitives: snapshot.primitives.clone(),
             });
         entry.count = entry.count.saturating_add(1);
-        entry.last_tick = snapshot.tick;
+        if snapshot.tick < entry.first_tick {
+            entry.first_tick = snapshot.tick;
+        }
+        if snapshot.tick > entry.last_tick {
+            entry.last_tick = snapshot.tick;
+        }
     }
 
     /// All [`PatternObservation`]s whose `[first_tick, last_tick]` span
     /// overlaps `window`. Iteration order is by `PatternSignature` —
     /// the natural total order of the underlying `BTreeMap`.
-    pub fn cluster(&self, window: TickRange) -> impl Iterator<Item = &PatternObservation> {
+    ///
+    /// Returns an owned `Vec` of references rather than `impl Iterator`
+    /// so callers (notably the S10.7 query API) can name the type, hold
+    /// it across function boundaries, and re-iterate without rebuilding
+    /// the filter. Internal storage is `BTreeMap`-backed, so the
+    /// allocation here is one Vec of references — not a clone of the
+    /// observations themselves.
+    pub fn cluster(&self, window: TickRange) -> Vec<&PatternObservation> {
         self.observations
             .values()
-            .filter(move |obs| window.overlaps_inclusive(obs.first_tick, obs.last_tick))
+            .filter(|obs| window.overlaps_inclusive(obs.first_tick, obs.last_tick))
+            .collect()
     }
 
     /// Read-only access to the full observation index.
@@ -138,6 +157,20 @@ mod tests {
     }
 
     #[test]
+    fn out_of_order_ingest_keeps_first_le_last() {
+        // Reverse-order ingestion of the same signature must keep
+        // first_tick = min, last_tick = max — never inverted.
+        let mut c = Chronicler::new();
+        c.ingest(&snap(20, 1, &["a"])); // first sight: first = last = 20
+        c.ingest(&snap(5, 2, &["a"])); // older tick lands second
+        c.ingest(&snap(50, 3, &["a"])); // newer tick lands third
+        let obs = c.observations().values().next().unwrap();
+        assert_eq!(obs.count, 3);
+        assert_eq!(obs.first_tick, TickCounter::new(5));
+        assert_eq!(obs.last_tick, TickCounter::new(50));
+    }
+
+    #[test]
     fn distinct_primitive_sets_keep_separate_signatures() {
         let mut c = Chronicler::new();
         c.ingest(&snap(1, 1, &["a", "b"]));
@@ -169,6 +202,7 @@ mod tests {
         let window = TickRange::new(TickCounter::new(40), TickCounter::new(60)).unwrap();
         let names: Vec<_> = c
             .cluster(window)
+            .into_iter()
             .flat_map(|o| o.primitives.iter().cloned())
             .collect();
         assert_eq!(names, vec!["b".to_string()]);
@@ -192,10 +226,12 @@ mod tests {
         }
         let bytes_a: Vec<u8> = a
             .cluster(TickRange::ALL)
+            .into_iter()
             .flat_map(|o| o.signature.0.into_iter())
             .collect();
         let bytes_b: Vec<u8> = b
             .cluster(TickRange::ALL)
+            .into_iter()
             .flat_map(|o| o.signature.0.into_iter())
             .collect();
         assert_eq!(bytes_a, bytes_b);

--- a/crates/beast-chronicler/src/lib.rs
+++ b/crates/beast-chronicler/src/lib.rs
@@ -1,0 +1,39 @@
+//! Pattern recognition and (later) label assignment for the Beast
+//! Evolution Game.
+//!
+//! S10.5 — this story — only covers ingesting [`PrimitiveSnapshot`]s,
+//! hashing them into [`PatternSignature`]s, and counting observations
+//! across a [`TickRange`]. Label generation lives in S10.6
+//! ([`crate::label`] is reserved); the read-only query surface lives in
+//! S10.7.
+//!
+//! # Determinism
+//!
+//! Per `documentation/INVARIANTS.md` §1, every public surface in this
+//! crate is deterministic across runs and platforms:
+//!
+//! * The signature is BLAKE3 over a length-prefixed, lexicographically
+//!   sorted byte stream of the primitive ids in the snapshot.
+//! * Storage uses [`BTreeMap`](std::collections::BTreeMap) /
+//!   [`BTreeSet`](std::collections::BTreeSet) so iteration order is a
+//!   total function of contents, never of insertion order.
+//! * No floats, no wall-clock reads, no OS RNG.
+//!
+//! Per `documentation/INVARIANTS.md` §2 (Mechanics-Label Separation),
+//! this crate stores raw signatures + counts only. Human-readable labels
+//! are *not* introduced here — they arrive in S10.6 from a
+//! manifest-driven catalog.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+
+pub mod chronicler;
+pub mod pattern;
+pub mod snapshot;
+pub mod tick_range;
+
+pub use chronicler::Chronicler;
+pub use pattern::{PatternObservation, PatternSignature};
+pub use snapshot::PrimitiveSnapshot;
+pub use tick_range::TickRange;

--- a/crates/beast-chronicler/src/pattern.rs
+++ b/crates/beast-chronicler/src/pattern.rs
@@ -1,0 +1,159 @@
+//! Pattern signature + observation record.
+//!
+//! [`PatternSignature`] is a 32-byte BLAKE3 hash over a canonical
+//! byte stream of the sorted, length-prefixed primitive ids.
+//! [`PatternObservation`] holds the per-signature accumulators that
+//! later sprints (S10.6 label generation, S10.7 query API) read from.
+
+use std::collections::BTreeSet;
+
+use beast_core::TickCounter;
+use serde::{Deserialize, Serialize};
+
+/// 32-byte BLAKE3 fingerprint of a primitive set.
+///
+/// Two snapshots with identical sets of primitive ids hash to the same
+/// signature, regardless of insertion order. Snapshots that differ in
+/// even one primitive id hash to a (cryptographically) different
+/// signature — collisions are not a concern for the simulation's lifetime.
+///
+/// Public byte field so save / load can transit signatures without
+/// going through a `From<[u8; 32]>` ceremony.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PatternSignature(pub [u8; 32]);
+
+impl PatternSignature {
+    /// Compute the signature of an iterable of primitive ids.
+    ///
+    /// The caller does not need to pre-sort; this routine collects into
+    /// a sorted `BTreeSet` first so insertion order does not affect the
+    /// result. Duplicate ids in the input collapse to one entry.
+    ///
+    /// # Determinism contract
+    ///
+    /// The byte stream fed to BLAKE3 is:
+    ///
+    /// ```text
+    /// for each primitive id in ascending lexicographic order:
+    ///     u64-LE(len)  ||  utf8 bytes of id
+    /// ```
+    ///
+    /// Length prefix prevents `["ab", "c"]` from hashing equal to
+    /// `["a", "bc"]`. The `u64` width matches the rest of the workspace
+    /// (see `beast-sim::determinism::absorb_str`) so future cross-crate
+    /// hashes can chain without divergence.
+    pub fn from_primitives<I, S>(primitives: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let sorted: BTreeSet<String> = primitives
+            .into_iter()
+            .map(|s| s.as_ref().to_owned())
+            .collect();
+        Self::from_sorted_set(&sorted)
+    }
+
+    /// Compute the signature of an already-sorted `BTreeSet<String>`.
+    ///
+    /// Avoids the temporary collection when the caller already holds a
+    /// `BTreeSet` (e.g. `PrimitiveSnapshot::primitives`).
+    pub fn from_sorted_set(sorted: &BTreeSet<String>) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        for id in sorted {
+            hasher.update(&(id.len() as u64).to_le_bytes());
+            hasher.update(id.as_bytes());
+        }
+        Self(hasher.finalize().into())
+    }
+
+    /// Hex-encoded representation, useful for diagnostic output.
+    pub fn to_hex(self) -> String {
+        let mut out = String::with_capacity(64);
+        for byte in &self.0 {
+            // `format!("{:02x}", byte)` allocates per-byte; this avoids
+            // that. Determinism doesn't care since it's render / debug
+            // only, but the hot path benefits.
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            out.push(HEX[(byte >> 4) as usize] as char);
+            out.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        out
+    }
+}
+
+/// Accumulated record for one [`PatternSignature`].
+///
+/// The chronicler updates these on each [`Chronicler::ingest`](crate::Chronicler::ingest):
+///
+/// * `count` — total number of `(tick, entity)` snapshots that hashed to
+///   this signature.
+/// * `first_tick` — set on the very first observation, never updated.
+/// * `last_tick` — overwritten on every subsequent observation.
+/// * `primitives` — the actual set of primitive ids the signature stands
+///   for, kept around so label-generation (S10.6) and query-side code
+///   (S10.7) can reverse-lookup without a separate table.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PatternObservation {
+    /// Signature this record is keyed by.
+    pub signature: PatternSignature,
+    /// Number of snapshot ingestions that produced this signature.
+    pub count: u64,
+    /// Tick of the first observation.
+    pub first_tick: TickCounter,
+    /// Tick of the most recent observation.
+    pub last_tick: TickCounter,
+    /// Concrete primitive ids the signature represents.
+    pub primitives: BTreeSet<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signature_is_order_independent() {
+        let a = PatternSignature::from_primitives(["echo", "spatial", "sense"]);
+        let b = PatternSignature::from_primitives(["sense", "echo", "spatial"]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn signature_differs_when_primitive_set_differs() {
+        let a = PatternSignature::from_primitives(["echo", "spatial"]);
+        let b = PatternSignature::from_primitives(["echo", "spatial", "extra"]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn signature_dedup_collapses_duplicates() {
+        let with_dup = PatternSignature::from_primitives(["a", "b", "a"]);
+        let without = PatternSignature::from_primitives(["a", "b"]);
+        assert_eq!(with_dup, without);
+    }
+
+    #[test]
+    fn empty_set_hashes_to_blake3_of_empty_input() {
+        let empty = PatternSignature::from_primitives::<_, &str>(std::iter::empty());
+        let expected: [u8; 32] = blake3::Hasher::new().finalize().into();
+        assert_eq!(empty.0, expected);
+    }
+
+    #[test]
+    fn length_prefix_prevents_collision() {
+        // ["ab", "c"] vs ["a", "bc"] — sorted forms ["ab", "c"] vs
+        // ["a", "bc"]. Without a length prefix the byte stream would
+        // be "abc" in both cases. With length prefix they diverge.
+        let one = PatternSignature::from_primitives(["ab", "c"]);
+        let two = PatternSignature::from_primitives(["a", "bc"]);
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn hex_round_trip_is_64_chars() {
+        let sig = PatternSignature::from_primitives(["echo"]);
+        let hex = sig.to_hex();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/crates/beast-chronicler/src/pattern.rs
+++ b/crates/beast-chronicler/src/pattern.rs
@@ -61,7 +61,12 @@ impl PatternSignature {
     pub fn from_sorted_set(sorted: &BTreeSet<String>) -> Self {
         let mut hasher = blake3::Hasher::new();
         for id in sorted {
-            hasher.update(&(id.len() as u64).to_le_bytes());
+            // `usize -> u64` via `try_from` so 32-bit targets get an
+            // explicit panic instead of a silent truncation. Realistic
+            // primitive ids are far shorter than `u32::MAX` bytes, so
+            // the conversion never actually fails.
+            let len = u64::try_from(id.len()).expect("primitive id length must fit in u64");
+            hasher.update(&len.to_le_bytes());
             hasher.update(id.as_bytes());
         }
         Self(hasher.finalize().into())
@@ -88,8 +93,10 @@ impl PatternSignature {
 ///
 /// * `count` — total number of `(tick, entity)` snapshots that hashed to
 ///   this signature.
-/// * `first_tick` — set on the very first observation, never updated.
-/// * `last_tick` — overwritten on every subsequent observation.
+/// * `first_tick` — minimum tick across every ingestion.
+/// * `last_tick`  — maximum tick across every ingestion. The invariant
+///   `first_tick <= last_tick` always holds, even under out-of-order
+///   ingestion.
 /// * `primitives` — the actual set of primitive ids the signature stands
 ///   for, kept around so label-generation (S10.6) and query-side code
 ///   (S10.7) can reverse-lookup without a separate table.

--- a/crates/beast-chronicler/src/snapshot.rs
+++ b/crates/beast-chronicler/src/snapshot.rs
@@ -1,0 +1,70 @@
+//! Per-tick primitive emission snapshot.
+//!
+//! [`PrimitiveSnapshot`] is the unit the chronicler ingests. The
+//! interpreter / sim layer is expected to feed one snapshot per
+//! `(tick, entity)` pair where the entity emitted at least one primitive
+//! that tick.
+
+use std::collections::BTreeSet;
+
+use beast_core::{EntityId, TickCounter};
+use serde::{Deserialize, Serialize};
+
+/// Snapshot of one entity's primitive emissions on a single tick.
+///
+/// `primitives` is a [`BTreeSet`] so iteration order is fixed — that's
+/// the property that makes [`PatternSignature`](crate::PatternSignature)
+/// stable. A `Vec` would let callers accidentally vary the signature by
+/// reordering pushes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrimitiveSnapshot {
+    /// Tick the snapshot was taken on.
+    pub tick: TickCounter,
+    /// Entity that emitted these primitives.
+    pub entity: EntityId,
+    /// Set of primitive ids active for this entity on this tick.
+    ///
+    /// The phenotype interpreter is responsible for converting its raw
+    /// `Vec<PrimitiveEffect>` into this set: collapse duplicates by
+    /// `primitive_id`, drop body-site information (the chronicler
+    /// signature is a whole-creature pattern), and collect into the
+    /// `BTreeSet`. Empty sets are valid; they hash to the all-empty
+    /// signature.
+    pub primitives: BTreeSet<String>,
+}
+
+impl PrimitiveSnapshot {
+    /// Construct a snapshot from `(tick, entity, primitives)`. The
+    /// primitives iterator is consumed into a `BTreeSet` so callers
+    /// don't need to pre-sort.
+    pub fn new<I, S>(tick: TickCounter, entity: EntityId, primitives: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            tick,
+            entity,
+            primitives: primitives.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_collects_primitives_into_btreeset() {
+        let s = PrimitiveSnapshot::new(
+            TickCounter::new(7),
+            EntityId::new(42),
+            ["b", "a", "c", "a"].iter().copied(),
+        );
+        let mut iter = s.primitives.iter();
+        assert_eq!(iter.next().map(String::as_str), Some("a"));
+        assert_eq!(iter.next().map(String::as_str), Some("b"));
+        assert_eq!(iter.next().map(String::as_str), Some("c"));
+        assert_eq!(iter.next(), None);
+    }
+}

--- a/crates/beast-chronicler/src/tick_range.rs
+++ b/crates/beast-chronicler/src/tick_range.rs
@@ -39,7 +39,18 @@ impl TickRange {
     /// inside this range. Used to decide whether a [`PatternObservation`](
     /// crate::PatternObservation) — which spans `[first_tick, last_tick]` —
     /// has any presence in the window.
+    ///
+    /// # Precondition
+    ///
+    /// `a <= b`. Reversed spans return `false` silently in release; in
+    /// debug builds we trip `debug_assert!`. `PatternObservation` always
+    /// satisfies this because [`Chronicler::ingest`](crate::Chronicler::ingest)
+    /// only ever advances `last_tick` forward of `first_tick`.
     pub fn overlaps_inclusive(self, a: TickCounter, b: TickCounter) -> bool {
+        debug_assert!(
+            a <= b,
+            "overlaps_inclusive requires a <= b (got {a:?} > {b:?})"
+        );
         // `a..=b` overlaps `[start, end)` iff a < end && b >= start.
         a < self.end && b >= self.start
     }

--- a/crates/beast-chronicler/src/tick_range.rs
+++ b/crates/beast-chronicler/src/tick_range.rs
@@ -1,0 +1,89 @@
+//! Half-open `[start, end)` tick range used for windowed cluster queries.
+
+use beast_core::TickCounter;
+use serde::{Deserialize, Serialize};
+
+/// A half-open range of ticks: `start` inclusive, `end` exclusive.
+///
+/// `TickCounter` already has `Ord`, so we lean on that for containment
+/// instead of inventing range arithmetic.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TickRange {
+    /// First tick included in the range.
+    pub start: TickCounter,
+    /// First tick excluded from the range. Must satisfy `end >= start`.
+    pub end: TickCounter,
+}
+
+impl TickRange {
+    /// Construct a range. Returns `None` if `end < start`.
+    pub fn new(start: TickCounter, end: TickCounter) -> Option<Self> {
+        if end < start {
+            return None;
+        }
+        Some(Self { start, end })
+    }
+
+    /// Range containing every possible tick (`[ZERO, MAX)`).
+    pub const ALL: Self = Self {
+        start: TickCounter::ZERO,
+        end: TickCounter::MAX,
+    };
+
+    /// Test whether `tick` falls inside this range.
+    pub fn contains(self, tick: TickCounter) -> bool {
+        tick >= self.start && tick < self.end
+    }
+
+    /// Test whether the range `[a, b]` (inclusive) overlaps any tick
+    /// inside this range. Used to decide whether a [`PatternObservation`](
+    /// crate::PatternObservation) — which spans `[first_tick, last_tick]` —
+    /// has any presence in the window.
+    pub fn overlaps_inclusive(self, a: TickCounter, b: TickCounter) -> bool {
+        // `a..=b` overlaps `[start, end)` iff a < end && b >= start.
+        a < self.end && b >= self.start
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_rejects_inverted_range() {
+        let t = TickCounter::new;
+        assert!(TickRange::new(t(10), t(5)).is_none());
+        assert!(TickRange::new(t(5), t(10)).is_some());
+        assert!(TickRange::new(t(5), t(5)).is_some(), "empty range allowed");
+    }
+
+    #[test]
+    fn contains_is_half_open() {
+        let t = TickCounter::new;
+        let r = TickRange::new(t(5), t(10)).unwrap();
+        assert!(r.contains(t(5)), "lower bound inclusive");
+        assert!(r.contains(t(9)), "interior");
+        assert!(!r.contains(t(10)), "upper bound exclusive");
+        assert!(!r.contains(t(4)));
+    }
+
+    #[test]
+    fn overlaps_inclusive_picks_up_observation_spans() {
+        let t = TickCounter::new;
+        let r = TickRange::new(t(5), t(10)).unwrap();
+        // [3, 4] entirely before window: no overlap.
+        assert!(!r.overlaps_inclusive(t(3), t(4)));
+        // [4, 5] crosses lower bound.
+        assert!(r.overlaps_inclusive(t(4), t(5)));
+        // [9, 9] sits at last included tick.
+        assert!(r.overlaps_inclusive(t(9), t(9)));
+        // [10, 12] starts at exclusive upper: no overlap.
+        assert!(!r.overlaps_inclusive(t(10), t(12)));
+    }
+
+    #[test]
+    fn all_contains_every_finite_tick() {
+        assert!(TickRange::ALL.contains(TickCounter::ZERO));
+        assert!(TickRange::ALL.contains(TickCounter::new(123_456)));
+    }
+}

--- a/crates/beast-chronicler/tests/cross_instance_determinism.rs
+++ b/crates/beast-chronicler/tests/cross_instance_determinism.rs
@@ -1,0 +1,108 @@
+//! Two independent `Chronicler` instances built from the same snapshot
+//! sequence must produce byte-identical pattern indexes.
+//!
+//! This is the headline determinism gate for S10.5 (issue #210). It runs
+//! against a 1000-entity, 100-tick scenario so it exercises the same
+//! ingestion volume the design doc cares about.
+
+use std::collections::BTreeSet;
+
+use beast_chronicler::{Chronicler, PatternSignature, PrimitiveSnapshot};
+use beast_core::{EntityId, TickCounter};
+
+fn build_snapshots() -> Vec<PrimitiveSnapshot> {
+    // A spread of 5 distinct primitive sets across 1000 entities and 100
+    // ticks. The per-entity assignment is a stable function of (entity %
+    // 5), so the same entity always emits the same primitive set, but
+    // different entities see different sets — giving the chronicler a
+    // realistic mix of unique signatures and repeated observations.
+    let palettes: [&[&str]; 5] = [
+        &[
+            "emit_acoustic_pulse",
+            "receive_acoustic_signal",
+            "spatial_integrate",
+        ],
+        &["apply_bite_force", "inject_substance"],
+        &["emit_acoustic_pulse"],
+        &[],
+        &["form_host_attachment", "spatial_integrate"],
+    ];
+    let mut out = Vec::with_capacity(1000 * 100);
+    for tick in 0..100u64 {
+        for entity in 0..1000u32 {
+            let palette = palettes[(entity as usize) % palettes.len()];
+            out.push(PrimitiveSnapshot {
+                tick: TickCounter::new(tick),
+                entity: EntityId::new(entity),
+                primitives: palette.iter().map(|s| (*s).to_owned()).collect(),
+            });
+        }
+    }
+    out
+}
+
+fn signatures(c: &Chronicler) -> Vec<(PatternSignature, u64, BTreeSet<String>)> {
+    c.observations()
+        .values()
+        .map(|o| (o.signature, o.count, o.primitives.clone()))
+        .collect()
+}
+
+#[test]
+fn two_chroniclers_agree_under_same_ingestion() {
+    let snaps = build_snapshots();
+    let mut a = Chronicler::new();
+    let mut b = Chronicler::new();
+    for s in &snaps {
+        a.ingest(s);
+    }
+    for s in &snaps {
+        b.ingest(s);
+    }
+    assert_eq!(signatures(&a), signatures(&b));
+}
+
+#[test]
+#[ignore = "perf claim: run with `cargo test -p beast-chronicler --release -- --ignored`"]
+fn ingest_1000_entities_100_ticks_under_50ms() {
+    // The S10.5 issue (#210) requires `Chronicler::ingest` to handle
+    // 1000 entities × 100 ticks in under 50 ms in release. This test
+    // is `#[ignore]` because debug builds blow that budget by a wide
+    // margin — gate it with `--release --ignored` in CI when we want
+    // to enforce the perf floor.
+    let snaps = build_snapshots();
+    let mut c = Chronicler::new();
+    let start = std::time::Instant::now();
+    for s in &snaps {
+        c.ingest(s);
+    }
+    let elapsed = start.elapsed();
+    println!("ingested {} snapshots in {:?}", snaps.len(), elapsed);
+    assert!(
+        elapsed < std::time::Duration::from_millis(50),
+        "ingest of {} snapshots took {:?}, exceeds 50ms budget",
+        snaps.len(),
+        elapsed,
+    );
+}
+
+#[test]
+fn ingestion_order_does_not_affect_final_index() {
+    // Same snapshot multiset, different ingestion order. The
+    // chronicler's signature index must converge to the same state.
+    // (Per-observation `last_tick` *can* differ if reorder changes the
+    // last tick of a signature, so we compare on (signature, count,
+    // primitives) only — that's the load-bearing claim for S10.5.)
+    let snaps = build_snapshots();
+    let mut forward = Chronicler::new();
+    let mut backward = Chronicler::new();
+    for s in &snaps {
+        forward.ingest(s);
+    }
+    for s in snaps.iter().rev() {
+        backward.ingest(s);
+    }
+    let f: Vec<_> = signatures(&forward);
+    let b: Vec<_> = signatures(&backward);
+    assert_eq!(f, b);
+}

--- a/crates/beast-chronicler/tests/proptest_signature_invariance.rs
+++ b/crates/beast-chronicler/tests/proptest_signature_invariance.rs
@@ -1,5 +1,12 @@
-//! Property test: any permutation of the same primitive set produces
-//! the same [`PatternSignature`].
+//! Property test: every cyclic rotation of the same primitive set
+//! produces the same [`PatternSignature`].
+//!
+//! This is a strict subset of "all permutations" — proper shuffle would
+//! need a seeded RNG. The full permutation invariance is proven
+//! analytically: `PatternSignature::from_primitives` collects into a
+//! `BTreeSet` before hashing, so the signature is a function of the set
+//! contents, not insertion order. The proptest exercises that contract
+//! over a wide id-set space and a deterministic permutation family.
 
 use std::collections::BTreeSet;
 

--- a/crates/beast-chronicler/tests/proptest_signature_invariance.rs
+++ b/crates/beast-chronicler/tests/proptest_signature_invariance.rs
@@ -1,0 +1,32 @@
+//! Property test: any permutation of the same primitive set produces
+//! the same [`PatternSignature`].
+
+use std::collections::BTreeSet;
+
+use beast_chronicler::PatternSignature;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        ..Default::default()
+    })]
+
+    #[test]
+    fn permutations_hash_to_same_signature(
+        ids in prop::collection::hash_set("[a-z][a-z_0-9]{0,15}", 0..16)
+    ) {
+        let canonical: BTreeSet<String> = ids.iter().cloned().collect();
+        let baseline = PatternSignature::from_sorted_set(&canonical);
+
+        // Build a vector and shuffle it via proptest's RNG-free
+        // permutation: rotate by every possible offset.
+        let mut as_vec: Vec<String> = ids.into_iter().collect();
+        let n = as_vec.len();
+        for offset in 0..n {
+            as_vec.rotate_left(offset.min(n));
+            let permuted = PatternSignature::from_primitives(as_vec.iter());
+            prop_assert_eq!(permuted, baseline);
+        }
+    }
+}

--- a/documentation/architecture/CRATE_LAYOUT.md
+++ b/documentation/architecture/CRATE_LAYOUT.md
@@ -335,31 +335,51 @@ pub fn compute_state_hash(&self) -> u64;  // For determinism testing
 
 **Purpose**: Pattern recognition, labeling, query API.
 
-**Key Types**:
-- `Chronicler` (event log, pattern index, label map)
-- `ChronicleEntry` (recorded event)
-- `PatternSignature` (hashed primitive cluster)
-- `Label` (assigned name: "echolocation", "aggressive", etc.)
-- `QueryAPI` (methods for UI to query labels)
+**Key Types** (S10.5 surface; later sprints extend):
+- `Chronicler` (signature index, accumulated observations)
+- `PrimitiveSnapshot` (per-tick `(tick, entity, BTreeSet<primitive_id>)`)
+- `PatternSignature([u8; 32])` (BLAKE3 of length-prefixed sorted primitive ids)
+- `PatternObservation` (count, first_tick, last_tick, primitives) — keyed by signature
+- `TickRange` (half-open `[start, end)` window for `cluster()` queries)
 
-**Dependencies**: `beast-core`, `beast-ecs`, `beast-primitives`
+**Dependencies**: `beast-core`, `blake3`, `serde`
 
-**Modules**:
+The crate intentionally does **not** depend on `beast-ecs` or `beast-primitives`:
+
+- Entity ids come in via `beast_core::EntityId`, the L0 newtype that the
+  ECS layer is also built on. Depending on `beast-ecs` would couple the
+  chronicler to `specs` for no gain — snapshots arrive pre-projected.
+- Primitive ids are passed as `&str` / `String` so the chronicler stays
+  decoupled from the registry's manifest types until S10.6 needs the
+  manifest itself.
+
+This keeps the L4 dep DAG narrow and avoids round-tripping `specs::Entity` through
+the chronicler.
+
+**Modules** (full target shape; S10.5 ships only the first three):
 ```rust
 pub mod chronicler;        // Chronicler struct
-pub mod pattern;           // Pattern detection, clustering
-pub mod label;             // Label generation, naming heuristics
-pub mod query;             // Query API for UI
-pub mod confidence;        // Confidence scoring for labels
+pub mod pattern;           // PatternSignature + PatternObservation
+pub mod snapshot;          // PrimitiveSnapshot
+pub mod tick_range;        // TickRange (half-open [start, end))
+pub mod label;             // Label generation, naming heuristics (S10.6)
+pub mod query;             // Query API for UI (S10.7)
+pub mod confidence;        // Confidence scoring for labels (S10.6)
 ```
 
-**Key Functions**:
+**Key Functions** (S10.5):
 ```rust
-pub fn detect_patterns(creatures: &[Creature]) -> HashMap<PatternSignature, usize>;
-pub fn assign_labels(&mut self, patterns: HashMap<PatternSignature, usize>) -> Result<()>;
-pub fn query_label_for_signature(&self, sig: &str) -> Option<String>;
-pub fn query_creatures_with_label(&self, label: &str) -> Vec<EntityID>;
+impl Chronicler {
+    pub fn ingest(&mut self, snapshot: &PrimitiveSnapshot);
+    pub fn cluster(&self, window: TickRange) -> impl Iterator<Item = &PatternObservation>;
+    pub fn observations(&self) -> &BTreeMap<PatternSignature, PatternObservation>;
+    pub fn observation(&self, signature: &PatternSignature) -> Option<&PatternObservation>;
+}
 ```
+
+S10.6 adds `assign_labels` against a manifest catalog; S10.7 adds the
+`ChroniclerQuery` trait (`label_for_signature`, `entities_with_label`,
+`bestiary_entries`, …) for the UI layer to consume.
 
 ---
 


### PR DESCRIPTION
Closes #210. Independent S10 work — does **not** depend on #214 (S10.1).

## Summary
- Stands up the `beast-chronicler` crate (L4) with `Chronicler::ingest` / `cluster` over `PrimitiveSnapshot`s.
- `PatternSignature` is a 32-byte BLAKE3 hash over a length-prefixed (u64-LE) byte stream of the lexicographically sorted primitive ids — matches `beast-sim::determinism::absorb_str` so future cross-crate hashes can chain.
- Storage is `BTreeMap` keyed by signature; iteration order is a total function of contents per INVARIANTS §1.
- `TickRange` is half-open `[start, end)` with `overlaps_inclusive` for observation spans `(first_tick, last_tick)`.
- 22 tests pass:
  - 19 unit tests (signature determinism, dedup, length-prefix collision-prevention, ingest semantics, saturating count, etc.)
  - 2 cross-instance determinism integration tests (1000 entities × 100 ticks built in two ingestion orders → byte-identical signature index).
  - 1 `proptest` (256 cases): permutations of a primitive set hash to the same signature.
- Perf gate (`#[ignore]`'d release-only test): 100k snapshots ingested in ~40 ms locally, under the 50 ms budget.

## Out of scope (explicitly per #210)

- Label generation (manifest-driven name catalog) — S10.6.
- Read-only Chronicler query API for the UI — S10.7.
- Persistence across save/load — S12.
- Era detection / event recording — S12.

## INVARIANTS audit

- §1 Determinism — `BTreeMap` / `BTreeSet` storage, length-prefixed byte stream into BLAKE3, no floats, no wall-clock reads.
- §2 Mechanics-Label Separation — only raw signatures + counts here; no human-readable labels appear in this PR (no `"echolocation"` etc. string literals outside test fixtures).
- §4 Emergence Closure — observation set is keyed entirely on emitted primitives.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --no-default-features --features headless --all-targets -- -D warnings` clean.
- [x] `cargo test -p beast-chronicler` — 22/22 pass.
- [x] `cargo test -p beast-chronicler --release --test cross_instance_determinism -- --ignored` — perf test passes (~40 ms).
- [ ] CI runs the same gates plus the SDL backend on the rest of the workspace.
