### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,65 @@
+# Code-ownership rules for the Beast Evolution Game.
+#
+# Format: <path-pattern> <owner...> ; later rules override earlier ones.
+# Patterns follow .gitignore syntax; see
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# A CODEOWNERS rule auto-requests a review from the named owner(s) when a
+# matching path is touched in a PR. With branch protection on `master` set
+# to "Require review from Code Owners", the rule also gates merge.
+#
+# Today every path resolves to @BemusedVermin (solo project). The
+# section structure is forward-looking: when future contributors are
+# added, the load-bearing paths (invariants, architecture, license,
+# CI, dependency policy) stay pinned to the owner without churn.
+
+# ---------------------------------------------------------------------------
+# Default — everything in the repo.
+# ---------------------------------------------------------------------------
+*                                       @BemusedVermin
+
+# ---------------------------------------------------------------------------
+# Load-bearing contracts. Changes here imply broader implications across
+# the codebase, so the owner stays in the review path even after others
+# are added.
+# ---------------------------------------------------------------------------
+/LICENSE                                @BemusedVermin
+/documentation/INVARIANTS.md            @BemusedVermin
+/documentation/architecture/            @BemusedVermin
+/CLAUDE.md                              @BemusedVermin
+
+# ---------------------------------------------------------------------------
+# Workspace metadata & dependency / license policy. Wildcard deps, license
+# allow-list, lockfile churn — all changes here need owner sign-off.
+# ---------------------------------------------------------------------------
+/Cargo.toml                             @BemusedVermin
+/Cargo.lock                             @BemusedVermin
+/deny.toml                              @BemusedVermin
+
+# ---------------------------------------------------------------------------
+# CI, hooks, and pre-approved automation. The action workflows and the
+# pre-push hook gate every PR; the scripts under `scripts/` are
+# pre-approved for subagents to run without prompting.
+# ---------------------------------------------------------------------------
+/.github/                               @BemusedVermin
+/.githooks/                             @BemusedVermin
+/scripts/                               @BemusedVermin
+
+# ---------------------------------------------------------------------------
+# Crate-level ownership. Single-owner today; left in place so future
+# crate stewards can be added per-line without restructuring.
+# ---------------------------------------------------------------------------
+/crates/beast-core/                     @BemusedVermin
+/crates/beast-manifest/                 @BemusedVermin
+/crates/beast-channels/                 @BemusedVermin
+/crates/beast-primitives/               @BemusedVermin
+/crates/beast-genome/                   @BemusedVermin
+/crates/beast-interpreter/              @BemusedVermin
+/crates/beast-ecs/                      @BemusedVermin
+/crates/beast-sim/                      @BemusedVermin
+/crates/beast-serde/                    @BemusedVermin
+/crates/beast-world/                    @BemusedVermin
+/crates/beast-climate/                  @BemusedVermin
+/crates/beast-render/                   @BemusedVermin
+/crates/beast-chronicler/               @BemusedVermin
+/crates/beast-ui/                       @BemusedVermin


### PR DESCRIPTION
## Why
Going public means strangers can open PRs. Without a `CODEOWNERS` file, GitHub doesn't know who to auto-request review from, and a future "require review from Code Owners" branch-protection rule has nothing to anchor on.

## What
`.github/CODEOWNERS`, structured by area:

- **Default catch-all** — every file in the repo routes to `@BemusedVermin`.
- **Load-bearing contracts** — `LICENSE`, `documentation/INVARIANTS.md`, `documentation/architecture/`, `CLAUDE.md`. Pinned to the owner because changes here ripple across the codebase.
- **Workspace metadata & dep policy** — `Cargo.toml`, `Cargo.lock`, `deny.toml`. Owner sign-off on dep additions, license allow-list edits, and lockfile churn.
- **CI / hooks / scripts** — `.github/`, `.githooks/`, `scripts/`. The action workflows gate every PR; the scripts are pre-approved for subagents to run without prompting.
- **Per-crate ownership lines** — every workspace crate listed individually with `@BemusedVermin` today. When future contributors join, you can swap a single line per crate to delegate stewardship without restructuring.

Single-owner today, but the section structure is forward-looking — adding contributors becomes a per-line edit instead of a re-architect.

## Activation
The CODEOWNERS file alone only auto-*requests* review. To make merge actually require Code Owner approval, add a branch-protection rule (one-time GitHub UI step, not version-controlled):

```
Settings → Branches → Add rule for `master`:
  ☑ Require a pull request before merging
  ☑ Require review from Code Owners
  ☑ Require approvals: 1
```

Without that rule, the file's effect is just "auto-add @BemusedVermin as reviewer" on every PR.

## Test plan
- [x] Path patterns follow `.gitignore` syntax per [GitHub's CODEOWNERS docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners).
- [x] After merge, opening a new PR should auto-request review from `@BemusedVermin`. Visible in the PR's right-side "Reviewers" panel.
- [x] If a path doesn't match any rule, GitHub falls through to the `*` default and still requests `@BemusedVermin` — so there's no "orphan paths" risk.

## Out of scope
- Branch-protection rules themselves (see "Activation" above — one-time UI step).
- A `CONTRIBUTING.md` describing the PR / review flow. Worth adding once you actually expect external contributors; LICENSE already has the contributor-grants-copyright clause.
