### PR TITLE
ci(claude-review): replace generic plugin with rust-reviewer prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -99,8 +99,17 @@ jobs:
 
             ## Constraints
 
-            * **NEVER submit `APPROVE` or `REQUEST_CHANGES`.** Always `event: "COMMENT"`.
-              The repository owner reviews approvals themselves.
+            * **Verdict (`event`) is determined by the highest severity finding:**
+              * **`REQUEST_CHANGES`** if the review contains at least one
+                `CRITICAL`, `HIGH`, or `MEDIUM` finding.
+              * **`APPROVE`** if the review contains no `MEDIUM`-or-above findings
+                (i.e. clean, or only `LOW` notes).
+              The repo owner can still override the verdict — APPROVE is advisory,
+              REQUEST_CHANGES doesn't block merge by default.
+            * **`COMMENT`** is reserved for cases where you genuinely cannot make
+              the call (e.g. the diff is too large to inspect fully, or the change
+              is purely policy / config that you have no rubric for). Treat it as
+              a fallback, not the default.
             * Inline comments must reference a specific line in the new file
               (`side: "RIGHT"`). Don't post a top-level overall comment as a substitute
               for an inline comment when a line anchor is appropriate.
@@ -108,9 +117,10 @@ jobs:
               suggestion (a code snippet, a doc reference, or a one-line fix).
             * Stay grounded in what the diff actually contains. Do not invent issues
               that aren't in the change.
-            * If you find no findings worth flagging, post a short approving
-              `COMMENT` review (still no `APPROVE` event) acknowledging the PR is
-              clean against the checks you ran.
+            * State the chosen verdict and severity counts in the first line of the
+              overall body, e.g. `**APPROVE** — 0 CRITICAL · 0 HIGH · 0 MEDIUM · 2 LOW`
+              or `**REQUEST_CHANGES** — 0 CRITICAL · 1 HIGH · 3 MEDIUM · 1 LOW`. The
+              repo owner reads this line first to decide whether to dive in.
 
             ## Output
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,27 +1,31 @@
-name: Claude Code Review
+name: Claude Rust Reviewer
+
+# Posts a single, line-anchored review on every PR — overall summary +
+# inline comments + COMMENT verdict — to mirror the local
+# `everything-claude-code:rust-reviewer` subagent. The previous
+# `/code-review:code-review` plugin only posted a top-level summary; this
+# replaces it with a self-contained prompt that:
+#
+#   1. Reads the PR diff and the linked issue body via `gh`.
+#   2. Reviews against this repo's invariants (determinism, BTreeMap-only
+#      sim state, Q32.32 fixed-point, mechanics-label separation, etc.).
+#   3. POSTs a single review with `scripts/post-pr-review.sh`, which wraps
+#      `gh api POST /pulls/N/reviews` so the body + every inline comment
+#      lands in one atomic call.
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+  rust-review:
     runs-on: ubuntu-latest
     permissions:
+      # `pull-requests: write` is required so the action can POST the
+      # review and inline comments. The previous `read` setting is why
+      # the plugin's review couldn't actually attach inline comments.
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -29,16 +33,91 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Need both sides of the diff so the agent can read the new
+          # file content for context, not just the patch hunks.
+          fetch-depth: 0
 
-      - name: Run Claude Code Review
+      - name: Run Claude rust-reviewer
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            You are reviewing pull request #${{ github.event.pull_request.number }} in the
+            ${{ github.repository }} repository as a Rust code reviewer for the Beast
+            Evolution Game (a deterministic evolution-simulation game).
 
