### PR TITLE
chore(scripts+githooks): ci-local.sh + pre-push delegation

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,10 +7,11 @@
 # Bypass in a genuine emergency with `git push --no-verify`; every bypass
 # should be explained in the next commit message.
 #
-# Heads-up: the CI pipeline below (fmt → clippy → tests → doc tests → release
-# build → cargo-deny) can take several minutes on a cold target/. This is
-# deliberate — it mirrors the CI gate in CLAUDE.md "Commands" so a failing
-# push is caught here instead of round-tripping through GitHub Actions.
+# Heads-up: the CI pipeline below (fmt → clippy → tests → doc tests →
+# beast-render headless → cargo-deny → coverage → quality → release →
+# determinism gate) can take several minutes on a cold `target/`. This is
+# deliberate — it mirrors the CI gate in `CLAUDE.md` so a failing push is
+# caught here instead of round-tripping through GitHub Actions.
 
 set -eu
 
@@ -49,40 +50,26 @@ done
 
 # --- CI checks ---------------------------------------------------------------
 #
-# Mirrors the CI pipeline documented in CLAUDE.md "Commands" so failures
-# surface before the push leaves this machine. Ordered fast-first: fmt and
-# clippy fail in seconds; the release build and cargo-deny are the slow
-# tail. `set -e` aborts on the first non-zero exit status.
-
-step() {
-    printf '\npre-push: %s\n' "$1" >&2
-}
-
-step 'cargo fmt --all -- --check'
-cargo fmt --all -- --check
-
-step 'cargo clippy --workspace --all-targets -- -D warnings'
-cargo clippy --workspace --all-targets -- -D warnings
-
-step 'cargo test --workspace --all-targets --locked'
-cargo test --workspace --all-targets --locked
-
-step 'cargo test --workspace --doc --locked'
-cargo test --workspace --doc --locked
-
-# --- Quality metrics ---------------------------------------------------------
+# Delegated to `scripts/ci-local.sh` so this hook and the GitHub Actions
+# `ci` workflow run the exact same gates with the exact same flags. Edit
+# `scripts/ci-local.sh` to change the gate set; both this hook and the
+# subagents that pre-push will pick the change up.
 #
-# Delegated to the shared driver so this hook and the `quality-metrics` CI
-# job run the exact same lizard invocations and thresholds. Edit
-# `.github/scripts/run-quality-metrics.sh` to change either.
-step '.github/scripts/run-quality-metrics.sh'
-.github/scripts/run-quality-metrics.sh >/dev/null
+# `PRE_PUSH_CI_FLAGS` lets ad-hoc local runs opt out of the slow tail
+# (e.g. `PRE_PUSH_CI_FLAGS="--quick" git push`). Default is unset, which
+# runs the full suite including release builds + determinism gate.
 
-step 'cargo build --workspace --release --locked'
-cargo build --workspace --release --locked
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+ci_script="$repo_root/scripts/ci-local.sh"
 
-step 'cargo deny check'
-cargo deny check
+if [ ! -x "$ci_script" ]; then
+    echo "pre-push: $ci_script is missing or not executable." >&2
+    echo "pre-push: restore it from \`origin/master\` and run \`chmod +x $ci_script\`." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC2086  # intentional word-splitting for flag pass-through.
+"$ci_script" ${PRE_PUSH_CI_FLAGS:-}
 
 printf '\npre-push: all CI checks passed.\n' >&2
 exit 0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,36 @@ Small utilities used by automation (review subagents, CI helpers). Each
 script is **pre-approved** in `.claude/settings.local.json` so it runs
 without a permission prompt.
 
