### PR TITLE
fix(ci): clear all quality gates (deny + lizard + doc coverage)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,27 @@
+name: "Beast Evolution Game CodeQL config"
+
+# Query suites we run.
+#
+# * `security-extended` is a strict superset of the default `security`
+#   suite and pulls in higher-precision (still high-confidence) checks.
+#   The CodeQL alert that flagged the previous `workflow_run` checkout
+#   of an untrusted ref came from this suite.
+# * `security-and-quality` would add maintainability/style checks; we
+#   already get those from clippy + lizard, so we don't double up here.
+queries:
+  - uses: security-extended
+
+# Paths CodeQL must skip outright (extraction is not even attempted).
+# Keep this list short — `paths-ignore` is more flexible and lets the
+# extractor at least walk the tree.
+paths-ignore:
+  # Cargo build output. Re-extracting these on every run wastes time
+  # and surfaces findings we can't act on (third-party generated code).
+  - target/
+  - "**/target/"
+  # Vendored / generated assets that aren't source we ship.
+  - documentation/
+  - "**/*.md"
+  # Tests are still scanned (security findings in tests still matter),
+  # but the workflow's QA artefact dirs are not — they're generated.
+  - .github/qa/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,30 +40,39 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
-      # `--exclude beast-render` keeps the main lint + test jobs off the
-      # `sdl3` build-from-source path so the L0–L4 crates get fast feedback
-      # without each PR paying the cost of compiling SDL3 + cmake. The
-      # render crate is exercised separately a few steps down in headless
-      # mode; the cross-platform job covers the SDL backend in S9.* once
-      # Linux system deps are sorted.
+      # `--exclude beast-render` and `--exclude beast-ui` keep the main
+      # lint + test jobs off the `sdl3` build-from-source path so the
+      # L0–L4 crates get fast feedback without each PR paying the cost of
+      # compiling SDL3 + cmake. `beast-ui` defaults to the `sdl` feature
+      # (which propagates to `beast-render/sdl`), so it has to be excluded
+      # alongside `beast-render` itself or cargo will pull in SDL3 via the
+      # transitive dep. Both crates are exercised separately a few steps
+      # down in headless mode; the cross-platform job covers the SDL
+      # backend in S9.* once Linux system deps are sorted.
       - name: cargo clippy (all targets, -D warnings)
-        run: cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude beast-render --exclude beast-ui --all-targets -- -D warnings
 
       - name: cargo test (unit + integration)
-        run: cargo test --workspace --exclude beast-render --all-targets --locked
+        run: cargo test --workspace --exclude beast-render --exclude beast-ui --all-targets --locked
 
       - name: cargo test --doc
-        run: cargo test --workspace --exclude beast-render --doc --locked
+        run: cargo test --workspace --exclude beast-render --exclude beast-ui --doc --locked
 
-      # beast-render: exercise the public API + headless backend.
-      # `--no-default-features --features headless` skips the SDL3
-      # source build, so this step doesn't need cmake/X11/Wayland on the
-      # runner.
+      # beast-render + beast-ui: exercise the public API + headless
+      # backend. `--no-default-features --features headless` skips the
+      # SDL3 source build, so these steps don't need cmake/X11/Wayland
+      # on the runner.
       - name: cargo clippy beast-render (headless)
         run: cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings
 
       - name: cargo test beast-render (headless)
         run: cargo test -p beast-render --no-default-features --features headless --all-targets --locked
+
+      - name: cargo clippy beast-ui (headless)
+        run: cargo clippy -p beast-ui --no-default-features --features headless --all-targets -- -D warnings
+
+      - name: cargo test beast-ui (headless)
+        run: cargo test -p beast-ui --no-default-features --features headless --all-targets --locked
 
   # Cross-platform determinism sanity: the Box-Muller Gaussian and the PRNG
   # both claim bit-identical output across x86_64 targets. Running tests on
@@ -89,14 +98,17 @@ jobs:
         with:
           shared-key: ci-${{ matrix.os }}
 
-      # See lint-and-test for why beast-render is excluded here. Linux is
-      # the easy target for SDL3 from source; Windows + macOS get a
-      # follow-up job once Linux passes.
+      # See lint-and-test for why beast-render and beast-ui are excluded
+      # here. Linux is the easy target for SDL3 from source; Windows +
+      # macOS get a follow-up job once Linux passes.
       - name: cargo test
-        run: cargo test --workspace --exclude beast-render --all-targets --locked
+        run: cargo test --workspace --exclude beast-render --exclude beast-ui --all-targets --locked
 
       - name: cargo test beast-render (headless)
         run: cargo test -p beast-render --no-default-features --features headless --all-targets --locked
+
+      - name: cargo test beast-ui (headless)
+        run: cargo test -p beast-ui --no-default-features --features headless --all-targets --locked
 
   # Dependency audit: advisories, licenses, unknown registries / git sources.
   # Configuration lives in `deny.toml` at the repo root. Failing here means a
@@ -144,15 +156,19 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
-      # Coverage excludes beast-render's SDL backend for the same reason
-      # the lint-and-test job does (Linux runner doesn't yet have the
-      # X11/Wayland system deps SDL3 needs). The headless backend is
-      # included so the public API surface still gets covered.
+      # Coverage excludes beast-render's and beast-ui's SDL-feature build
+      # for the same reason the lint-and-test job does (Linux runner
+      # doesn't yet have the X11/Wayland system deps SDL3 needs). The
+      # headless backend is included so the public API surface still gets
+      # covered.
       - name: cargo llvm-cov (summary)
-        run: cargo llvm-cov --workspace --exclude beast-render --all-targets --locked --summary-only --no-fail-fast
+        run: cargo llvm-cov --workspace --exclude beast-render --exclude beast-ui --all-targets --locked --summary-only --no-fail-fast
 
       - name: cargo llvm-cov beast-render (headless)
         run: cargo llvm-cov -p beast-render --no-default-features --features headless --all-targets --locked --no-report
+
+      - name: cargo llvm-cov beast-ui (headless)
+        run: cargo llvm-cov -p beast-ui --no-default-features --features headless --all-targets --locked --no-report
 
       - name: cargo llvm-cov (JSON summary artifact)
         run: cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
@@ -233,11 +249,16 @@ jobs:
         with:
           shared-key: ci-release
 
-      # Release build excludes beast-render until the Linux runner has the
-      # native deps SDL3 needs (X11, libxext, libxrandr, …). Tracked as a
-      # follow-up to S9.1 — see PR description.
+      # Release build excludes beast-render and beast-ui until the Linux
+      # runner has the native deps SDL3 needs (X11, libxext, libxrandr,
+      # …). beast-ui defaults to the `sdl` feature which transitively
+      # pulls SDL3 in, so it has to be excluded alongside beast-render.
+      # Tracked as a follow-up to S9.1 — see PR description.
       - name: cargo build --release
-        run: cargo build --workspace --exclude beast-render --release --locked
+        run: cargo build --workspace --exclude beast-render --exclude beast-ui --release --locked
 
       - name: cargo build --release beast-render (headless)
         run: cargo build -p beast-render --no-default-features --features headless --release --locked
+
+      - name: cargo build --release beast-ui (headless)
+        run: cargo build -p beast-ui --no-default-features --features headless --release --locked

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,13 +12,40 @@ name: Claude Rust Reviewer
 #   3. POSTs a single review with `scripts/post-pr-review.sh`, which wraps
 #      `gh api POST /pulls/N/reviews` so the body + every inline comment
 #      lands in one atomic call.
+#
+# ## Trigger: `workflow_run` after CI, not `pull_request` directly
+#
+# The reviewer is gated on the CI workflow completing successfully so:
+#
+#   * The review reflects the same code state CI just signed off on (no
+#     race where the reviewer posts before clippy/tests/quality-metrics
+#     have a verdict).
+#   * Tokens aren't burned reviewing PRs whose builds are red — the
+#     `if:` clause below skips when `workflow_run.conclusion != 'success'`.
+#   * Pushing a new commit to a PR branch re-runs CI which, on success,
+#     re-runs this reviewer automatically. No separate trigger needed.
+#
+# Caveats of `workflow_run`:
+#   * GitHub uses the workflow file that exists on the **default branch**
+#     when this trigger fires. Edits on a PR don't take effect for that
+#     PR — only for future PRs once merged.
+#   * `github.event.pull_request.*` is unavailable; the PR number is
+#     resolved from `workflow_run.pull_requests[0]` (or, for fork PRs,
+#     from a head-SHA → PRs API lookup).
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
   rust-review:
+    # Only review PR-triggered CI runs that finished green. Skips:
+    #   - direct pushes to master (workflow_run.event != 'pull_request')
+    #   - failed / cancelled / skipped CI runs (conclusion != 'success')
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       # `pull-requests: write` is required so the action can POST the
@@ -30,20 +57,48 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Resolve PR number from workflow_run
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The same-repo case fills `pull_requests[]` directly; the
+          # fork-PR case leaves it empty and we fall back to a SHA lookup.
+          PR_HINT: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -eu
+          pr_number=$(jq -r '.[0].number // empty' <<<"$PR_HINT")
+          if [ -z "$pr_number" ]; then
+            pr_number=$(gh api \
+              "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[0].number // empty')
+          fi
+          if [ -z "$pr_number" ]; then
+            echo "no PR associated with head_sha=${HEAD_SHA}; skipping review" >&2
+            exit 0
+          fi
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR number: ${pr_number}"
+
+      - name: Checkout PR HEAD
+        if: steps.pr.outputs.pr_number != ''
         uses: actions/checkout@v6
         with:
+          # Pin to the exact commit CI just verified, not the branch tip
+          # (which may have moved on by now if the author pushed again).
+          ref: ${{ github.event.workflow_run.head_sha }}
           # Need both sides of the diff so the agent can read the new
           # file content for context, not just the patch hunks.
           fetch-depth: 0
 
       - name: Run Claude rust-reviewer
+        if: steps.pr.outputs.pr_number != ''
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are reviewing pull request #${{ github.event.pull_request.number }} in the
+            You are reviewing pull request #${{ steps.pr.outputs.pr_number }} in the
             ${{ github.repository }} repository as a Rust code reviewer for the Beast
             Evolution Game (a deterministic evolution-simulation game).
 
@@ -70,9 +125,9 @@ jobs:
 
             ## What to do
 
-            1. Run `gh pr view ${{ github.event.pull_request.number }} --json title,body,files`
+            1. Run `gh pr view ${{ steps.pr.outputs.pr_number }} --json title,body,files`
                to get PR metadata and the file list.
-            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the full
+            2. Run `gh pr diff ${{ steps.pr.outputs.pr_number }}` to get the full
                diff. For files where you need surrounding context, read them off disk
                (the repo is checked out at the workflow workspace root).
             3. If the PR body references a story issue (`Closes #N` or `Part of epic #N`),
@@ -92,7 +147,7 @@ jobs:
                   scripts/post-pr-review.sh \
                     ${{ github.event.repository.owner.login }} \
                     ${{ github.event.repository.name }} \
-                    ${{ github.event.pull_request.number }} \
+                    ${{ steps.pr.outputs.pr_number }} \
                     <payload-path>
                This is a single `gh api POST /pulls/N/reviews` call — body and every
                inline comment land atomically.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,16 +80,25 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
           echo "Resolved PR number: ${pr_number}"
 
-      - name: Checkout PR HEAD
+      # SECURITY: workflow_run runs with full `pull-requests: write` against
+      # the trusted default-branch workflow file. Checking out the PR's
+      # head_sha would put untrusted code (e.g. a malicious
+      # scripts/post-pr-review.sh) on disk and run it with our token —
+      # CodeQL's "privileged workflow / untrusted code" pattern. So we
+      # check out the default branch instead, and the agent fetches the
+      # PR diff and any PR-side file content over the GitHub API
+      # (`gh pr diff`, `gh api repos/.../contents/...?ref=<head_sha>`).
+      # Trusted local files (post-pr-review.sh, README) come from
+      # master.
+      - name: Checkout default branch (trusted)
         if: steps.pr.outputs.pr_number != ''
         uses: actions/checkout@v6
         with:
-          # Pin to the exact commit CI just verified, not the branch tip
-          # (which may have moved on by now if the author pushed again).
-          ref: ${{ github.event.workflow_run.head_sha }}
-          # Need both sides of the diff so the agent can read the new
-          # file content for context, not just the patch hunks.
-          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          # Shallow is fine — we don't need PR history on disk; the
+          # agent reads the diff via the API.
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude rust-reviewer
         if: steps.pr.outputs.pr_number != ''
@@ -128,8 +137,14 @@ jobs:
             1. Run `gh pr view ${{ steps.pr.outputs.pr_number }} --json title,body,files`
                to get PR metadata and the file list.
             2. Run `gh pr diff ${{ steps.pr.outputs.pr_number }}` to get the full
-               diff. For files where you need surrounding context, read them off disk
-               (the repo is checked out at the workflow workspace root).
+               diff. For files where you need surrounding context **on the PR side**,
+               fetch them over the API rather than from disk:
+                 gh api "repos/${{ github.repository }}/contents/<path>?ref=${{ github.event.workflow_run.head_sha }}" \
+                   --jq '.content' | base64 -d
+               The local checkout is the **default branch**, not the PR — see the
+               security note in the workflow file. Trusted helpers
+               (`scripts/post-pr-review.sh`, `scripts/README.md`) come from disk and
+               are safe to run; PR-side source files must be fetched.
             3. If the PR body references a story issue (`Closes #N` or `Part of epic #N`),
                read the issue with `gh issue view N` so you can check DoD coverage.
             4. Review for: idiomatic Rust (ownership, error handling, naming, traits),

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,22 +1,23 @@
 name: CodeQL
 
 # Replaces the repo-level "Default setup" with an Advanced setup driven
-# from this file. Two reasons we want the explicit workflow:
+# from this file. Why we want the explicit workflow:
 #
-#   1. The Rust extractor needs a working `cargo build`. The default
-#      setup runs autobuild, which on this workspace tries the
-#      SDL3-from-source path and fails on the Linux runner (no X11
-#      dev libs). This workflow uses `build-mode: manual` and matches
-#      the lint-and-test command exactly — same `--exclude` list,
-#      same locked deps.
-#   2. We can tune query suites and paths via .github/codeql/codeql-
-#      config.yml. The default setup gives us only the base `security`
-#      suite; the advanced setup we run here uses `security-extended`.
+#   * Tune query suites and paths via .github/codeql/codeql-config.yml.
+#     Default setup gives us only the base `security` suite; the
+#     advanced setup uses `security-extended`, which is what flagged
+#     the workflow_run checkout pattern in claude-code-review.yml.
+#   * Cover Actions YAML alongside Rust on a schedule we control.
+#   * Pin tooling and trigger on the same events as the rest of CI.
 #
-# **One-time UI step:** when this lands on master, disable the repo's
-# Default code-scanning setup at
+# **One-time UI step required for this to take effect:** disable the
+# repo's Default code-scanning setup at
 # `Settings → Code security → Code scanning → Default setup → Disable`.
-# Otherwise GitHub will run *both* setups and double-bill scan minutes.
+# Until that's done, this workflow's SARIF upload is rejected by GitHub
+# with the message "CodeQL analyses from advanced configurations cannot
+# be processed when the default setup is enabled" — i.e. the analysis
+# runs but the results are dropped on upload, and the check shows red.
+# After disabling, this advanced workflow is the single source of truth.
 
 on:
   push:
@@ -59,25 +60,25 @@ jobs:
           # `claude-code-review.yml`).
           - language: actions
             build-mode: none
-          # Rust source scanning. Beta as of 2024 but increasingly
-          # useful — flags things clippy doesn't (taint flow, unsafe
-          # propagation, etc.).
+          # Rust source scanning. As of CodeQL 2.25+ the Rust extractor
+          # uses `build-mode: none` exclusively — it parses sources and
+          # `cargo metadata` directly without invoking the compiler, so
+          # we don't need to mirror lint-and-test's --exclude list here.
+          # (`manual` is rejected: "Rust does not support the manual
+          # build mode.")
           - language: rust
-            build-mode: manual
+            build-mode: none
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # The Rust extractor needs `cargo metadata` to read the workspace
+      # graph; we install the toolchain so cargo is on PATH. No build
+      # step follows — `build-mode: none` skips compilation entirely.
       - name: Install Rust toolchain (stable)
         if: matrix.language == 'rust'
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build artifacts
-        if: matrix.language == 'rust'
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci-codeql
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -85,32 +86,6 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
-
-      # Match the lint-and-test job exactly so feature resolution
-      # mirrors what every other Linux job does — beast-render and
-      # beast-ui are excluded because the SDL3-from-source build
-      # needs X11 dev libs the runner lacks. Headless variants are
-      # still extracted because the workspace path-deps make CodeQL
-      # see the source either way.
-      - name: Build for CodeQL extraction
-        if: matrix.language == 'rust'
-        env:
-          CARGO_TERM_COLOR: always
-          CARGO_INCREMENTAL: 0
-          # Don't fail the build on warnings — CodeQL needs the build
-          # to succeed to extract; lint-and-test (the dedicated CI
-          # job) is where `-D warnings` lives.
-          RUSTFLAGS: ""
-        run: |
-          cargo build --workspace \
-            --exclude beast-render --exclude beast-ui \
-            --all-targets --locked
-          cargo build -p beast-render \
-            --no-default-features --features headless \
-            --all-targets --locked
-          cargo build -p beast-ui \
-            --no-default-features --features headless \
-            --all-targets --locked
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,118 @@
+name: CodeQL
+
+# Replaces the repo-level "Default setup" with an Advanced setup driven
+# from this file. Two reasons we want the explicit workflow:
+#
+#   1. The Rust extractor needs a working `cargo build`. The default
+#      setup runs autobuild, which on this workspace tries the
+#      SDL3-from-source path and fails on the Linux runner (no X11
+#      dev libs). This workflow uses `build-mode: manual` and matches
+#      the lint-and-test command exactly — same `--exclude` list,
+#      same locked deps.
+#   2. We can tune query suites and paths via .github/codeql/codeql-
+#      config.yml. The default setup gives us only the base `security`
+#      suite; the advanced setup we run here uses `security-extended`.
+#
+# **One-time UI step:** when this lands on master, disable the repo's
+# Default code-scanning setup at
+# `Settings → Code security → Code scanning → Default setup → Disable`.
+# Otherwise GitHub will run *both* setups and double-bill scan minutes.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Sunday 06:00 UTC. Catches advisories that landed against
+    # already-shipped code without us needing a push to trigger.
+    - cron: "0 6 * * 0"
+
+# Cancel older in-flight scans on the same ref so a fast-following
+# push doesn't queue a stale analysis behind the new one.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # `security-events: write` is required so the analyze step can upload
+  # SARIF results to the code-scanning database. No other write scope
+  # is needed.
+  security-events: write
+  # `actions: read` lets the action enumerate caller workflows for
+  # dependency-resolution. Read-only by design.
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions YAML scanning. Picks up workflow-injection
+          # and privilege-escalation patterns (this is the suite that
+          # flagged the workflow_run checkout we fixed in
+          # `claude-code-review.yml`).
+          - language: actions
+            build-mode: none
+          # Rust source scanning. Beta as of 2024 but increasingly
+          # useful — flags things clippy doesn't (taint flow, unsafe
+          # propagation, etc.).
+          - language: rust
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain (stable)
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build artifacts
+        if: matrix.language == 'rust'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-codeql
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # Match the lint-and-test job exactly so feature resolution
+      # mirrors what every other Linux job does — beast-render and
+      # beast-ui are excluded because the SDL3-from-source build
+      # needs X11 dev libs the runner lacks. Headless variants are
+      # still extracted because the workspace path-deps make CodeQL
+      # see the source either way.
+      - name: Build for CodeQL extraction
+        if: matrix.language == 'rust'
+        env:
+          CARGO_TERM_COLOR: always
+          CARGO_INCREMENTAL: 0
+          # Don't fail the build on warnings — CodeQL needs the build
+          # to succeed to extract; lint-and-test (the dedicated CI
+          # job) is where `-D warnings` lives.
+          RUSTFLAGS: ""
+        run: |
+          cargo build --workspace \
+            --exclude beast-render --exclude beast-ui \
+            --all-targets --locked
+          cargo build -p beast-render \
+            --no-default-features --features headless \
+            --all-targets --locked
+          cargo build -p beast-ui \
+            --no-default-features --features headless \
+            --all-targets --locked
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/crates/beast-channels/src/composition.rs
+++ b/crates/beast-channels/src/composition.rs
@@ -126,68 +126,63 @@ pub fn evaluate_hook(hook: &CompositionHook, other: Q3232) -> HookOutcome {
             factor: Q3232::ONE,
             gate_open: true,
         },
-        CompositionKind::Threshold => {
-            // The schema-validated load path always sets `threshold`
-            // for Threshold/Gating kinds, but `CompositionHook` is a
-            // public struct with public fields — external callers
-            // (mods, integration tests, fuzzers) can construct a
-            // hook with `threshold: None`. Fail-safe behaviour is
-            // **closed gate, zero contribution**: callers AND-gate
-            // `gate_open` across hooks to decide channel expression,
-            // so a missing-threshold hook must NOT silently enable
-            // expression (`HookOutcome::NEUTRAL`'s `gate_open: true`
-            // would do exactly that — opposite of fail-safe).
-            // `debug_assert!` still surfaces the misconstruction in
-            // development builds; release degrades to closed-gate.
-            let Some(t) = hook.threshold else {
-                debug_assert!(
-                    false,
-                    "CompositionHook {{ kind: Threshold, threshold: None }} — \
-                     load-time validation should have rejected this. \
-                     Falling back to closed gate in release.",
-                );
-                return HookOutcome {
-                    delta: Q3232::ZERO,
-                    factor: Q3232::ONE,
-                    gate_open: false,
-                };
-            };
-            if other >= t {
-                HookOutcome {
-                    delta: hook.coefficient * other,
-                    factor: Q3232::ONE,
-                    gate_open: true,
-                }
-            } else {
-                HookOutcome {
-                    delta: Q3232::ZERO,
-                    factor: Q3232::ONE,
-                    gate_open: false,
-                }
-            }
+        CompositionKind::Threshold => evaluate_threshold(hook.coefficient, other, hook.threshold),
+        CompositionKind::Gating => evaluate_gating(other, hook.threshold),
+    }
+}
+
+/// Closed-gate fallback used by Threshold/Gating when `threshold: None`
+/// slips past load-time validation.
+///
+/// The schema-validated load path always sets `threshold` for
+/// Threshold/Gating kinds, but `CompositionHook` has public fields —
+/// external callers (mods, integration tests, fuzzers) can construct
+/// `threshold: None`. Fail-safe behaviour is **closed gate, zero
+/// contribution**: callers AND-gate `gate_open` across hooks to decide
+/// channel expression, so a missing-threshold hook must not silently
+/// enable expression (`HookOutcome::NEUTRAL`'s `gate_open: true` would
+/// do exactly that — opposite of fail-safe).
+const CLOSED_GATE: HookOutcome = HookOutcome {
+    delta: Q3232::ZERO,
+    factor: Q3232::ONE,
+    gate_open: false,
+};
+
+fn evaluate_threshold(coefficient: Q3232, other: Q3232, threshold: Option<Q3232>) -> HookOutcome {
+    let Some(t) = threshold else {
+        debug_assert!(
+            false,
+            "CompositionHook {{ kind: Threshold, threshold: None }} — \
+             load-time validation should have rejected this. \
+             Falling back to closed gate in release.",
+        );
+        return CLOSED_GATE;
+    };
+    if other >= t {
+        HookOutcome {
+            delta: coefficient * other,
+            factor: Q3232::ONE,
+            gate_open: true,
         }
-        CompositionKind::Gating => {
-            // Same closed-gate fallback as Threshold above.
-            let Some(t) = hook.threshold else {
-                debug_assert!(
-                    false,
-                    "CompositionHook {{ kind: Gating, threshold: None }} — \
-                     load-time validation should have rejected this. \
-                     Falling back to closed gate in release.",
-                );
-                return HookOutcome {
-                    delta: Q3232::ZERO,
-                    factor: Q3232::ONE,
-                    gate_open: false,
-                };
-            };
-            let open = other >= t;
-            HookOutcome {
-                delta: Q3232::ZERO,
-                factor: Q3232::ONE,
-                gate_open: open,
-            }
-        }
+    } else {
+        CLOSED_GATE
+    }
+}
+
+fn evaluate_gating(other: Q3232, threshold: Option<Q3232>) -> HookOutcome {
+    let Some(t) = threshold else {
+        debug_assert!(
+            false,
+            "CompositionHook {{ kind: Gating, threshold: None }} — \
+             load-time validation should have rejected this. \
+             Falling back to closed gate in release.",
+        );
+        return CLOSED_GATE;
+    };
+    HookOutcome {
+        delta: Q3232::ZERO,
+        factor: Q3232::ONE,
+        gate_open: other >= t,
     }
 }
 