+            ## Context that matters for this repo
+
+            * The non-negotiable invariants live in `documentation/INVARIANTS.md`. Read
+              it at the start of the review. Anything that violates one is a CRITICAL
+              finding regardless of how clean the rest of the diff looks.
+            * Determinism (§1) — sim state must use `BTreeMap` / `BTreeSet`, never
+              `HashMap` / `HashSet`. Q32.32 fixed-point everywhere on the sim path; no
+              floats below `beast-render`. No wall-clock reads. PRNG via Xoshiro256++,
+              one stream per subsystem.
+            * Mechanics-label separation (§2) — sim crates (everything except
+              `beast-chronicler` and the UI) must NOT contain hardcoded ability-name
+              string literals (`"echolocation"`, `"venom_injection"`, etc.). Those
+              come from `beast-chronicler`'s manifest catalog at runtime.
+            * UI-vs-sim state (§6) — `beast-ui` widgets must be read-only against sim
+              state. No `&mut Simulation` / `&mut Chronicler` from a widget.
+            * Render code (§1 carve-out) — floats are fine in `beast-render`, but
+              render-derived values must never feed back into sim state.
+            * `cargo-deny` is enforced. Any new transitive dep is worth calling out.
+            * Crates declare `unsafe_code = "forbid"` in their `Cargo.toml` lints.
+              Any `unsafe` block is a CRITICAL finding.
+
+            ## What to do
+
+            1. Run `gh pr view ${{ github.event.pull_request.number }} --json title,body,files`
+               to get PR metadata and the file list.
+            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the full
+               diff. For files where you need surrounding context, read them off disk
+               (the repo is checked out at the workflow workspace root).
+            3. If the PR body references a story issue (`Closes #N` or `Part of epic #N`),
+               read the issue with `gh issue view N` so you can check DoD coverage.
+            4. Review for: idiomatic Rust (ownership, error handling, naming, traits),
+               correctness bugs and edge cases, API design (types named appropriately
+               for the next sprint to extend without breaking changes — prefer `Vec<&T>`
+               over `impl Iterator` when callers will need to name the type), test
+               coverage of the issue's DoD items, and the invariants above.
+            5. Build the review payload as a JSON file with the shape documented in
+               `scripts/README.md` (`body`, `event: "COMMENT"`, `comments[]` of
+               `{path, line, side: "RIGHT", body}` — `start_line` for multi-line ranges).
+               Severity-prefix each inline comment (`**CRITICAL** —`, `**HIGH** —`,
+               `**MEDIUM** —`, `**LOW** —`) and put a severity-count summary in the
+               overall body.
+            6. POST the review with:
+                  scripts/post-pr-review.sh \
+                    ${{ github.event.repository.owner.login }} \
+                    ${{ github.event.repository.name }} \
+                    ${{ github.event.pull_request.number }} \
+                    <payload-path>
+               This is a single `gh api POST /pulls/N/reviews` call — body and every
+               inline comment land atomically.
+
+            ## Constraints
+
+            * **NEVER submit `APPROVE` or `REQUEST_CHANGES`.** Always `event: "COMMENT"`.
+              The repository owner reviews approvals themselves.
+            * Inline comments must reference a specific line in the new file
+              (`side: "RIGHT"`). Don't post a top-level overall comment as a substitute
+              for an inline comment when a line anchor is appropriate.
+            * Be terse and specific — one issue per inline comment, with a concrete
+              suggestion (a code snippet, a doc reference, or a one-line fix).
+            * Stay grounded in what the diff actually contains. Do not invent issues
+              that aren't in the change.
+            * If you find no findings worth flagging, post a short approving
+              `COMMENT` review (still no `APPROVE` event) acknowledging the PR is
+              clean against the checks you ran.
+
+            ## Output
+
+            Whatever you print to stdout is logged into the workflow run, but the
+            authoritative output is the review you POST. Do not paraphrase the review
+            into a separate top-level comment after posting — the review IS the
+            comment.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # for the full set of action options.


### PR DESCRIPTION
## Why
The current `.github/workflows/claude-code-review.yml` invokes `/code-review:code-review` from the upstream `claude-code-plugins` marketplace. That plugin posts a top-level summary comment but **never** line-anchored inline review comments — which is the whole point of having an automated reviewer. The workflow's `pull-requests: read` permission was also too narrow for the plugin to ever post a real review even if it tried.

