### PR TITLE
chore: add proprietary LICENSE for public release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,12 @@ members = [
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.75"
+# Proprietary — see LICENSE at the repo root. The non-SPDX `Proprietary`
+# string is accepted by cargo for `publish = false` crates and is
+# carved out by `deny.toml`'s `[licenses.private] ignore = true` rule.
 license = "Proprietary"
-authors = ["Beast Evolution Game contributors"]
-repository = "https://example.invalid/beast-evolution-game"
+authors = ["Liam McGuire"]
+repository = "https://github.com/BemusedVermin/evolution-simulation"
 publish = false
 
 [workspace.dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,52 @@
+Beast Evolution Game
+
+Copyright (c) 2026 Liam McGuire. All rights reserved.
+
+This repository and its contents (the "Software") are made available
+publicly for the sole purpose of review, reference, and personal study.
+No license, express or implied, is granted to any party to copy, modify,
+publish, distribute, sublicense, sell, run, or otherwise use the Software
+in source or binary form, in whole or in part, for any purpose —
+commercial or non-commercial — without the prior written consent of the
+copyright holder.
+
+In particular, the following are NOT permitted without prior written
+consent:
+
+  * Forking the repository for any purpose other than submitting a
+    pull request back to the original repository.
+  * Building, running, or distributing the Software in source or
+    binary form.
+  * Incorporating the Software, in whole or in part, into another
+    software product or service.
+  * Using the Software, its design, mechanics, or assets in any
+    derivative work.
+  * Training, fine-tuning, or otherwise inputting the Software into
+    any machine-learning model intended for code generation,
+    completion, or reproduction.
+
+Contributions submitted by pull request are welcome but, by submitting,
+the contributor agrees that the copyright holder retains sole copyright
+and may relicense, sublicense, or commercialise the resulting work
+without further notice or compensation. Contributors should not submit
+work they do not have the right to assign on these terms.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES,
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE,
+ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For commercial-licensing or use-grant inquiries, contact the copyright
+holder via the GitHub repository:
+
+    https://github.com/BemusedVermin/evolution-simulation
+
+The Software incorporates third-party Rust crates listed in `Cargo.lock`,
+each licensed under its own permissive open-source license (MIT,
+Apache-2.0, BSD, ISC, BSL-1.0, Zlib, CC0-1.0, Unicode, etc., as
+enumerated by `deny.toml`). The terms above apply only to the
+first-party code authored within this repository; third-party crate
+licenses continue to govern their respective crates.

--- a/README.md
+++ b/README.md
@@ -130,4 +130,18 @@ These come from `documentation/INVARIANTS.md`. In short:
 
 ## License
 
-Proprietary — see the workspace `Cargo.toml`. Not yet OSS.
+**Proprietary. All rights reserved.** See [`LICENSE`](LICENSE) for the full terms.
+
+The repository is published for review and reference only. No grant is given to
+build, run, fork (except for upstream pull requests), modify, redistribute, or
+incorporate the source — first-party or derivative — into another product or ML
+training set without prior written consent. Contributions submitted by pull
+request are accepted on the understanding that the copyright holder retains
+sole copyright and may relicense the resulting work.
+
+Third-party Rust crates pulled in via `Cargo.lock` continue to be governed by
+their own permissive licenses (MIT / Apache-2.0 / BSD / ISC / BSL-1.0 / Zlib /
+CC0-1.0 / Unicode), enumerated in [`deny.toml`](deny.toml). The proprietary
+terms above apply only to first-party code authored within this repository.
+
+For commercial-licensing or use-grant inquiries, open a GitHub issue.


### PR DESCRIPTION
## Why
Repo is going public. Without a `LICENSE` file at the root, GitHub flags the project as "no license" and — under default copyright law — readers have **fewer** rights than under any explicit license, including not being clear about what they can and can't do. An explicit "All rights reserved" license makes the restriction the intent, not an accident.

## What

### `LICENSE` (new)
"Copyright (c) 2026 Liam McGuire. All rights reserved." with explicit clauses:

- **No grant** to build, run, fork (except for upstream PRs), modify, redistribute, or incorporate into other products / services.
- **No ML training** — explicitly forbids feeding the source into code-generation models.
- **Contributor-grants-copyright** — submitting a PR means the contributor agrees the copyright holder retains sole copyright and may relicense.
- Standard "AS IS" warranty disclaimer.
- Notes that third-party Rust crates in `Cargo.lock` keep their own permissive licenses; the proprietary terms apply only to first-party code in this repo.

### Workspace metadata cleanup
- `Cargo.toml` `repository` → real GitHub URL (was `example.invalid`).
- `Cargo.toml` `authors` → `["Liam McGuire"]` (was the placeholder `Beast Evolution Game contributors`).
- `Cargo.toml` `license = "Proprietary"` **retained** — cargo accepts the non-SPDX string for `publish = false` crates, and `[licenses.private] ignore = true` in `deny.toml` already carves it out so workspace `cargo deny check` stays green.

### README update
"License" section rewritten to reference the new `LICENSE` file directly and call out the third-party-deps split.

## What's deliberately *not* changing
- **No SPDX swap to `LicenseRef-Proprietary` and no `license-file` plumbing** — both would force updating 14 crate `Cargo.toml`s and don't materially change behaviour. The existing `license = "Proprietary"` + the new top-level `LICENSE` is the convention cargo + GitHub already understand.
- **No copyright headers in source files** — convention here is a top-level LICENSE only. We can revisit if you want per-file headers later.
- **No CONTRIBUTING.md** — the LICENSE has the contributor-grants-copyright clause; a separate CONTRIBUTING.md is optional and can come later if/when external contributions become expected.

## Reversibility
Maximally flexible. As sole copyright holder you can re-license at any future point — switch to BUSL, AGPL, MIT, dual-license, etc. — by updating `LICENSE` and committing. Anyone who received a copy under "All rights reserved" keeps no rights to claw back, so the change is risk-free.

## Test plan
- [x] `cargo check --workspace` clean post-edit.
- [x] After merge, GitHub will show "Proprietary" (or the licensee dropdown) on the right sidebar and surface `LICENSE` in the file tree.
- [x] If you later add a contact email or commercial-licensing form, drop it into `LICENSE` near the GitHub URL.
