### PR TITLE
chore(deps): bump rand_core 0.9→0.10 and rand_xoshiro 0.7→0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "criterion",
  "fixed",
  "proptest",
- "rand_core",
+ "rand_core 0.10.1",
  "rand_xoshiro",
  "serde",
  "serde_json",
@@ -314,9 +314,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -358,9 +358,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -523,9 +523,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "displaydoc"
@@ -636,9 +636,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84695c6689b01384700a3d93acecbd07231ee6fff1bf22ae980b4c307e6ddfd5"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -921,9 +921,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1249,7 +1249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1272,21 +1272,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "1f0b2cc7bfeef8f0320ca45f88b00157a03c67137022d59393614352d6bf4312"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
  "serde",
 ]
 
@@ -1341,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5554bf79f4acf770dc3193b44b2d63b348f5f7b7448a0ea1191b37b620728"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
@@ -1730,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1819,11 +1825,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1832,7 +1838,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1977,6 +1983,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ publish = false
 [workspace.dependencies]
 blake3 = { version = "1.5", default-features = false }
 fixed = { version = "1.28", features = ["serde"] }
-rand_core = "0.9"
-rand_xoshiro = { version = "0.7", features = ["serde"] }
+rand_core = "0.10"
+rand_xoshiro = { version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/beast-core/src/prng.rs
+++ b/crates/beast-core/src/prng.rs
@@ -17,7 +17,9 @@
 //!   forces explicit allocation of a stream slot rather than accidentally
 //!   colliding with an existing one.
 
-use rand_core::{RngCore, SeedableRng};
+use core::convert::Infallible;
+
+use rand_core::{Rng, SeedableRng, TryRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use serde::{Deserialize, Serialize};
 
@@ -205,18 +207,28 @@ impl Prng {
     }
 }
 
-impl RngCore for Prng {
+// rand_core 0.10 renamed `RngCore` → `Rng` and made `Rng` an extension of
+// `TryRng<Error = Infallible>` (see crates.io/crates/rand_core/0.10.1).
+// Implementing `TryRng` is the load-bearing impl; `Rng` is then provided
+// by the blanket `impl<R> Rng for R where R: TryRng<Error = Infallible>`
+// in `rand_core`. This means `Prng` continues to satisfy any bound that
+// reads `R: Rng` (e.g. random distributions) without us writing the
+// extension methods ourselves.
+impl TryRng for Prng {
+    type Error = Infallible;
+
     #[inline]
-    fn next_u32(&mut self) -> u32 {
-        self.inner.next_u32()
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.inner.next_u32())
     }
     #[inline]
-    fn next_u64(&mut self) -> u64 {
-        self.inner.next_u64()
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.inner.next_u64())
     }
     #[inline]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.inner.fill_bytes(dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.fill_bytes(dest);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces dependabot PRs **#217** (rand_xoshiro) and **#218** (rand_core) with a single consolidated bump. The two are coupled: `rand_xoshiro 0.8` requires `rand_core ^0.10`, so neither dependabot PR could land alone, and the API breakage in `rand_core 0.10` (`RngCore → Rng`, with `Rng` now a blanket extension of `TryRng<Error = Infallible>`) has to happen in the same commit anyway.

| Crate | From | To |
|---|---|---|
| `rand_core` | 0.9.5 | 0.10.1 |
| `rand_xoshiro` | 0.7.0 | 0.8.0 |

## API change in `crates/beast-core/src/prng.rs`

`rand_core 0.10` changelog ([#45](https://github.com/rust-random/rand_core/pull/45) / [#54](https://github.com/rust-random/rand_core/pull/54)):

> `Rng` is now an extension trait of `TryRng<Error = Infallible>`.

Net effect — the only file that touched the `rand_core` trait API was `prng.rs`. Switched:

```rust
// before
impl RngCore for Prng { fn next_u32 ...; fn next_u64 ...; fn fill_bytes ... }

// after
impl TryRng for Prng {
    type Error = Infallible;
    fn try_next_u32(&mut self) -> Result<u32, Self::Error> { ... }
    fn try_next_u64(&mut self) -> Result<u64, Self::Error> { ... }
    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> { ... }
}
```

The `Rng` extension trait is auto-implemented for every `TryRng<Error = Infallible>`, so any consumer that takes `R: Rng` (random distributions, sequence ops, etc.) keeps working unchanged — `Prng: Rng` continues to hold.

## Determinism

Per-method byte streams are identical for the same seed across rand_xoshiro 0.7 and 0.8 (the algorithm is unchanged; only the trait shape moved). Verified locally with `cargo test --test determinism_test --release` against the existing seed corpus — all 5 tests pass.

## What this PR does *not* do

- Does not change `Stream` discriminants or `split_stream` semantics. Save-file compatibility preserved.
- Does not touch any other crate. `grep -rn "RngCore\|rand_core::"` across `crates/` shows the one site that needed updating.

## Closes

- #217 (rand_xoshiro 0.7→0.8 standalone — superseded)
- #218 (rand_core 0.9.5→0.10.1 standalone — superseded)

## Test plan

- [x] `bash scripts/ci-local.sh` — 15/15 gates green locally.
- [x] `cargo test --test determinism_test --release` — replay-determinism gate intact.
- [x] CI on this PR completes green.