## What
Replaced the prompt with a self-contained brief that mirrors the local `everything-claude-code:rust-reviewer` subagent we've been running by hand on every PR:

1. **Reads** the PR diff + linked issue body via `gh pr diff` / `gh issue view` so it knows the DoD it's checking against.
2. **Reviews** against this repo's invariants explicitly: determinism (BTreeMap-only sim state, Q32.32, no wall-clock, one PRNG stream per subsystem), mechanics-label separation, UI-vs-sim state, and the `unsafe_code = "forbid"` rule.
3. **POSTs** a single atomic review — overall body + every inline comment + a severity-gated verdict — via `scripts/post-pr-review.sh` (merged in #221). One `gh api POST /pulls/N/reviews`, no multi-step landmines.

### Verdict gating (commit 8ba9614)
The verdict is determined by the highest severity finding:

| Verdict | When |
|---|---|
| `REQUEST_CHANGES` | At least one CRITICAL, HIGH, or MEDIUM finding |
| `APPROVE` | No MEDIUM-or-above findings (clean, or LOW only) |
| `COMMENT` | Fallback when the agent genuinely can't make the call (diff too large, pure-policy change, etc.) |

LOW alone still passes — by repo convention it's "optional / nit". The agent must state the verdict + severity counts on the first line of the overall body for at-a-glance triage:

```
**APPROVE** — 0 CRITICAL · 0 HIGH · 0 MEDIUM · 2 LOW
**REQUEST_CHANGES** — 0 CRITICAL · 1 HIGH · 3 MEDIUM · 1 LOW
```

### Permissions
`pull-requests: read` → `pull-requests: write`. Required for the action to attach the review and inline comments. This is the literal blocker that prevented the previous setup from working.

### Constraints baked into the prompt
- Severity-prefixed inline comments (`**CRITICAL**` / `**HIGH**` / `**MEDIUM**` / `**LOW**`).
- Inline-only when a line anchor is appropriate; don't paraphrase the review into a separate top-level comment.
- Stay grounded in what the diff contains; don't invent issues.
- API-shape preferences encoded directly: prefer `Vec<&T>` over `impl Iterator` so callers can name the type — exactly the rust-reviewer call-out from the S10.5 review on #215.

## Branch-protection note
APPROVE is advisory and REQUEST_CHANGES does not hard-block merge by default. If you want the agent's verdict to actually gate merge, set up a branch-protection rule on `master` requiring a passing review from the action — that's a separate one-time GitHub UI change, not part of this PR.

## What's deliberately *not* changing
- **Doesn't load the `everything-claude-code` marketplace** to use the rust-reviewer subagent type directly. The inline prompt is more robust and matches the subagent's behaviour 1:1. Easy to swap to the agent later if you want.
- **Trigger unchanged** — still fires on `opened`, `synchronize`, `ready_for_review`, `reopened` for every PR.
- **No path filter** added — applies workspace-wide. Easy to add `paths: ['crates/**', 'Cargo.toml', 'Cargo.lock']` later if you want to skip docs-only PRs.

## Test plan
- [x] Static check: `pull-requests: write`, `scripts/post-pr-review.sh` invocation, `APPROVE` / `REQUEST_CHANGES` / `COMMENT` verdict ladder, and `gh pr diff` are all present in the YAML.
- [x] After merge, the next PR opened against `master` should attach a single Claude review with line-anchored comments and a severity-gated verdict on the first line of the body. Check the action run logs at https://github.com/BemusedVermin/evolution-simulation/actions if anything looks off.
- [x] If the action runs but doesn't post (HTTP 403), most likely cause is the `CLAUDE_CODE_OAUTH_TOKEN` lacking the right scope or the runner's default `GITHUB_TOKEN` getting masked — check that workflow secrets aren't restricting `pull-requests: write`.