--- a/crates/beast-interpreter/src/lib.rs
+++ b/crates/beast-interpreter/src/lib.rs
@@ -39,14 +39,23 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+/// Per-body-site channel aggregation (Story 4.5 — issue #59).
 pub mod body_map;
+/// Hook composition + ordering (Story 4.3 — issue #57).
 pub mod composition;
+/// Primitive emission (Story 4.4 — issue #58).
 pub mod emission;
+/// Typed [`InterpreterError`] / [`Result`] for fallible interpreter ops.
 pub mod error;
+/// Affordance-driven hook expression filter (Story 4.2 — issue #56).
 pub mod expression;
+/// Top-level [`interpret_phenotype`] orchestrator wiring all stages.
 pub mod interpreter;
+/// Parameter expression parser + evaluator (Story 4.4 — issue #58).
 pub mod parameter_map;
+/// Phenotype data types: body sites, regions, life stages, environment.
 pub mod phenotype;
+/// Scale-band gating (Story 4.1 — issue #55).
 pub mod scale_band;
 
 pub use body_map::{

--- a/crates/beast-primitives/src/lib.rs
+++ b/crates/beast-primitives/src/lib.rs
@@ -24,12 +24,19 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+/// `PrimitiveCategory` taxonomy + `Modality` flags.
 pub mod category;
+/// Deterministic cost-function evaluator over Q32.32 parameter values.
 pub mod cost;
+/// `PrimitiveEffect`: an emitted (id, parameters) record from the interpreter.
 pub mod effect;
+/// Strongly typed primitive-manifest representation.
 pub mod manifest;
+/// Fixed-point `exp` / `ln` / `pow` helpers used by the cost evaluator.
 pub(crate) mod math;
+/// `PrimitiveRegistry`: deterministic [`std::collections::BTreeMap`]-backed index.
 pub mod registry;
+/// Two-stage (JSON Schema + semantic) manifest validator.
 pub mod schema;
 
 pub use category::{Modality, PrimitiveCategory};

--- a/crates/beast-render/examples/animation.rs
+++ b/crates/beast-render/examples/animation.rs
@@ -11,42 +11,20 @@
 //!   cargo run -p beast-render --example animation
 
 #[cfg(feature = "sdl")]
+use beast_core::Q3232;
+#[cfg(feature = "sdl")]
+use beast_interpreter::{LifeStage, ResolvedPhenotype};
+#[cfg(feature = "sdl")]
+use beast_render::blueprint::CreatureBlueprint;
+#[cfg(feature = "sdl")]
+use beast_render::{compile_blueprint, directive::ColorSpec, Animator, Renderer, WindowConfig};
+#[cfg(feature = "sdl")]
+use sdl3::{event::Event, keyboard::Keycode, pixels::Color, render::WindowCanvas};
+
+#[cfg(feature = "sdl")]
 fn main() -> beast_render::Result<()> {
-    use std::collections::BTreeMap;
-
-    use beast_core::Q3232;
-    use beast_interpreter::{LifeStage, ResolvedPhenotype};
-    use beast_render::{compile_blueprint, directive::ColorSpec, Animator, Renderer, WindowConfig};
-    use sdl3::{event::Event, keyboard::Keycode, pixels::Color};
-
-    // Build a "quadruped walker" phenotype so we get a 4-limb skeleton
-    // and the QuadrupedWalk locomotion style.
-    let mut phenotype = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
-    let channels: BTreeMap<String, Q3232> = [
-        ("elastic_deformation", 0.2_f64),
-        ("structural_rigidity", 0.2),
-        ("mass_density", 0.5),
-        ("metabolic_rate", 0.6),
-        ("surface_friction", 0.9),
-        ("kinetic_force", 0.7),
-    ]
-    .into_iter()
-    .map(|(k, v)| (k.to_string(), Q3232::from_num(v)))
-    .collect();
-    phenotype.global_channels = channels;
-
-    let blueprint = compile_blueprint(
-        &phenotype,
-        &[],
-        ColorSpec::rgb(
-            Q3232::from_num(120),
-            Q3232::from_num(0.4_f64),
-            Q3232::from_num(0.5_f64),
-        ),
-        "demo",
-    );
-
-    let walk_clip = &blueprint
+    let blueprint = build_walker_blueprint();
+    let walk_clip = blueprint
         .animations
         .locomotion
         .first()
@@ -79,34 +57,75 @@ fn main() -> beast_render::Result<()> {
         let canvas = renderer.canvas();
         canvas.set_draw_color(Color::RGB(20, 24, 32));
         canvas.clear();
-
-        // Draw each bone as a line. Origin is the screen centre; each
-        // bone-id maps to a horizontal slot so motion is visible.
-        canvas.set_draw_color(Color::RGB(220, 220, 240));
-        let cx: i32 = 640;
-        let cy: i32 = 360;
-        for (i, bone) in blueprint.skeleton.bones.iter().enumerate() {
-            let rotation_deg = pose
-                .bone_rotations
-                .iter()
-                .find(|r| r.bone_id == bone.id)
-                .map(|r| r.rotation.to_num::<f32>())
-                .unwrap_or(0.0);
-            let length: f32 = bone.length.to_num::<f32>() * 60.0;
-            let theta = rotation_deg.to_radians();
-            let (sin, cos) = theta.sin_cos();
-            let x0 = cx + (i as i32 * 40) - (blueprint.skeleton.bones.len() as i32 * 20);
-            let y0 = cy;
-            let x1 = x0 + (length * cos) as i32;
-            let y1 = y0 + (length * sin) as i32;
-            canvas
-                .draw_line((x0, y0), (x1, y1))
-                .map_err(|e| beast_render::RenderError::Sdl(e.to_string()))?;
-        }
-
+        draw_skeleton(canvas, &blueprint, &pose)?;
         renderer.present();
     }
 
+    Ok(())
+}
+
+/// Build a "quadruped walker" phenotype so we get a 4-limb skeleton and
+/// the QuadrupedWalk locomotion style.
+#[cfg(feature = "sdl")]
+fn build_walker_blueprint() -> CreatureBlueprint {
+    use std::collections::BTreeMap;
+
+    let mut phenotype = ResolvedPhenotype::new(Q3232::from_num(50_i32), LifeStage::Adult);
+    let channels: BTreeMap<String, Q3232> = [
+        ("elastic_deformation", 0.2_f64),
+        ("structural_rigidity", 0.2),
+        ("mass_density", 0.5),
+        ("metabolic_rate", 0.6),
+        ("surface_friction", 0.9),
+        ("kinetic_force", 0.7),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), Q3232::from_num(v)))
+    .collect();
+    phenotype.global_channels = channels;
+
+    compile_blueprint(
+        &phenotype,
+        &[],
+        ColorSpec::rgb(
+            Q3232::from_num(120),
+            Q3232::from_num(0.4_f64),
+            Q3232::from_num(0.5_f64),
+        ),
+        "demo",
+    )
+}
+
+/// Draw each bone as a line. Origin is the screen centre; each bone-id
+/// maps to a horizontal slot so motion is visible.
+#[cfg(feature = "sdl")]
+fn draw_skeleton(
+    canvas: &mut WindowCanvas,
+    blueprint: &CreatureBlueprint,
+    pose: &beast_render::animation::PoseFrame,
+) -> beast_render::Result<()> {
+    canvas.set_draw_color(Color::RGB(220, 220, 240));
+    let cx: i32 = 640;
+    let cy: i32 = 360;
+    let bone_count = blueprint.skeleton.bones.len() as i32;
+    for (i, bone) in blueprint.skeleton.bones.iter().enumerate() {
+        let rotation_deg = pose
+            .bone_rotations
+            .iter()
+            .find(|r| r.bone_id == bone.id)
+            .map(|r| r.rotation.to_num::<f32>())
+            .unwrap_or(0.0);
+        let length: f32 = bone.length.to_num::<f32>() * 60.0;
+        let theta = rotation_deg.to_radians();
+        let (sin, cos) = theta.sin_cos();
+        let x0 = cx + (i as i32 * 40) - (bone_count * 20);
+        let y0 = cy;
+        let x1 = x0 + (length * cos) as i32;
+        let y1 = y0 + (length * sin) as i32;
+        canvas
+            .draw_line((x0, y0), (x1, y1))
+            .map_err(|e| beast_render::RenderError::Sdl(e.to_string()))?;
+    }
     Ok(())
 }
 

--- a/crates/beast-render/examples/encounter.rs
+++ b/crates/beast-render/examples/encounter.rs
@@ -13,21 +13,77 @@
 //!   cargo run -p beast-render --example encounter
 
 #[cfg(feature = "sdl")]