+## `ci-local.sh`
+
+Run every CI gate from `.github/workflows/ci.yml` locally, in the same order, with the same flags. Mirror of:
+
+1. `cargo fmt --check`
+2. `cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings`
+3. `cargo test --workspace --exclude beast-render --all-targets --locked`
+4. `cargo test --workspace --exclude beast-render --doc --locked`
+5. `cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings`
+6. `cargo test  -p beast-render --no-default-features --features headless --all-targets --locked`
+7. `cargo deny check`                                                   *(skipped if cargo-deny isn't installed)*
+8. `cargo llvm-cov` summary                                             *(skipped if cargo-llvm-cov isn't installed)*
+9. `.github/scripts/run-quality-metrics.sh`                             *(skipped if `lizard` isn't installed)*
+10. `cargo build --release --workspace --exclude beast-render --locked`
+11. `cargo build --release -p beast-render --headless --locked`
+12. `cargo test --test determinism_test --release` *(once the M1 target lands)*
+
+### Usage
+
+```bash
+scripts/ci-local.sh                  # fail-fast (recommended for pre-push)
+scripts/ci-local.sh --keep-going     # run every gate, then list failures
+scripts/ci-local.sh --quick          # skip release builds, coverage, quality
+scripts/ci-local.sh --no-render      # skip the SDL3-from-source render steps
+```
+
+The script forces `RUSTFLAGS=-D warnings` and `CARGO_INCREMENTAL=0` so the local run matches CI bit-for-bit. Optional gates (cargo-deny, cargo-llvm-cov, lizard) print a clear "skipped" line when the tool isn't installed instead of failing.
+
+---
+
 ## `post-pr-review.sh`
 
 Post a complete GitHub PR review — overall body + every inline comment +

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Run every CI gate from `.github/workflows/ci.yml` locally, in the same
+# order, with the same flags. Fails fast on the first red step unless
+# `--keep-going` is passed, in which case every step runs and the script
+# exits non-zero if *any* step failed.
+#
+# Steps mirror the CI jobs:
+#   1. cargo fmt --check                          (lint-and-test)
+#   2. cargo clippy --workspace --exclude beast-render --all-targets -D warnings
+#   3. cargo test  --workspace --exclude beast-render --all-targets --locked
+#   4. cargo test  --workspace --exclude beast-render --doc --locked
+#   5. cargo clippy beast-render headless         (lint-and-test, render lane)
+#   6. cargo test  beast-render headless          (lint-and-test, render lane)
+#   7. cargo deny check                           (cargo-deny)            [skipped if not installed]
+#   8. cargo llvm-cov summary                     (coverage)              [skipped if not installed]
+#   9. .github/scripts/run-quality-metrics.sh     (quality-metrics)       [skipped if lizard missing]
+#  10. cargo build --release --workspace --exclude beast-render --locked  (release-build)
+#  11. cargo build --release -p beast-render --headless --locked          (release-build, render lane)
+#  12. cargo test --test determinism_test --release  (M1 determinism gate, runs only once it lands)
+#
+# Usage:
+#   scripts/ci-local.sh                 # fail-fast
+#   scripts/ci-local.sh --keep-going    # run everything, report failures at end
+#   scripts/ci-local.sh --quick         # skip release builds + coverage + quality
+#   scripts/ci-local.sh --no-render     # skip the SDL3-from-source render steps
+#
+# Exit codes:
+#   0  all gates green
+#   1  one or more gates failed
+#   64 bad CLI usage
+
+set -uo pipefail
+
+KEEP_GOING=0
+QUICK=0
+NO_RENDER=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep-going) KEEP_GOING=1 ;;
+    --quick)      QUICK=1 ;;
+    --no-render)  NO_RENDER=1 ;;
+    -h|--help)
+      sed -n '2,32p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 64
+      ;;
+  esac
+done
+
+# Match the CI environment exactly. `-D warnings` is propagated to every
+# `cargo *` invocation through RUSTFLAGS so any new lint that lands later
+# trips here too.
+export CARGO_TERM_COLOR=always
+export CARGO_INCREMENTAL=0
+export RUSTFLAGS="${RUSTFLAGS:--D warnings}"
+export RUST_BACKTRACE=short
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ANSI helpers — degrade gracefully if stdout isn't a tty.
+if [[ -t 1 ]]; then
+  C_BOLD=$(printf '\033[1m')
+  C_GREEN=$(printf '\033[32m')
+  C_YELLOW=$(printf '\033[33m')
+  C_RED=$(printf '\033[31m')
+  C_DIM=$(printf '\033[2m')
+  C_RESET=$(printf '\033[0m')
+else
+  C_BOLD=""; C_GREEN=""; C_YELLOW=""; C_RED=""; C_DIM=""; C_RESET=""
+fi
+
+declare -a FAILED_STEPS
+TOTAL=0
+
+# Run a named step. On failure either bail or, with --keep-going, record
+# the step name and continue.
+step() {
+  local name="$1"; shift
+  TOTAL=$((TOTAL+1))
+  printf '\n%s=== [%d] %s%s\n' "$C_BOLD" "$TOTAL" "$name" "$C_RESET"
+  printf '%s$ %s%s\n' "$C_DIM" "$*" "$C_RESET"
+  local start ended dt rc
+  start=$(date +%s)
+  "$@"
+  rc=$?
+  ended=$(date +%s)
+  dt=$((ended - start))
+  if [[ $rc -eq 0 ]]; then
+    printf '%s✓ %s — %ds%s\n' "$C_GREEN" "$name" "$dt" "$C_RESET"
+  else
+    printf '%s✗ %s — failed in %ds (exit %d)%s\n' "$C_RED" "$name" "$dt" "$rc" "$C_RESET"
+    FAILED_STEPS+=("$name")
+    if [[ $KEEP_GOING -eq 0 ]]; then
+      summarize
+      exit 1
+    fi
+  fi
+}
+
+# Run a step that may legitimately not be runnable on this host (e.g.
+# cargo-deny not installed). On a missing-tool / not-applicable case
+# print a clear "skipped" note instead of failing.
+optional_step() {
+  local name="$1"; shift
+  local probe="$1"; shift   # command that exits 0 if the tool is available
+  TOTAL=$((TOTAL+1))
+  printf '\n%s=== [%d] %s%s\n' "$C_BOLD" "$TOTAL" "$name" "$C_RESET"
+  if ! eval "$probe" >/dev/null 2>&1; then
+    printf '%s↷ %s — skipped (missing prerequisite)%s\n' "$C_YELLOW" "$name" "$C_RESET"
+    return 0
+  fi
+  printf '%s$ %s%s\n' "$C_DIM" "$*" "$C_RESET"
+  local rc
+  "$@"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    printf '%s✓ %s%s\n' "$C_GREEN" "$name" "$C_RESET"
+  else
+    printf '%s✗ %s — failed (exit %d)%s\n' "$C_RED" "$name" "$rc" "$C_RESET"
+    FAILED_STEPS+=("$name")
+    if [[ $KEEP_GOING -eq 0 ]]; then
+      summarize
+      exit 1
+    fi
+  fi
+}
+
+summarize() {
+  printf '\n%s── summary ──%s\n' "$C_BOLD" "$C_RESET"
+  if [[ ${#FAILED_STEPS[@]} -eq 0 ]]; then
+    printf '%s✓ all %d gates passed%s\n' "$C_GREEN" "$TOTAL" "$C_RESET"
+  else
+    printf '%s✗ %d / %d gates failed:%s\n' "$C_RED" "${#FAILED_STEPS[@]}" "$TOTAL" "$C_RESET"
+    for s in "${FAILED_STEPS[@]}"; do
+      printf '  - %s\n' "$s"
+    done
+  fi
+}
+
+# ----- 1. fmt -------------------------------------------------------------
+step "cargo fmt --check" \
+  cargo fmt --all -- --check
+
+# ----- 2. clippy (workspace minus beast-render) ---------------------------
+step "cargo clippy (workspace, exclude beast-render)" \
+  cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings
+
+# ----- 3. test (workspace minus beast-render) -----------------------------
+step "cargo test (workspace, exclude beast-render)" \
+  cargo test --workspace --exclude beast-render --all-targets --locked
+
+# ----- 4. doctests --------------------------------------------------------
+step "cargo test --doc" \
+  cargo test --workspace --exclude beast-render --doc --locked
+
+# ----- 5 + 6. beast-render headless --------------------------------------
+if [[ $NO_RENDER -eq 0 ]]; then
+  step "cargo clippy beast-render (headless)" \
+    cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings
+  step "cargo test beast-render (headless)" \
+    cargo test -p beast-render --no-default-features --features headless --all-targets --locked
+else
+  printf '\n%s↷ skipping beast-render headless steps (--no-render)%s\n' "$C_YELLOW" "$C_RESET"
+fi
+
+# ----- 7. cargo-deny -----------------------------------------------------
+optional_step "cargo deny check" \
+  "command -v cargo-deny" \
+  cargo deny check --hide-inclusion-graph
+
+if [[ $QUICK -eq 0 ]]; then
+  # ----- 8. coverage summary --------------------------------------------
+  optional_step "cargo llvm-cov (summary)" \
+    "command -v cargo-llvm-cov" \
+    cargo llvm-cov --workspace --exclude beast-render --all-targets --locked --summary-only --no-fail-fast
+
+  # ----- 9. quality metrics ---------------------------------------------
+  optional_step "quality-metrics (lizard)" \
+    "command -v lizard || python -m lizard --help" \
+    .github/scripts/run-quality-metrics.sh
+
+  # ----- 10 + 11. release build -----------------------------------------
+  step "cargo build --release (workspace, exclude beast-render)" \
+    cargo build --workspace --exclude beast-render --release --locked
+  if [[ $NO_RENDER -eq 0 ]]; then
+    step "cargo build --release beast-render (headless)" \
+      cargo build -p beast-render --no-default-features --features headless --release --locked
+  fi
+fi
+
+# ----- 12. determinism gate ----------------------------------------------
+# Skip silently if the test target doesn't exist yet — it lands once the
+# 100-tick replay test is wired into a workspace integration target.
+if cargo metadata --no-deps --format-version 1 2>/dev/null \
+   | grep -q '"determinism_test"'; then
+  step "cargo test --test determinism_test (release)" \
+    cargo test --test determinism_test --release --locked -- --nocapture
+else
+  printf '\n%s↷ determinism_test target not present — skipping (will gate once it lands)%s\n' \
+    "$C_YELLOW" "$C_RESET"
+fi
+
+summarize
+[[ ${#FAILED_STEPS[@]} -eq 0 ]] || exit 1


### PR DESCRIPTION
## Why
Reproducing a CI failure locally currently means running 6+ `cargo` invocations by hand with the right flags, the right exclusions, and the right `RUSTFLAGS`. Easy to drift, easy to miss a step. And the existing `.githooks/pre-push` ran its own near-duplicate sequence inline, so the two could (and did) diverge.

## What

### 1. `scripts/ci-local.sh`
Mirrors `.github/workflows/ci.yml` step-for-step:

1. `cargo fmt --check`
2. `cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings`
3. `cargo test  --workspace --exclude beast-render --all-targets --locked`
4. `cargo test  --workspace --exclude beast-render --doc --locked`
5. `cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings`
6. `cargo test  -p beast-render --no-default-features --features headless --all-targets --locked`
7. `cargo deny check`                                              *(skipped if cargo-deny isn't installed)*
8. `cargo llvm-cov` summary                                        *(skipped if cargo-llvm-cov isn't installed)*
9. `.github/scripts/run-quality-metrics.sh`                        *(skipped if `lizard` isn't installed)*
10. `cargo build --release --workspace --exclude beast-render --locked`
11. `cargo build --release -p beast-render --headless --locked`
12. `cargo test --test determinism_test --release` *(auto-skipped until the target lands)*

Same flags, same exclusions, same `RUSTFLAGS=-D warnings` env so the local run reproduces CI bit-for-bit. Optional gates print a clear "skipped" line when the prerequisite tool isn't installed.

#### Flags
```
--keep-going   run every gate, then list failures at the end
--quick        skip release builds, coverage, quality
--no-render    skip the SDL3-from-source render steps
```

### 2. `.githooks/pre-push` now delegates to the script
The pre-push hook used to inline its own fmt → clippy → test → release → cargo-deny sequence. It now calls `scripts/ci-local.sh` so the two stay in sync — the hook automatically picks up the new `beast-render` headless lane and the determinism gate.

`PRE_PUSH_CI_FLAGS` lets ad-hoc local runs opt out of the slow tail:

```bash
PRE_PUSH_CI_FLAGS="--quick" git push
```

Master-protection logic (block direct push / delete of master) is unchanged.

#### Activation
The hook is opt-in per clone (existing convention; documented at the top of the hook file). To wire it up on your machine:

```bash
git config core.hooksPath .githooks
```

`core.hooksPath` defaults to `.git/hooks/`, so the hook file alone wouldn't run without that one-time setting.

### 3. Pre-approval
`.claude/settings.local.json` (gitignored, not in this PR) gets allow entries for `Bash(scripts/ci-local.sh*)` so subagents can invoke it without a permission prompt.

## Test plan
- [x] `bash scripts/ci-local.sh --quick --no-render --keep-going` — all gates run; the only failure is the real `cargo deny check` (RUSTSEC paste / bincode unmaintained advisories, separate issue).
- [x] Failed-step exit codes report correctly.
- [x] `--quick` skips release / coverage / quality. `--no-render` skips beast-render gates.
- [x] `bash -n .githooks/pre-push` syntax-checks clean.
- [x] After merge + `git config core.hooksPath .githooks`, next `git push` runs the full suite.

## Notes
- Two cargo-deny advisories (`paste 1.0.15` and `bincode 1.3.3`) are flagged as unmaintained on the current `Cargo.lock`. They're CI failures today too — out of scope for this PR; tracked separately.
- Doesn't change CI itself.