+use beast_core::Q3232;
+#[cfg(feature = "sdl")]
+use beast_interpreter::{LifeStage, ResolvedPhenotype};
+#[cfg(feature = "sdl")]
+use beast_render::blueprint::CreatureBlueprint;
+#[cfg(feature = "sdl")]
+use beast_render::encounter::{draw_encounter, Backdrop, EncounterEntity, Position2D, Projection};
+#[cfg(feature = "sdl")]
+use beast_render::{compile_blueprint, directive::ColorSpec, Renderer, WindowConfig};
+#[cfg(feature = "sdl")]
+use beast_world::BiomeTag;
+#[cfg(feature = "sdl")]
+use sdl3::{event::Event, keyboard::Keycode};
+
+#[cfg(feature = "sdl")]
 fn main() -> beast_render::Result<()> {
+    let blueprints = build_blueprints();
+    let positions: [Position2D; 5] = [
+        Position2D::new(-1.4, -0.4), // front-left
+        Position2D::new(0.0, -0.6),  // front-centre
+        Position2D::new(1.4, -0.4),  // front-right
+        Position2D::new(-0.7, 0.6),  // back-left
+        Position2D::new(0.7, 0.6),   // back-right
+    ];
+
+    let mut renderer = Renderer::new(WindowConfig {
+        title: "beast-render: S9.4 encounter".to_string(),
+        ..Default::default()
+    })?;
+
+    let backdrop = Backdrop::new(BiomeTag::Forest);
+    let projection = Projection::default();
+    let mut selected = 0_usize;
+
+    'mainloop: loop {
+        let events: Vec<Event> = renderer.event_pump().poll_iter().collect();
+        for event in events {
+            if !handle_event(event, &mut selected, blueprints.len()) {
+                break 'mainloop;
+            }
+        }
+
+        let entities: Vec<EncounterEntity<'_>> = blueprints
+            .iter()
+            .zip(positions.iter())
+            .enumerate()
+            .map(|(i, (bp, pos))| EncounterEntity {
+                id: i as u32,
+                blueprint: bp,
+                position: *pos,
+                selected: i == selected,
+            })
+            .collect();
+
+        let canvas = renderer.canvas();
+        canvas.set_draw_color(sdl3::pixels::Color::RGB(0, 0, 0));
+        canvas.clear();
+        draw_encounter(canvas, &backdrop, &entities, &projection)
+            .map_err(beast_render::RenderError::Sdl)?;
+        renderer.present();
+    }
+    Ok(())
+}
+
+/// Five hand-tuned phenotypes so each creature in the scene reads
+/// visibly different. Channel values map roughly to body-plan archetypes
+/// — elastic worm, rigid armor, tall sprinter, etc.
+#[cfg(feature = "sdl")]
+fn build_blueprints() -> Vec<CreatureBlueprint> {
     use std::collections::BTreeMap;
 
-    use beast_core::Q3232;
-    use beast_interpreter::{LifeStage, ResolvedPhenotype};
-    use beast_render::encounter::{
-        draw_encounter, Backdrop, EncounterEntity, Position2D, Projection,
-    };
-    use beast_render::{compile_blueprint, directive::ColorSpec, Renderer, WindowConfig};
-    use beast_world::BiomeTag;
-    use sdl3::{event::Event, keyboard::Keycode};
-
-    // Five hand-tuned phenotypes so each creature in the scene reads
-    // visibly different. Channel values map roughly to body-plan
-    // archetypes — elastic worm, rigid armor, tall sprinter, etc.
     let phenotype_specs: [&[(&str, f64)]; 5] = [
         // 0: elastic worm
         &[
@@ -77,7 +133,7 @@ fn main() -> beast_render::Result<()> {
         Q3232::from_num(0.5_f64),
     );
 
-    let blueprints: Vec<_> = phenotype_specs
+    phenotype_specs
         .iter()
         .enumerate()
         .map(|(i, channels)| {
@@ -88,75 +144,34 @@ fn main() -> beast_render::Result<()> {
                 .collect::<BTreeMap<_, _>>();
             compile_blueprint(&p, &[], neutral_biome, format!("creature_{i}"))
         })
-        .collect();
+        .collect()
+}
 
-    // Position 5 creatures in two rows: 3 in front, 2 in back.
-    let positions: [Position2D; 5] = [
-        Position2D::new(-1.4, -0.4), // front-left
-        Position2D::new(0.0, -0.6),  // front-centre
-        Position2D::new(1.4, -0.4),  // front-right
-        Position2D::new(-0.7, 0.6),  // back-left
-        Position2D::new(0.7, 0.6),   // back-right
-    ];
-
-    let mut renderer = Renderer::new(WindowConfig {
-        title: "beast-render: S9.4 encounter".to_string(),
-        ..Default::default()
-    })?;
-
-    let backdrop = Backdrop::new(BiomeTag::Forest);
-    let projection = Projection::default();
-    let mut selected = 0_usize;
-
-    'mainloop: loop {
-        // Snapshot canvas dims + collect events while no canvas borrow
-        // is live (same idiom as world_map example).
-        let events: Vec<Event> = renderer.event_pump().poll_iter().collect();
-        for event in events {
-            match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    keycode: Some(Keycode::Escape),
-                    ..
-                } => break 'mainloop,
-                Event::KeyDown {
-                    keycode: Some(Keycode::Tab),
-                    keymod,
-                    ..
-                } => {
-                    let len = blueprints.len();
-                    if keymod.contains(sdl3::keyboard::Mod::LSHIFTMOD)
-                        || keymod.contains(sdl3::keyboard::Mod::RSHIFTMOD)
-                    {
-                        selected = (selected + len - 1) % len;
-                    } else {
-                        selected = (selected + 1) % len;
-                    }
-                }
-                _ => {}
-            }
+/// Returns `false` to request shutdown of the main loop.
+#[cfg(feature = "sdl")]
+fn handle_event(event: Event, selected: &mut usize, len: usize) -> bool {
+    match event {
+        Event::Quit { .. }
+        | Event::KeyDown {
+            keycode: Some(Keycode::Escape),
+            ..
+        } => return false,
+        Event::KeyDown {
+            keycode: Some(Keycode::Tab),
+            keymod,
+            ..
+        } => {
+            let backwards = keymod.contains(sdl3::keyboard::Mod::LSHIFTMOD)
+                || keymod.contains(sdl3::keyboard::Mod::RSHIFTMOD);
+            *selected = if backwards {
+                (*selected + len - 1) % len
+            } else {
+                (*selected + 1) % len
+            };
         }
-
-        let entities: Vec<EncounterEntity<'_>> = blueprints
-            .iter()
-            .zip(positions.iter())
-            .enumerate()
-            .map(|(i, (bp, pos))| EncounterEntity {
-                id: i as u32,
-                blueprint: bp,
-                position: *pos,
-                selected: i == selected,
-            })
-            .collect();
-
-        let canvas = renderer.canvas();
-        canvas.set_draw_color(sdl3::pixels::Color::RGB(0, 0, 0));
-        canvas.clear();
-        draw_encounter(canvas, &backdrop, &entities, &projection)
-            .map_err(beast_render::RenderError::Sdl)?;
-        renderer.present();
+        _ => {}
     }
-    Ok(())
+    true
 }
 
 #[cfg(not(feature = "sdl"))]

--- a/crates/beast-render/examples/world_map.rs
+++ b/crates/beast-render/examples/world_map.rs
@@ -12,24 +12,76 @@
 //!   cargo run -p beast-render --example world_map
 
 #[cfg(feature = "sdl")]
+use beast_core::Prng;
+#[cfg(feature = "sdl")]
+use beast_render::world_map::{draw_archipelago, draw_creature_glyphs};
+#[cfg(feature = "sdl")]
+use beast_render::{Camera, CreatureGlyph, Renderer, WindowConfig};
+#[cfg(feature = "sdl")]
+use beast_world::{generate_archipelago, Archipelago, WorldConfig};
+#[cfg(feature = "sdl")]
+use sdl3::{event::Event, keyboard::Keycode, mouse::MouseWheelDirection};
+
+#[cfg(feature = "sdl")]
 fn main() -> beast_render::Result<()> {
-    use beast_core::Prng;
-    use beast_render::world_map::{draw_archipelago, draw_creature_glyphs};
-    use beast_render::{Camera, CreatureGlyph, Renderer, WindowConfig};
-    use beast_world::{generate_archipelago, WorldConfig};
-    use sdl3::{event::Event, keyboard::Keycode, mouse::MouseWheelDirection, pixels::Color};
+    use sdl3::pixels::Color;
 
-    // Generate a deterministic archipelago. Same seed → same world,
-    // every run.
-    let world_config = WorldConfig::default();
     let world_seed: u64 = 0xBEA5_5697_u64;
-    let archipelago = generate_archipelago(&world_config, world_seed)
+    let archipelago = generate_archipelago(&WorldConfig::default(), world_seed)
         .map_err(|e| beast_render::RenderError::Sdl(format!("world gen failed: {e}")))?;
+    let glyphs = scatter_glyphs(&archipelago, world_seed.wrapping_add(1), 200);
 
-    // Scatter 200 deterministic creature glyphs across the world.
-    let mut rng = Prng::from_seed(world_seed.wrapping_add(1));
-    let mut glyphs = Vec::with_capacity(200);
-    for _ in 0..200 {
+    let mut renderer = Renderer::new(WindowConfig {
+        title: "beast-render: S9.3 world map".to_string(),
+        ..Default::default()
+    })?;
+
+    let mut camera = Camera {
+        center_tile_x: archipelago.width as f32 * 0.5,
+        center_tile_y: archipelago.height as f32 * 0.5,
+        zoom: 16.0,
+    };
+
+    let pan_step: f32 = 12.0;
+    let mut last_mouse = (0_f32, 0_f32);
+
+    'mainloop: loop {
+        // Snapshot the canvas size before borrowing the event pump —
+        // SDL's pump and canvas both borrow the renderer mutably, so
+        // they can't be live at the same time.
+        let (cw, ch) = renderer
+            .canvas()
+            .output_size()
+            .map_err(|e| beast_render::RenderError::Sdl(e.to_string()))?;
+
+        let events: Vec<Event> = renderer.event_pump().poll_iter().collect();
+        for event in events {
+            if !handle_event(event, &mut camera, &mut last_mouse, cw, ch) {
+                break 'mainloop;
+            }
+        }
+
+        let (dx, dy) = read_pan_input(&mut renderer, pan_step);
+        if dx != 0.0 || dy != 0.0 {
+            camera.pan_pixels(dx, dy);
+        }
+
+        let canvas = renderer.canvas();
+        canvas.set_draw_color(Color::RGB(10, 10, 14));
+        canvas.clear();
+        draw_archipelago(canvas, &camera, &archipelago).map_err(beast_render::RenderError::Sdl)?;
+        draw_creature_glyphs(canvas, &camera, &glyphs).map_err(beast_render::RenderError::Sdl)?;
+        renderer.present();
+    }
+    Ok(())
+}
+
+/// Generate `count` deterministic glyphs scattered over the archipelago.
+#[cfg(feature = "sdl")]
+fn scatter_glyphs(archipelago: &Archipelago, seed: u64, count: usize) -> Vec<CreatureGlyph> {
+    let mut rng = Prng::from_seed(seed);
+    let mut glyphs = Vec::with_capacity(count);
+    for _ in 0..count {
         let tile_x = (rng.next_u32() % archipelago.width) as i32;
         let tile_y = (rng.next_u32() % archipelago.height) as i32;
         let tint = [
@@ -43,99 +95,60 @@ fn main() -> beast_render::Result<()> {
             species_tint: tint,
         });
     }
+    glyphs
+}
 
-    let mut renderer = Renderer::new(WindowConfig {
-        title: "beast-render: S9.3 world map".to_string(),
-        ..Default::default()
-    })?;
-
-    let mut camera = Camera {
-        center_tile_x: archipelago.width as f32 * 0.5,
-        center_tile_y: archipelago.height as f32 * 0.5,
-        zoom: 16.0,
-    };
-
-    // Pan speed in pixels per held-key tick. Held-key polling is done
-    // every frame from the keyboard state, separate from the discrete
-    // event stream.
-    let pan_step: f32 = 12.0;
-    let mut last_mouse = (0_f32, 0_f32);
-
-    'mainloop: loop {
-        // Snapshot the canvas size before borrowing the event pump —
-        // SDL's pump and canvas both borrow the renderer mutably, so
-        // they can't be live at the same time.
-        let (cw, ch) = renderer
-            .canvas()
-            .output_size()
-            .map_err(|e| beast_render::RenderError::Sdl(e.to_string()))?;
-
-        // Collect this frame's discrete events (Quit/Keys/Mouse) into
-        // an owned Vec so we can release the event-pump borrow before
-        // we start drawing.
-        let events: Vec<Event> = renderer.event_pump().poll_iter().collect();
-        for event in events {
-            match event {
-                Event::Quit { .. }
-                | Event::KeyDown {
-                    keycode: Some(Keycode::Escape),
-                    ..
-                } => break 'mainloop,
-                Event::MouseMotion { x, y, .. } => {
-                    last_mouse = (x, y);
-                }
-                Event::MouseWheel { y, direction, .. } => {
-                    let mut delta = y;
-                    if matches!(direction, MouseWheelDirection::Flipped) {
-                        delta = -delta;
-                    }
-                    let factor = if delta > 0.0 { 1.1 } else { 1.0 / 1.1 };
-                    camera.zoom_at(factor, last_mouse.0, last_mouse.1, cw, ch);
-                }
-                _ => {}
-            }
+/// Returns `false` to request shutdown of the main loop.
+#[cfg(feature = "sdl")]
+fn handle_event(
+    event: Event,
+    camera: &mut Camera,
+    last_mouse: &mut (f32, f32),
+    canvas_w: u32,
+    canvas_h: u32,
+) -> bool {
+    match event {
+        Event::Quit { .. }
+        | Event::KeyDown {
+            keycode: Some(Keycode::Escape),
+            ..
+        } => return false,
+        Event::MouseMotion { x, y, .. } => *last_mouse = (x, y),
+        Event::MouseWheel { y, direction, .. } => {
+            let delta = if matches!(direction, MouseWheelDirection::Flipped) {
+                -y
+            } else {
+                y
+            };
+            let factor = if delta > 0.0 { 1.1 } else { 1.0 / 1.1 };
+            camera.zoom_at(factor, last_mouse.0, last_mouse.1, canvas_w, canvas_h);
         }
-
-        // Held-key pan via keyboard state. `KeyboardState` is a
-        // snapshot; reading it once per frame gives smooth panning.
-        let (dx, dy) = {
-            let kbd = renderer.event_pump().keyboard_state();
-            let mut dx = 0.0_f32;
-            let mut dy = 0.0_f32;
-            if kbd.is_scancode_pressed(sdl3::keyboard::Scancode::Left)
-                || kbd.is_scancode_pressed(sdl3::keyboard::Scancode::A)
-            {
-                dx += pan_step;
-            }
-            if kbd.is_scancode_pressed(sdl3::keyboard::Scancode::Right)
-                || kbd.is_scancode_pressed(sdl3::keyboard::Scancode::D)
-            {
-                dx -= pan_step;
-            }
-            if kbd.is_scancode_pressed(sdl3::keyboard::Scancode::Up)
-                || kbd.is_scancode_pressed(sdl3::keyboard::Scancode::W)
-            {
-                dy += pan_step;
-            }
-            if kbd.is_scancode_pressed(sdl3::keyboard::Scancode::Down)
-                || kbd.is_scancode_pressed(sdl3::keyboard::Scancode::S)
-            {
-                dy -= pan_step;
-            }
-            (dx, dy)
-        };
-        if dx != 0.0 || dy != 0.0 {
-            camera.pan_pixels(dx, dy);
-        }
-
-        let canvas = renderer.canvas();
-        canvas.set_draw_color(Color::RGB(10, 10, 14));
-        canvas.clear();
-        draw_archipelago(canvas, &camera, &archipelago).map_err(beast_render::RenderError::Sdl)?;
-        draw_creature_glyphs(canvas, &camera, &glyphs).map_err(beast_render::RenderError::Sdl)?;
-        renderer.present();
+        _ => {}
     }
-    Ok(())
+    true
+}
+
+/// Held-key pan via keyboard state. `KeyboardState` is a snapshot;
+/// reading it once per frame gives smooth panning.
+#[cfg(feature = "sdl")]
+fn read_pan_input(renderer: &mut Renderer, pan_step: f32) -> (f32, f32) {
+    use sdl3::keyboard::Scancode;
+    let kbd = renderer.event_pump().keyboard_state();
+    let mut dx = 0.0_f32;
+    let mut dy = 0.0_f32;
+    if kbd.is_scancode_pressed(Scancode::Left) || kbd.is_scancode_pressed(Scancode::A) {
+        dx += pan_step;
+    }
+    if kbd.is_scancode_pressed(Scancode::Right) || kbd.is_scancode_pressed(Scancode::D) {
+        dx -= pan_step;
+    }
+    if kbd.is_scancode_pressed(Scancode::Up) || kbd.is_scancode_pressed(Scancode::W) {
+        dy += pan_step;
+    }
+    if kbd.is_scancode_pressed(Scancode::Down) || kbd.is_scancode_pressed(Scancode::S) {
+        dy -= pan_step;
+    }
+    (dx, dy)
 }
 
 #[cfg(not(feature = "sdl"))]

--- a/crates/beast-render/src/animation.rs
+++ b/crates/beast-render/src/animation.rs
@@ -557,7 +557,7 @@ fn sinusoid_keyframes(duration: Q3232, amplitude: Q3232, phase_fraction: Q3232) 
         .collect();
     // Re-sort by time so the keyframe list stays monotonic after the
     // phase wrap. Stable sort + Q3232::Ord both deterministic.
-    keyframes.sort_by(|a, b| a.time.cmp(&b.time));
+    keyframes.sort_by_key(|k| k.time);
     if let Some(last) = keyframes.last_mut() {
         last.easing = Easing::Linear;
     }

--- a/crates/beast-render/src/lib.rs
+++ b/crates/beast-render/src/lib.rs
@@ -22,7 +22,10 @@
 
 // Modules are crate-private; consumers should depend on the re-exports
 // below so they don't couple to internal module paths.
+
+/// Typed error returned by every fallible entry point in this crate.
 pub(crate) mod error;
+/// SDL3-backed window / canvas / event-pump façade.
 pub(crate) mod renderer;
 
 // Visual-pipeline modules. `blueprint` and `directive` are public so
@@ -30,22 +33,32 @@ pub(crate) mod renderer;
 // see the IR + output types. `pipeline` itself is crate-private — its
 // only public surface is [`compile_blueprint`] re-exported below — to
 // keep substage helpers from leaking into anyone's API.
+
+/// Skeletal animation — clips, tracks, easing, and the per-creature animator.
 pub mod animation;
+/// Creature blueprint IR (bones, volumes, materials, attached effects).
 pub mod blueprint;
+/// Stable channel-id constants the visual pipeline reads from.
 pub(crate) mod channels;
+/// Visual directive vocabulary the interpreter emits at Stage 4.
 pub mod directive;
+/// Blueprint compiler: directive set → [`blueprint::CreatureBlueprint`].
 pub(crate) mod pipeline;
 
-// Sprite atlas: id → Rect lookup loaded from a JSON manifest. Pure-Rust;
-// the GPU-upload step lands alongside the SDL renderers in S9.3 / S9.4.
+/// Sprite atlas: id → [`sprite::Rect`] lookup loaded from a JSON manifest.
+///
+/// Pure-Rust; the GPU-upload step lands alongside the SDL renderers in
+/// S9.3 / S9.4.
 pub mod sprite;
 
-// World-map renderer: pure Camera math + biome tint + (under `sdl`) the
-// SDL drawing entry points (`draw_archipelago`, `draw_creature_glyphs`).
+/// World-map renderer: [`world_map::Camera`] math, biome tint, and (under
+/// `sdl`) the SDL drawing entry points `draw_archipelago` and
+/// `draw_creature_glyphs`.
 pub mod world_map;
 
-// Encounter-view renderer: 2.5D projection + depth ordering + (under
-// `sdl`) the SDL drawing entry points (`draw_backdrop`, `draw_encounter`).
+/// Encounter-view renderer: 2.5D projection, depth ordering, and (under
+/// `sdl`) the SDL drawing entry points `draw_backdrop` and
+/// `draw_encounter`.
 pub mod encounter;
 
 pub use animation::{

--- a/crates/beast-render/src/sprite.rs
+++ b/crates/beast-render/src/sprite.rs
@@ -209,42 +209,10 @@ impl SpriteAtlas {
             .map(|p| p.join(&wire.source))
             .unwrap_or_else(|| PathBuf::from(&wire.source));
 
-        // Validation triage order per entry: empty id → non-positive
-        // dimensions → negative origin → duplicate id. The first check
-        // that fails wins; e.g. an entry with both `w=0` and `x=-1`
-        // surfaces `InvalidRegion`. Callers fix one issue at a time, so
-        // a single deterministic error per entry is more useful than a
-        // collected list.
         let mut regions = BTreeMap::new();
         for entry in wire.entries {
-            if entry.id.is_empty() {
-                return Err(AtlasError::EmptyId {
-                    path: path.to_path_buf(),
-                });
-            }
-            if entry.w <= 0 || entry.h <= 0 {
-                return Err(AtlasError::InvalidRegion {
-                    path: path.to_path_buf(),
-                    id: entry.id,
-                    w: entry.w,
-                    h: entry.h,
-                });
-            }
-            if entry.x < 0 || entry.y < 0 {
-                return Err(AtlasError::InvalidOrigin {
-                    path: path.to_path_buf(),
-                    id: entry.id,
-                    x: entry.x,
-                    y: entry.y,
-                });
-            }
-            // Duplicate-id check first so the success path can move
-            // `entry.id` into `SpriteId::new` instead of cloning it.
-            if regions.contains_key(&SpriteId::new(&entry.id)) {
-                return Err(AtlasError::DuplicateId { id: entry.id });
-            }
-            let rect = Rect::new(entry.x, entry.y, entry.w, entry.h);
-            regions.insert(SpriteId::new(entry.id), rect);
+            let (id, rect) = validate_entry(entry, &regions, path)?;
+            regions.insert(id, rect);
         }
 
         Ok(Self {
@@ -277,6 +245,50 @@ impl SpriteAtlas {
     pub fn iter(&self) -> impl Iterator<Item = (&SpriteId, &Rect)> {
         self.regions.iter()
     }
+}
+
+/// Validate one wire-format atlas entry and convert it to its in-memory
+/// `(SpriteId, Rect)` form.
+///
+/// Triage order: empty id → non-positive dimensions → negative origin →
+/// duplicate id. The first check that fails wins; e.g. an entry with both
+/// `w=0` and `x=-1` surfaces `InvalidRegion`. Callers fix one issue at a
+/// time, so a single deterministic error per entry is more useful than a
+/// collected list.
+fn validate_entry(
+    entry: AtlasEntryWire,
+    regions: &BTreeMap<SpriteId, Rect>,
+    path: &Path,
+) -> Result<(SpriteId, Rect), AtlasError> {
+    if entry.id.is_empty() {
+        return Err(AtlasError::EmptyId {
+            path: path.to_path_buf(),
+        });
+    }
+    if entry.w <= 0 || entry.h <= 0 {
+        return Err(AtlasError::InvalidRegion {
+            path: path.to_path_buf(),
+            id: entry.id,
+            w: entry.w,
+            h: entry.h,
+        });
+    }
+    if entry.x < 0 || entry.y < 0 {
+        return Err(AtlasError::InvalidOrigin {
+            path: path.to_path_buf(),
+            id: entry.id,
+            x: entry.x,
+            y: entry.y,
+        });
+    }
+    // Duplicate-id check before constructing the final `SpriteId` so the
+    // success path can move `entry.id` into `SpriteId::new` instead of
+    // cloning it.
+    if regions.contains_key(&SpriteId::new(&entry.id)) {
+        return Err(AtlasError::DuplicateId { id: entry.id });
+    }
+    let rect = Rect::new(entry.x, entry.y, entry.w, entry.h);
+    Ok((SpriteId::new(entry.id), rect))
 }
 
 #[cfg(test)]

--- a/crates/beast-serde/src/manager.rs
+++ b/crates/beast-serde/src/manager.rs
@@ -302,13 +302,28 @@ pub fn load_game(
     channels: ChannelRegistry,
     primitives: PrimitiveRegistry,
 ) -> Result<Simulation, ManagerError> {
+    verify_compatibility(&file, &channels, &primitives)?;
+    let mut sim = Simulation::new(SimulationConfig {
+        world_seed: file.world_seed,
+        channels,
+        primitives,
+    });
+    restore_rng_streams(&mut sim, &file);
+    rebuild_entities(&mut sim, file.entities);
+    Ok(sim)
+}
+
+fn verify_compatibility(
+    file: &SaveFile,
+    channels: &ChannelRegistry,
+    primitives: &PrimitiveRegistry,
+) -> Result<(), ManagerError> {
     if file.format_version != SAVE_FORMAT_VERSION {
         return Err(ManagerError::UnsupportedVersion {
             expected: SAVE_FORMAT_VERSION,
-            found: file.format_version,
+            found: file.format_version.clone(),
         });
     }
-
     let actual_channel_fp = channels.fingerprint();
     if actual_channel_fp != file.channel_fingerprint {
         return Err(ManagerError::ChannelRegistryMismatch {
@@ -316,76 +331,70 @@ pub fn load_game(
             actual: file.channel_fingerprint.to_hex(),
         });
     }
-    let actual_primitive_fp = primitive_fingerprint(&primitives)?;
+    let actual_primitive_fp = primitive_fingerprint(primitives)?;
     if actual_primitive_fp != file.primitive_fingerprint {
         return Err(ManagerError::PrimitiveRegistryMismatch {
             expected: actual_primitive_fp.to_hex(),
             actual: file.primitive_fingerprint.to_hex(),
         });
     }
+    Ok(())
+}
 
-    let mut sim = Simulation::new(SimulationConfig {
-        world_seed: file.world_seed,
-        channels,
-        primitives,
-    });
+/// Overwrite the freshly-derived PRNG streams with the persisted ones —
+/// the simulation may have already drawn from them before the snapshot
+/// was taken.
+fn restore_rng_streams(sim: &mut Simulation, file: &SaveFile) {
+    let resources = sim.resources_mut();
+    let streams = &file.rng_streams;
+    resources.rng_genetics = streams.genetics.clone();
+    resources.rng_phenotype = streams.phenotype.clone();
+    resources.rng_physics = streams.physics.clone();
+    resources.rng_combat = streams.combat.clone();
+    resources.rng_physiology = streams.physiology.clone();
+    resources.rng_ecology = streams.ecology.clone();
+    resources.rng_worldgen = streams.worldgen.clone();
+    resources.rng_chronicler = streams.chronicler.clone();
+    resources.tick_counter = TickCounter::new(file.current_tick);
+}
 
-    // Overwrite the freshly-derived PRNG streams with the persisted
-    // ones — the simulation may have already drawn from them before the
-    // snapshot was taken.
-    {
-        let resources = sim.resources_mut();
-        resources.rng_genetics = file.rng_streams.genetics;
-        resources.rng_phenotype = file.rng_streams.phenotype;
-        resources.rng_physics = file.rng_streams.physics;
-        resources.rng_combat = file.rng_streams.combat;
-        resources.rng_physiology = file.rng_streams.physiology;
-        resources.rng_ecology = file.rng_streams.ecology;
-        resources.rng_worldgen = file.rng_streams.worldgen;
-        resources.rng_chronicler = file.rng_streams.chronicler;
-        resources.tick_counter = TickCounter::new(file.current_tick);
-    }
-
-    // Re-create entities in `id`-ascending order. With a fresh
-    // `specs::World`, this regenerates the same `(id, gen)` pairs the
-    // original simulation produced — see module docs for the
-    // assumption (no entity deletion in MVP).
-    //
-    // The sort here is **load-bearing** even though `save_game` builds
-    // `entities` from a `BTreeMap` and therefore already produces
-    // sorted output: a `SaveFile` parsed from disk could have been
-    // hand-edited or built by an out-of-band fixture (test, mod
-    // toolchain, fuzz harness). Re-sorting here means the loader
-    // never relies on the producer-side invariant, and the resulting
-    // entity allocation order is the same regardless of how the file
-    // was assembled. Audit finding #68: keep the explicit `sort_by_key`
-    // and the runtime `assert_entities_sorted` check in `to_bincode`/
-    // `to_json` — both halves are guards, not redundancy.
-    let mut sorted = file.entities;
-    sorted.sort_by_key(|e| e.id);
+/// Re-create entities in `id`-ascending order. With a fresh
+/// `specs::World`, this regenerates the same `(id, gen)` pairs the
+/// original simulation produced — see module docs for the assumption (no
+/// entity deletion in MVP).
+///
+/// The sort here is **load-bearing** even though `save_game` builds
+/// `entities` from a `BTreeMap` and therefore already produces sorted
+/// output: a `SaveFile` parsed from disk could have been hand-edited or
+/// built by an out-of-band fixture (test, mod toolchain, fuzz harness).
+/// Re-sorting here means the loader never relies on the producer-side
+/// invariant, and the resulting entity allocation order is the same
+/// regardless of how the file was assembled. Audit finding #68: keep the
+/// explicit `sort_by_key` and the runtime `assert_entities_sorted` check
+/// in `to_bincode`/`to_json` — both halves are guards, not redundancy.
+fn rebuild_entities(sim: &mut Simulation, mut entities: Vec<SerializedEntity>) {
+    entities.sort_by_key(|e| e.id);
     // Intentional asymmetry with `SaveFile::assert_entities_sorted`'s
     // release-visible `assert!`: the producer-side check guards an
     // *invariant* (a save with out-of-order entities is malformed and
     // would produce non-deterministic bytes), so it must fire in
     // release. This loader-side check guards the stdlib `sort_by_key`
-    // contract — if `sorted.sort_by_key` ever returned an unsorted
-    // slice the entire toolchain has bigger problems, and
-    // `debug_assert!` is enough to catch a regression in tests
-    // without paying the linear-scan cost on every load.
+    // contract — if `sort_by_key` ever returned an unsorted slice the
+    // entire toolchain has bigger problems, and `debug_assert!` is
+    // enough to catch a regression in tests without paying the
+    // linear-scan cost on every load.
     debug_assert!(
-        sorted.windows(2).all(|w| w[0].id <= w[1].id),
+        entities.windows(2).all(|w| w[0].id <= w[1].id),
         "post-sort entities must be ascending — sort_by_key contract violated?"
     );
-    for entity_record in sorted {
-        let entity = build_entity(&mut sim, &entity_record);
-        for marker in &entity_record.markers {
+    for record in entities {
+        let entity = build_entity(sim, &record);
+        for marker in &record.markers {
             sim.resources_mut()
                 .entity_index
                 .insert(entity, wire_to_marker(*marker));
         }
     }
-
-    Ok(sim)
 }
 
 /// Pack the specs `(id, gen)` pair into a single `u64`. Layout:
@@ -438,8 +447,17 @@ fn wire_to_marker(marker: SerializedMarker) -> MarkerKind {
 /// builder chain short and matches the order used by spawner code in
 /// `beast-sim`'s tests.
 fn build_entity(sim: &mut Simulation, record: &SerializedEntity) -> beast_ecs::Entity {
-    let mut builder = sim.world_mut().create_entity();
-    for marker in &record.markers {
+    let builder = sim.world_mut().create_entity();
+    let builder = attach_markers(builder, &record.markers);
+    let builder = attach_data_components(builder, record);
+    builder.build()
+}
+
+fn attach_markers<'a>(
+    mut builder: beast_ecs::EntityBuilder<'a>,
+    markers: &[SerializedMarker],
+) -> beast_ecs::EntityBuilder<'a> {
+    for marker in markers {
         builder = match marker {
             SerializedMarker::Creature => builder.with(Creature),
             SerializedMarker::Pathogen => builder.with(Pathogen),
@@ -449,6 +467,18 @@ fn build_entity(sim: &mut Simulation, record: &SerializedEntity) -> beast_ecs::E
             SerializedMarker::Biome => builder.with(Biome),
         };
     }
+    builder
+}
+
+/// Attach the eight data components recorded in the wire format. The
+/// genome and phenotype are cloned because `record` is borrowed immutably
+/// — that's the only heap allocation in the per-entity restore path
+/// (every other component is `Copy`). Per PR #136 review (LOW): noted
+/// explicitly to deter future drive-by clones from creeping in.
+fn attach_data_components<'a>(
+    mut builder: beast_ecs::EntityBuilder<'a>,
+    record: &SerializedEntity,
+) -> beast_ecs::EntityBuilder<'a> {
     if let Some(p) = record.position {
         builder = builder.with(p);
     }
@@ -470,18 +500,13 @@ fn build_entity(sim: &mut Simulation, record: &SerializedEntity) -> beast_ecs::E
     if let Some(s) = record.species {
         builder = builder.with(s);
     }
-    // `record` is borrowed immutably; the genome must be cloned to
-    // hand ownership to the builder. This is the only heap allocation
-    // in `build_entity` — every other component is `Copy`. Per PR #136
-    // review (LOW): noting it explicitly to deter future drive-by
-    // clones from creeping into the per-entity restore path.
     if let Some(g) = record.genome.clone() {
         builder = builder.with(g);
     }
     if let Some(p) = record.phenotype.clone() {
         builder = builder.with(p);
     }
-    builder.build()
+    builder
 }
 
 /// Capture and write a [`Simulation`] to `path` atomically.
@@ -523,27 +548,41 @@ pub fn save_to_path_with_validator(
     validator: &crate::SaveValidator,
 ) -> Result<(), ManagerError> {
     let save = save_game(sim)?;
-    // Validator works on parsed JSON, not bincode bytes — the JSON
-    // round-trip is the authoritative inspectable form, and `extras`
-    // is the only place an unknown key can hide. Cost: one extra
-    // serialize+parse per save, which happens at checkpoint cadence,
-    // not per tick.
+    validate_envelope_json(&save, validator)?;
+    let bytes = save.to_bincode()?;
+    write_atomic(&bytes, path)
+}
+
+/// Run the [`crate::SaveValidator`] over the JSON form of `save`.
+///
+/// The validator works on parsed JSON, not bincode bytes — the JSON
+/// round-trip is the authoritative inspectable form, and `extras` is
+/// the only place an unknown key can hide. Cost: one extra
+/// serialize+parse per save, which happens at checkpoint cadence, not
+/// per tick.
+fn validate_envelope_json(
+    save: &SaveFile,
+    validator: &crate::SaveValidator,
+) -> Result<(), ManagerError> {
     let json = save.to_json()?;
     let value: serde_json::Value =
         serde_json::from_str(&json).map_err(crate::save::SaveError::Json)?;
     validator.validate(&value)?;
+    Ok(())
+}
 
-    let bytes = save.to_bincode()?;
-    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
-    let parent = match parent {
-        Some(p) => p,
-        // No parent (e.g., a bare filename in CWD) — write into ".".
-        None => Path::new("."),
-    };
+/// Write `bytes` to `path` atomically: stage into a sibling temp file
+/// and rename over the target. A mid-write crash leaves the existing
+/// file untouched.
+fn write_atomic(bytes: &[u8], path: &Path) -> Result<(), ManagerError> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
     fs::create_dir_all(parent)?;
     let mut temp = tempfile_in(parent)?;
     use std::io::Write as _;
-    temp.write_all(&bytes)?;
+    temp.write_all(bytes)?;
     temp.flush()?;
     temp.persist(path).map_err(|e| ManagerError::Io(e.error))?;
     Ok(())

--- a/crates/beast-sim/src/determinism.rs
+++ b/crates/beast-sim/src/determinism.rs
@@ -68,85 +68,98 @@ pub fn compute_state_hash(sim: &Simulation) -> [u8; 32] {
 
     for (marker, entity) in resources.entity_index.iter_all() {
         absorb_entity_header(&mut hasher, marker, entity);
-
-        absorb_opt(&mut hasher, ages.get(entity), |h, a| {
-            h.update(&a.ticks.to_le_bytes());
-        });
-        absorb_opt(&mut hasher, masses.get(entity), |h, m| {
-            h.update(&m.kg.to_bits().to_le_bytes());
-        });
-        absorb_opt(&mut hasher, health.get(entity), |h, s| {
-            h.update(&s.health.to_bits().to_le_bytes());
-            h.update(&s.energy.to_bits().to_le_bytes());
-        });
-        absorb_opt(&mut hasher, positions.get(entity), |h, p| {
-            h.update(&p.x.to_bits().to_le_bytes());
-            h.update(&p.y.to_bits().to_le_bytes());
-        });
-        absorb_opt(&mut hasher, velocities.get(entity), |h, v| {
-            h.update(&v.vx.to_bits().to_le_bytes());
-            h.update(&v.vy.to_bits().to_le_bytes());
-        });
-        absorb_opt(&mut hasher, stages.get(entity), |h, s| {
-            // Explicit match rather than `*s as u8` because
-            // DevelopmentalStage has no #[repr(u8)]; inserting a
-            // variant in the middle would silently renumber every
-            // later variant, invalidating persisted hashes. See PR
-            // #122 review note (HIGH).
-            let stage_byte: u8 = match s {
-                DevelopmentalStage::Egg => 0,
-                DevelopmentalStage::Larval => 1,
-                DevelopmentalStage::Juvenile => 2,
-                DevelopmentalStage::Adult => 3,
-                DevelopmentalStage::Geriatric => 4,
-            };
-            h.update(&[stage_byte]);
-        });
-        absorb_opt(&mut hasher, species.get(entity), |h, s| {
-            h.update(&s.id.to_le_bytes());
-        });
-        // Genome: bincode 2.x with the same `config::standard()` that
-        // beast-serde uses for save files. Stable across rustc /
-        // edition upgrades and ~10× cheaper than the previous
-        // `format!("{:?}", ...)` pre-S7 code path. Encoding can fail
-        // only on a serializer-internal error (size_limit overflow on
-        // a >2^32-byte payload, etc.) which a real genome cannot
-        // produce — the `expect` carries the same impossibility
-        // contract as `Genome::validate`'s `GenomeTooLarge` guard.
-        absorb_opt(&mut hasher, genomes.get(entity), |h, g| {
-            let cfg = bincode::config::standard();
-            let bytes = bincode::serde::encode_to_vec(&g.0, cfg)
-                .expect("Genome bincode encoding fits within size_limit");
-            h.update(&bytes);
-        });
-        // Phenotype: hand-encoded field-by-field instead of bincode'd.
-        // `PrimitiveEffect` is L1 and intentionally does **not** derive
-        // `Serialize` (that's gated by the wider serialize-on-the-
-        // sim-path question — see audit finding #67); a per-effect
-        // canonical byte stream gets us the same determinism guarantee
-        // without dragging serde into beast-primitives.
-        //
-        // Defensive sort: the interpreter contract emits sorted, but
-        // the hash gate must not assume — see PR #122 review
-        // (CRITICAL). Sort by `(primitive_id, body_site)` (matches
-        // INVARIANTS §1's hash-order contract) and sort each
-        // `source_channels` Vec since hook firing order isn't pinned.
-        absorb_opt(&mut hasher, phenotypes.get(entity), |h, p| {
-            let mut sorted = p.effects.clone();
-            sorted.sort_by(|a, b| {
-                (&a.primitive_id, &a.body_site).cmp(&(&b.primitive_id, &b.body_site))
-            });
-            for effect in &mut sorted {
-                effect.source_channels.sort();
-            }
-            h.update(&(sorted.len() as u64).to_le_bytes());
-            for effect in &sorted {
-                absorb_primitive_effect(h, effect);
-            }
-        });
+        absorb_opt(&mut hasher, ages.get(entity), absorb_age);
+        absorb_opt(&mut hasher, masses.get(entity), absorb_mass);
+        absorb_opt(&mut hasher, health.get(entity), absorb_health);
+        absorb_opt(&mut hasher, positions.get(entity), absorb_position);
+        absorb_opt(&mut hasher, velocities.get(entity), absorb_velocity);
+        absorb_opt(&mut hasher, stages.get(entity), absorb_stage);
+        absorb_opt(&mut hasher, species.get(entity), absorb_species);
+        absorb_opt(&mut hasher, genomes.get(entity), absorb_genome);
+        absorb_opt(&mut hasher, phenotypes.get(entity), absorb_phenotype);
     }
 
     *hasher.finalize().as_bytes()
+}
+
+fn absorb_age(h: &mut blake3::Hasher, a: &Age) {
+    h.update(&a.ticks.to_le_bytes());
+}
+
+fn absorb_mass(h: &mut blake3::Hasher, m: &Mass) {
+    h.update(&m.kg.to_bits().to_le_bytes());
+}
+
+fn absorb_health(h: &mut blake3::Hasher, s: &HealthState) {
+    h.update(&s.health.to_bits().to_le_bytes());
+    h.update(&s.energy.to_bits().to_le_bytes());
+}
+
+fn absorb_position(h: &mut blake3::Hasher, p: &Position) {
+    h.update(&p.x.to_bits().to_le_bytes());
+    h.update(&p.y.to_bits().to_le_bytes());
+}
+
+fn absorb_velocity(h: &mut blake3::Hasher, v: &Velocity) {
+    h.update(&v.vx.to_bits().to_le_bytes());
+    h.update(&v.vy.to_bits().to_le_bytes());
+}
+
+/// Explicit match rather than `*s as u8` because `DevelopmentalStage` has
+/// no `#[repr(u8)]`; inserting a variant in the middle would silently
+/// renumber every later variant, invalidating persisted hashes. See PR
+/// #122 review note (HIGH).
+fn absorb_stage(h: &mut blake3::Hasher, s: &DevelopmentalStage) {
+    let stage_byte: u8 = match s {
+        DevelopmentalStage::Egg => 0,
+        DevelopmentalStage::Larval => 1,
+        DevelopmentalStage::Juvenile => 2,
+        DevelopmentalStage::Adult => 3,
+        DevelopmentalStage::Geriatric => 4,
+    };
+    h.update(&[stage_byte]);
+}
+
+fn absorb_species(h: &mut blake3::Hasher, s: &Species) {
+    h.update(&s.id.to_le_bytes());
+}
+
+/// Genome: bincode 2.x with the same `config::standard()` that
+/// `beast-serde` uses for save files. Stable across rustc / edition
+/// upgrades and ~10× cheaper than the previous `format!("{:?}", ...)`
+/// pre-S7 code path. Encoding can fail only on a serializer-internal
+/// error (size_limit overflow on a >2^32-byte payload, etc.) which a
+/// real genome cannot produce — the `expect` carries the same
+/// impossibility contract as `Genome::validate`'s `GenomeTooLarge` guard.
+fn absorb_genome(h: &mut blake3::Hasher, g: &GenomeComponent) {
+    let cfg = bincode::config::standard();
+    let bytes = bincode::serde::encode_to_vec(&g.0, cfg)
+        .expect("Genome bincode encoding fits within size_limit");
+    h.update(&bytes);
+}
+
+/// Phenotype: hand-encoded field-by-field instead of bincode'd.
+/// `PrimitiveEffect` is L1 and intentionally does **not** derive
+/// `Serialize` (that's gated by the wider serialize-on-the-sim-path
+/// question — see audit finding #67); a per-effect canonical byte stream
+/// gets us the same determinism guarantee without dragging serde into
+/// `beast-primitives`.
+///
+/// Defensive sort: the interpreter contract emits sorted, but the hash
+/// gate must not assume — see PR #122 review (CRITICAL). Sort by
+/// `(primitive_id, body_site)` (matches INVARIANTS §1's hash-order
+/// contract) and sort each `source_channels` Vec since hook firing order
+/// isn't pinned.
+fn absorb_phenotype(h: &mut blake3::Hasher, p: &PhenotypeComponent) {
+    let mut sorted = p.effects.clone();
+    sorted.sort_by(|a, b| (&a.primitive_id, &a.body_site).cmp(&(&b.primitive_id, &b.body_site)));
+    for effect in &mut sorted {
+        effect.source_channels.sort();
+    }
+    h.update(&(sorted.len() as u64).to_le_bytes());
+    for effect in &sorted {
+        absorb_primitive_effect(h, effect);
+    }
 }
 
 fn absorb_preamble(hasher: &mut blake3::Hasher, resources: &Resources) {

--- a/crates/beast-ui/Cargo.toml
+++ b/crates/beast-ui/Cargo.toml
@@ -36,7 +36,14 @@ beast-core = { workspace = true }
 # build (including the Linux CI runner that has no X11 dev libs). The
 # explicit feature pass-throughs below are now the only way to enable a
 # backend.
-beast-render = { workspace = true, default-features = false }
+#
+# Using a direct `path = ...` instead of `workspace = true` because
+# overriding `default-features = false` through workspace inheritance is
+# unreliable in our cargo version: `cargo metadata` still reports
+# `uses_default_features: true` and CI's resolver pulls beast-render's
+# `sdl` feature in transitively. A direct path dep sidesteps the
+# inheritance path entirely.
+beast-render = { path = "../beast-render", default-features = false }
 serde = { workspace = true }
 
 [lints.rust]

--- a/crates/beast-ui/Cargo.toml
+++ b/crates/beast-ui/Cargo.toml
@@ -29,7 +29,14 @@ headless = ["beast-render/headless"]
 # no widget code in this story actually drives the renderer yet — that lands
 # in S10.4 when screens embed renderer viewports.
 beast-core = { workspace = true }
-beast-render = { workspace = true }
+# `default-features = false` is load-bearing: beast-render's default
+# feature is `sdl`, and cargo features are additive. Without this opt-out
+# the `sdl` feature would stay on even when a downstream caller selects
+# beast-ui's `headless` feature, dragging SDL3-from-source onto every
+# build (including the Linux CI runner that has no X11 dev libs). The
+# explicit feature pass-throughs below are now the only way to enable a
+# backend.
+beast-render = { workspace = true, default-features = false }
 serde = { workspace = true }
 
 [lints.rust]

--- a/crates/beast-world/src/archipelago.rs
+++ b/crates/beast-world/src/archipelago.rs
@@ -161,6 +161,13 @@ pub fn generate_archipelago(
 }
 
 fn validate_config(config: &WorldConfig) -> Result<(), GenerationError> {
+    validate_dimensions(config)?;
+    validate_noise_params(config)?;
+    validate_unit_thresholds(config)?;
+    validate_threshold_relationships(config)
+}
+
+fn validate_dimensions(config: &WorldConfig) -> Result<(), GenerationError> {
     if config.width == 0 || config.height == 0 {
         return Err(GenerationError::EmptyDimensions {
             width: config.width,
@@ -170,19 +177,26 @@ fn validate_config(config: &WorldConfig) -> Result<(), GenerationError> {
     if config.octaves == 0 {
         return Err(GenerationError::ZeroOctaves);
     }
-    // Noise-shape parameters must be strictly positive. A zero
-    // `frequency` collapses every cell onto the same lattice
-    // point (constant map); zero `gain` stalls fBm after one
-    // octave; non-positive `lacunarity` flips frequency direction
-    // each octave producing a subtle deterministic bias that's
-    // hard to diagnose from a degenerate map alone.
+    Ok(())
+}
+
+/// Noise-shape parameters must be strictly positive. A zero `frequency`
+/// collapses every cell onto the same lattice point (constant map);
+/// zero `gain` stalls fBm after one octave; non-positive `lacunarity`
+/// flips frequency direction each octave, producing a subtle
+/// deterministic bias that's hard to diagnose from a degenerate map
+/// alone.
+fn validate_noise_params(config: &WorldConfig) -> Result<(), GenerationError> {
     check_positive("frequency", config.frequency)?;
     check_positive("gain", config.gain)?;
     check_positive("lacunarity", config.lacunarity)?;
-    // Range checks for unit-interval thresholds. Without these, a
-    // misconfigured WorldConfig (e.g., loaded from an external
-    // file) silently produces a degenerate world rather than a
-    // typed error.
+    Ok(())
+}
+
+/// Range checks for unit-interval thresholds. Without these, a
+/// misconfigured `WorldConfig` (e.g., loaded from an external file)
+/// silently produces a degenerate world rather than a typed error.
+fn validate_unit_thresholds(config: &WorldConfig) -> Result<(), GenerationError> {
     check_unit_threshold("sea_level", config.sea_level)?;
     check_unit_threshold("mountain_threshold", config.mountain_threshold)?;
     check_unit_threshold(
@@ -191,6 +205,10 @@ fn validate_config(config: &WorldConfig) -> Result<(), GenerationError> {
     )?;
     check_unit_threshold("desert_threshold", config.desert_threshold)?;
     check_unit_threshold("forest_threshold", config.forest_threshold)?;
+    Ok(())
+}
+
+fn validate_threshold_relationships(config: &WorldConfig) -> Result<(), GenerationError> {
     if config.mountain_threshold <= config.sea_level {
         return Err(GenerationError::InvalidThresholds {
             detail: format!(

--- a/crates/beast-world/src/lib.rs
+++ b/crates/beast-world/src/lib.rs
@@ -56,9 +56,13 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+/// Archipelago generation: seed + [`WorldConfig`] → row-major [`BiomeTag`] grid.
 pub mod archipelago;
+/// `BiomeTag` enum — local mirror of `beast_ecs::components::BiomeKind`.
 pub mod biome_tag;
+/// `WorldConfig`: tunable thresholds for elevation, moisture, and latitude bands.
 pub mod config;
+/// Deterministic value-noise primitives ([`value_noise_2d`], [`fbm_2d`]).
 pub mod noise;
 
 pub use archipelago::{generate_archipelago, Archipelago, GenerationError};

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,24 @@ yanked = "warn"
 # Treat every unreviewed advisory as a hard failure. If we ever need to
 # acknowledge-and-ship through one, add its RUSTSEC id to `ignore` with a
 # dated justification.
-ignore = []
+ignore = [
+    # RUSTSEC-2025-0141 — `bincode` v2 marked unmaintained (2026-04-27).
+    # Not a vulnerability; the bincode team ceased development with no safe
+    # upgrade path. `bincode` is the mandated serializer per CLAUDE.md
+    # ("Serialization: serde + bincode (deterministic config)") and underpins
+    # `beast-serde`'s deterministic save format. Migration to `postcard` /
+    # `bitcode` is tracked in #225 and will be evaluated once an alternative
+    # meets our bit-identical-replay determinism gate.
+    "RUSTSEC-2025-0141",
+    # RUSTSEC-2024-0436 — `paste` archived/unmaintained (2026-04-27).
+    # Not a vulnerability; transitive only, reaches us via
+    # `specs -> nougat -> macro_rules_attribute -> paste`. We do not depend
+    # on `paste` directly. The `specs` ECS is mandated by CLAUDE.md and
+    # cannot be swapped without a major refactor. Migration tracked in #226;
+    # lift this ignore when `specs` (or our chosen replacement) drops the
+    # `paste` chain.
+    "RUSTSEC-2024-0436",
+]
 
 [licenses]
 version = 2

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -5,18 +5,21 @@
 # exits non-zero if *any* step failed.
 #
 # Steps mirror the CI jobs:
-#   1. cargo fmt --check                          (lint-and-test)
-#   2. cargo clippy --workspace --exclude beast-render --all-targets -D warnings
-#   3. cargo test  --workspace --exclude beast-render --all-targets --locked
-#   4. cargo test  --workspace --exclude beast-render --doc --locked
-#   5. cargo clippy beast-render headless         (lint-and-test, render lane)
-#   6. cargo test  beast-render headless          (lint-and-test, render lane)
-#   7. cargo deny check                           (cargo-deny)            [skipped if not installed]
-#   8. cargo llvm-cov summary                     (coverage)              [skipped if not installed]
-#   9. .github/scripts/run-quality-metrics.sh     (quality-metrics)       [skipped if lizard missing]
-#  10. cargo build --release --workspace --exclude beast-render --locked  (release-build)
-#  11. cargo build --release -p beast-render --headless --locked          (release-build, render lane)
-#  12. cargo test --test determinism_test --release  (M1 determinism gate, runs only once it lands)
+#   1. cargo fmt --check                                      (lint-and-test)
+#   2. cargo clippy --workspace --exclude {beast-render,beast-ui} --all-targets -D warnings
+#   3. cargo test  --workspace --exclude {beast-render,beast-ui} --all-targets --locked
+#   4. cargo test  --workspace --exclude {beast-render,beast-ui} --doc --locked
+#   5. cargo clippy beast-render headless                     (lint-and-test, render lane)
+#   6. cargo test  beast-render headless                      (lint-and-test, render lane)
+#   7. cargo clippy beast-ui     headless                     (lint-and-test, ui lane)
+#   8. cargo test  beast-ui     headless                      (lint-and-test, ui lane)
+#   9. cargo deny check                                       (cargo-deny)        [skipped if not installed]
+#  10. cargo llvm-cov summary                                 (coverage)          [skipped if not installed]
+#  11. .github/scripts/run-quality-metrics.sh                 (quality-metrics)   [skipped if lizard missing]
+#  12. cargo build --release --workspace --exclude {beast-render,beast-ui} --locked
+#  13. cargo build --release -p beast-render --headless --locked
+#  14. cargo build --release -p beast-ui     --headless --locked
+#  15. cargo test --test determinism_test --release          (M1 determinism gate)
 #
 # Usage:
 #   scripts/ci-local.sh                 # fail-fast
@@ -147,26 +150,33 @@ summarize() {
 step "cargo fmt --check" \
   cargo fmt --all -- --check
 
-# ----- 2. clippy (workspace minus beast-render) ---------------------------
-step "cargo clippy (workspace, exclude beast-render)" \
-  cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings
+# ----- 2. clippy (workspace minus beast-render + beast-ui) ---------------
+# beast-ui defaults to the `sdl` feature, which propagates to
+# beast-render/sdl and triggers the SDL3 build-from-source path. Exclude
+# both here and run them separately in headless mode below.
+step "cargo clippy (workspace, exclude beast-render+beast-ui)" \
+  cargo clippy --workspace --exclude beast-render --exclude beast-ui --all-targets -- -D warnings
 
-# ----- 3. test (workspace minus beast-render) -----------------------------
-step "cargo test (workspace, exclude beast-render)" \
-  cargo test --workspace --exclude beast-render --all-targets --locked
+# ----- 3. test (workspace minus beast-render + beast-ui) -----------------
+step "cargo test (workspace, exclude beast-render+beast-ui)" \
+  cargo test --workspace --exclude beast-render --exclude beast-ui --all-targets --locked
 
 # ----- 4. doctests --------------------------------------------------------
 step "cargo test --doc" \
-  cargo test --workspace --exclude beast-render --doc --locked
+  cargo test --workspace --exclude beast-render --exclude beast-ui --doc --locked
 
-# ----- 5 + 6. beast-render headless --------------------------------------
+# ----- 5 + 6 + 7 + 8. beast-render + beast-ui headless -------------------
 if [[ $NO_RENDER -eq 0 ]]; then
   step "cargo clippy beast-render (headless)" \
     cargo clippy -p beast-render --no-default-features --features headless --all-targets -- -D warnings
   step "cargo test beast-render (headless)" \
     cargo test -p beast-render --no-default-features --features headless --all-targets --locked
+  step "cargo clippy beast-ui (headless)" \
+    cargo clippy -p beast-ui --no-default-features --features headless --all-targets -- -D warnings
+  step "cargo test beast-ui (headless)" \
+    cargo test -p beast-ui --no-default-features --features headless --all-targets --locked
 else
-  printf '\n%s↷ skipping beast-render headless steps (--no-render)%s\n' "$C_YELLOW" "$C_RESET"
+  printf '\n%s↷ skipping beast-render+beast-ui headless steps (--no-render)%s\n' "$C_YELLOW" "$C_RESET"
 fi
 
 # ----- 7. cargo-deny -----------------------------------------------------
@@ -175,22 +185,24 @@ optional_step "cargo deny check" \
   cargo deny check --hide-inclusion-graph
 
 if [[ $QUICK -eq 0 ]]; then
-  # ----- 8. coverage summary --------------------------------------------
+  # ----- 10. coverage summary -------------------------------------------
   optional_step "cargo llvm-cov (summary)" \
     "command -v cargo-llvm-cov" \
-    cargo llvm-cov --workspace --exclude beast-render --all-targets --locked --summary-only --no-fail-fast
+    cargo llvm-cov --workspace --exclude beast-render --exclude beast-ui --all-targets --locked --summary-only --no-fail-fast
 
-  # ----- 9. quality metrics ---------------------------------------------
+  # ----- 11. quality metrics --------------------------------------------
   optional_step "quality-metrics (lizard)" \
     "command -v lizard || python -m lizard --help" \
     .github/scripts/run-quality-metrics.sh
 
-  # ----- 10 + 11. release build -----------------------------------------
-  step "cargo build --release (workspace, exclude beast-render)" \
-    cargo build --workspace --exclude beast-render --release --locked
+  # ----- 12 + 13 + 14. release build ------------------------------------
+  step "cargo build --release (workspace, exclude beast-render+beast-ui)" \
+    cargo build --workspace --exclude beast-render --exclude beast-ui --release --locked
   if [[ $NO_RENDER -eq 0 ]]; then
     step "cargo build --release beast-render (headless)" \
       cargo build -p beast-render --no-default-features --features headless --release --locked
+    step "cargo build --release beast-ui (headless)" \
+      cargo build -p beast-ui --no-default-features --features headless --release --locked
   fi
 fi
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -73,7 +73,9 @@ else
   C_BOLD=""; C_GREEN=""; C_YELLOW=""; C_RED=""; C_DIM=""; C_RESET=""
 fi
 
-declare -a FAILED_STEPS
+# Explicit empty initialiser so `${#FAILED_STEPS[@]}` is safe under
+# `set -u` even when no step has appended to the array yet.
+FAILED_STEPS=()
 TOTAL=0
 
 # Run a named step. On failure either bail or, with --keep-going, record


### PR DESCRIPTION
## Summary

`scripts/ci-local.sh` was failing on three independent gates. This PR fixes each, plus a latent bash bug that prevented a green exit even after the substantive fixes landed.

| Gate | Before | After |
|---|---|---|
| `cargo deny check` | FAIL — 2 unmaintained advisories (bincode, paste) | PASS — both ignored with dated justifications + tracker issues |
| `quality-metrics` (doc coverage) | FAIL at 78.79% | PASS at 82.92% |
| `quality-metrics` (lizard CCN/length) | FAIL — 10 production/example functions over threshold | PASS — refactored, no whitelizard.txt growth |
| `ci-local.sh` exit code | exit 1 with `FAILED_STEPS: unbound variable` even on all-green | exit 0 |

## Commits

* `47b4334` **docs**: document `pub mod` entries in four lib.rs files (raises Public API doc coverage to 82.92%)
* `5803aae` **chore(deny)**: ignore unmaintained bincode + paste advisories — tracked in #225 and #226
* `eeff607` **refactor**: split 10 functions exceeding lizard CCN/length thresholds (no whitelizard.txt growth)
* `c1cb789` **chore(scripts)**: init `FAILED_STEPS=()` so `ci-local.sh` exits 0 on full pass

## Notes on the deny.toml ignores

Both advisories are **unmaintained** notices, not security vulnerabilities, and both explicitly state *"No safe upgrade is available"*:

* **bincode** — upstream team has ceased development. Migration means switching crates (postcard / bitcode / rkyv), which touches the deterministic save format and the `compute_state_hash` BLAKE3 gate. Tracked in #225.
* **paste** — transitive only via `specs → nougat → macro_rules_attribute → paste`. `specs 0.20` is the latest; nothing to upgrade. Tracked in #226.

The `deny.toml` itself documents the dated-justification escape hatch as the right move for this case.

## Refactor scope

All ten functions split along natural seams; behaviour preserved. See the `refactor:` commit message for the per-function breakdown.

* Production: `evaluate_hook`, `SpriteAtlas::parse`, `validate_config`, `compute_state_hash`, `load_game`, `build_entity`, `save_to_path_with_validator`.
* Example smoke tests: the three `main()`s in `world_map`, `encounter`, `animation`.

## Test plan

- [x] `bash scripts/ci-local.sh` — all 12 gates pass, script exits 0.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude beast-render --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude beast-render --all-targets --locked` — full workspace test suite green.
- [x] `cargo clippy beast-render --no-default-features --features headless --all-targets -- -D warnings`
- [x] `cargo check -p beast-render --features sdl --examples` — confirms the three refactored examples still compile against SDL3.
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`.
- [x] `python -m lizard ... -W .github/qa/whitelizard.txt crates` — *"No thresholds exceeded"*.
- [x] `cargo test --test determinism_test --release` — replay-determinism gate (5 tests) still passes.