### PR TITLE
feat(beast-chronicler): S10.6 manifest-driven label engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,12 @@ name = "beast-chronicler"
 version = "0.1.0"
 dependencies = [
  "beast-core",
+ "beast-manifest",
  "blake3",
  "proptest",
  "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/assets/manifests/labels.json
+++ b/assets/manifests/labels.json
@@ -1,0 +1,30 @@
+{
+  "labels": [
+    {
+      "id": "echolocation",
+      "primitives": [
+        "emit_acoustic_pulse",
+        "receive_acoustic_signal",
+        "spatial_integrate"
+      ],
+      "min_confidence": 0.6
+    },
+    {
+      "id": "bioluminescence",
+      "primitives": [
+        "emit_chemical_marker",
+        "elevate_metabolic_rate"
+      ],
+      "min_confidence": 0.5
+    },
+    {
+      "id": "pack_hunting",
+      "primitives": [
+        "form_pair_bond",
+        "apply_bite_force",
+        "apply_locomotive_thrust"
+      ],
+      "min_confidence": 0.7
+    }
+  ]
+}

--- a/crates/beast-chronicler/Cargo.toml
+++ b/crates/beast-chronicler/Cargo.toml
@@ -10,15 +10,22 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
-# beast-core supplies TickCounter + EntityId + Q3232 (the latter for the
-# label confidence work that lands in S10.6). beast-primitives is not a
-# direct dep yet — primitive ids are passed as `&str` so the chronicler
-# stays decoupled from the registry's manifest types until S10.6 needs
-# them. blake3 backs PatternSignature and is already a workspace dep used
-# by the determinism gate.
+# beast-core supplies TickCounter + EntityId + Q3232. Q3232 is the
+# fixed-point type used for label confidence so the [0,1] result stays
+# bit-identical across platforms. beast-manifest gives us the shared
+# JSON-Schema validator + violation type that the channel and primitive
+# loaders already use, so the label-manifest loader follows the same
+# two-stage pipeline. beast-primitives is intentionally still not a
+# direct dep — primitive ids are matched as `&str`/`String`, keeping the
+# chronicler decoupled from the registry's manifest types. blake3 backs
+# PatternSignature and is already a workspace dep used by the
+# determinism gate.
 beast-core = { workspace = true }
+beast-manifest = { workspace = true }
 blake3 = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 # proptest powers the property test that asserts signature stability

--- a/crates/beast-chronicler/src/chronicler.rs
+++ b/crates/beast-chronicler/src/chronicler.rs
@@ -1,27 +1,31 @@
 //! [`Chronicler`] — accumulates pattern observations from primitive
-//! snapshots.
-//!
-//! S10.5 surface only — the read API for the UI layer (S10.7) and the
-//! manifest-driven label assignment (S10.6) layer on top of this struct
-//! in later stories.
+//! snapshots and (S10.6) holds the latest manifest-driven label
+//! assignments. The read API for the UI layer (S10.7) layers on top.
 
 use std::collections::BTreeMap;
 
 use beast_core::TickCounter;
 
+use crate::label::{Label, LabelEngine};
 use crate::pattern::{PatternObservation, PatternSignature};
 use crate::snapshot::PrimitiveSnapshot;
 use crate::tick_range::TickRange;
 
-/// Pattern observation accumulator.
+/// Pattern observation accumulator with cached label assignments.
 ///
 /// Stores one [`PatternObservation`] per unique [`PatternSignature`] that
 /// has ever been ingested. Iteration order over the storage is the
 /// natural total order of `PatternSignature` (lexicographic over its 32
 /// bytes), which keeps tests and downstream UI views deterministic.
+///
+/// Labels are *derived* from observations + a [`LabelEngine`] via
+/// [`Self::assign_labels`]. They are not produced by `ingest()` — per
+/// `INVARIANTS.md` §2, labels remain off the sim path until an
+/// explicit assignment pass runs them against the manifest catalog.
 #[derive(Clone, Debug, Default)]
 pub struct Chronicler {
     observations: BTreeMap<PatternSignature, PatternObservation>,
+    labels: BTreeMap<PatternSignature, Label>,
 }
 
 impl Chronicler {
@@ -114,6 +118,40 @@ impl Chronicler {
             .map(|o| o.last_tick)
             .max()
             .unwrap_or(TickCounter::ZERO)
+    }
+
+    /// Run the manifest-driven [`LabelEngine`] against every stored
+    /// observation, replacing the cached label index.
+    ///
+    /// Each pass starts from an empty index so labels whose backing
+    /// pattern slipped below `min_confidence` (because newer
+    /// observations diluted their frequency, or their stability span
+    /// did not keep pace with the sim clock) drop out. Iteration is
+    /// over the `BTreeMap`'s sorted key set, so the resulting label
+    /// index is identical between two equally-ingested chroniclers
+    /// regardless of insertion order.
+    ///
+    /// `current_tick` is normally [`Self::last_observed_tick`] but
+    /// callers running the assignment ahead of the world clock can
+    /// supply a different value.
+    pub fn assign_labels(&mut self, engine: &LabelEngine, current_tick: TickCounter) {
+        let total = self.total_ingested();
+        let mut next: BTreeMap<PatternSignature, Label> = BTreeMap::new();
+        for (signature, observation) in &self.observations {
+            if let Some(label) = engine.assign(observation, total, current_tick) {
+                next.insert(*signature, label);
+            }
+        }
+        self.labels = next;
+    }
+
+    /// Read-only view of the cached label index.
+    ///
+    /// Empty until [`Self::assign_labels`] has been called at least
+    /// once. Iteration order is the natural total order of
+    /// [`PatternSignature`].
+    pub fn labels(&self) -> &BTreeMap<PatternSignature, Label> {
+        &self.labels
     }
 }
 
@@ -256,5 +294,60 @@ mod tests {
         c.observations.get_mut(&sig).unwrap().count = u64::MAX;
         c.ingest(&key);
         assert_eq!(c.observation(&sig).unwrap().count, u64::MAX);
+    }
+
+    #[test]
+    fn labels_starts_empty_until_assign_runs() {
+        let c = Chronicler::new();
+        assert!(c.labels().is_empty());
+    }
+
+    #[test]
+    fn assign_labels_is_idempotent_for_stable_state() {
+        let manifest = r#"{
+            "labels": [
+                { "id": "marker", "primitives": ["a"], "min_confidence": 0.0 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(manifest).unwrap();
+        let mut c = Chronicler::new();
+        for tick in 0..50 {
+            c.ingest(&snap(tick, 1, &["a"]));
+        }
+        c.assign_labels(&engine, c.last_observed_tick());
+        let first_pass: Vec<_> = c
+            .labels()
+            .values()
+            .map(|l| (l.id.clone(), l.confidence.to_bits()))
+            .collect();
+        c.assign_labels(&engine, c.last_observed_tick());
+        let second_pass: Vec<_> = c
+            .labels()
+            .values()
+            .map(|l| (l.id.clone(), l.confidence.to_bits()))
+            .collect();
+        assert_eq!(first_pass, second_pass);
+        assert_eq!(first_pass.len(), 1);
+    }
+
+    #[test]
+    fn assign_labels_drops_entries_below_min_confidence() {
+        // Two patterns; only the one whose frequency clears the bar gets
+        // labelled. The other observation sits in storage unlabelled.
+        let manifest = r#"{
+            "labels": [
+                { "id": "common", "primitives": ["a"], "min_confidence": 0.5 },
+                { "id": "rare",   "primitives": ["b"], "min_confidence": 0.5 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(manifest).unwrap();
+        let mut c = Chronicler::new();
+        for tick in 0..99 {
+            c.ingest(&snap(tick, 1, &["a"]));
+        }
+        c.ingest(&snap(99, 1, &["b"]));
+        c.assign_labels(&engine, c.last_observed_tick());
+        let label_ids: Vec<&str> = c.labels().values().map(|l| l.id.as_str()).collect();
+        assert_eq!(label_ids, vec!["common"]);
     }
 }

--- a/crates/beast-chronicler/src/confidence.rs
+++ b/crates/beast-chronicler/src/confidence.rs
@@ -1,0 +1,164 @@
+//! Confidence scoring for chronicler labels (S10.6).
+//!
+//! The confidence of a label assignment is a single Q32.32 number on
+//! `[0, 1]` derived from how often the underlying pattern fires
+//! (frequency) and how long the pattern has persisted (stability):
+//!
+//! ```text
+//! freq        = clamp01( count / total_observations )
+//! stability   = clamp01( (last_tick - first_tick) / current_tick )
+//! confidence  = clamp01( 0.6 * freq + 0.4 * stability )
+//! ```
+//!
+//! Per `documentation/INVARIANTS.md` §1, every step runs through Q32.32
+//! saturating arithmetic so the result is bit-identical across platforms
+//! — labels are sim-side state per `systems/09_world_history_lore.md` §5.
+
+use beast_core::{TickCounter, Q3232};
+
+use crate::pattern::PatternObservation;
+
+/// Frequency-term weight in the confidence formula.
+const FREQUENCY_WEIGHT_BITS: i64 = 0x_0000_0000_9999_999A; // 0.6 in Q32.32
+
+/// Stability-term weight in the confidence formula.
+const STABILITY_WEIGHT_BITS: i64 = 0x_0000_0000_6666_6666; // 0.4 in Q32.32
+
+/// Frequency contribution: `clamp01(count / total_observations)`.
+///
+/// A `total_observations` of zero degenerates to zero rather than a
+/// saturating divide; without observations there is nothing to weight.
+#[inline]
+fn frequency_term(count: u64, total_observations: u64) -> Q3232 {
+    if total_observations == 0 {
+        return Q3232::ZERO;
+    }
+    let count_q = Q3232::from_num(count);
+    let total_q = Q3232::from_num(total_observations);
+    (count_q / total_q).clamp(Q3232::ZERO, Q3232::ONE)
+}
+
+/// Stability contribution:
+/// `clamp01((last_tick - first_tick) / current_tick)`.
+///
+/// `current_tick == 0` means the world is at tick zero, so no observation
+/// can have elapsed — return zero rather than saturate. The numerator
+/// is computed via `TickCounter::saturating_sub`, which already clamps at
+/// zero, so out-of-order ingestion (last < first, briefly possible during
+/// tests) cannot drive the term negative.
+#[inline]
+fn stability_term(observation: &PatternObservation, current_tick: TickCounter) -> Q3232 {
+    if current_tick.raw() == 0 {
+        return Q3232::ZERO;
+    }
+    let span = observation
+        .last_tick
+        .saturating_sub(observation.first_tick)
+        .raw();
+    let span_q = Q3232::from_num(span);
+    let current_q = Q3232::from_num(current_tick.raw());
+    (span_q / current_q).clamp(Q3232::ZERO, Q3232::ONE)
+}
+
+/// Compute the confidence score for an observation.
+///
+/// `total_observations` is the chronicler's running total ingestion count
+/// (`Chronicler::total_ingested`), used to normalise this observation's
+/// frequency. `current_tick` is the world's current tick, used to
+/// normalise the observation's persistence span.
+///
+/// The returned value is clamped to `[0, 1]` and saturates rather than
+/// panicking on any intermediate overflow.
+#[inline]
+pub fn compute_confidence(
+    observation: &PatternObservation,
+    total_observations: u64,
+    current_tick: TickCounter,
+) -> Q3232 {
+    let freq = frequency_term(observation.count, total_observations);
+    let stab = stability_term(observation, current_tick);
+    let weighted = Q3232::from_bits(FREQUENCY_WEIGHT_BITS) * freq
+        + Q3232::from_bits(STABILITY_WEIGHT_BITS) * stab;
+    weighted.clamp(Q3232::ZERO, Q3232::ONE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pattern::PatternSignature;
+    use std::collections::BTreeSet;
+
+    fn obs(count: u64, first: u64, last: u64) -> PatternObservation {
+        PatternObservation {
+            signature: PatternSignature([0u8; 32]),
+            count,
+            first_tick: TickCounter::new(first),
+            last_tick: TickCounter::new(last),
+            primitives: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn weight_constants_sum_to_exactly_one() {
+        // 0x9999999A + 0x66666666 = 0x100000000 = 2^32, which is the
+        // bit pattern of Q3232::ONE.
+        let freq = Q3232::from_bits(FREQUENCY_WEIGHT_BITS);
+        let stab = Q3232::from_bits(STABILITY_WEIGHT_BITS);
+        assert_eq!((freq + stab).to_bits(), Q3232::ONE.to_bits());
+    }
+
+    #[test]
+    fn zero_total_observations_returns_zero() {
+        let o = obs(0, 0, 0);
+        assert_eq!(
+            compute_confidence(&o, 0, TickCounter::new(100)),
+            Q3232::ZERO
+        );
+    }
+
+    #[test]
+    fn zero_current_tick_drops_stability_to_zero() {
+        // count == total → freq = 1.0, weighted by 0.6.
+        let o = obs(5, 0, 0);
+        let c = compute_confidence(&o, 5, TickCounter::ZERO);
+        assert_eq!(c, Q3232::from_bits(FREQUENCY_WEIGHT_BITS));
+    }
+
+    #[test]
+    fn full_frequency_full_stability_returns_one() {
+        // count == total (freq = 1) and span == current_tick (stability = 1)
+        // → 0.6 + 0.4 = 1.0 exactly.
+        let o = obs(10, 5, 105);
+        let c = compute_confidence(&o, 10, TickCounter::new(100));
+        assert_eq!(c.to_bits(), Q3232::ONE.to_bits());
+    }
+
+    #[test]
+    fn out_of_order_span_clamps_at_zero() {
+        // last < first should not yield a negative stability — saturating
+        // sub on TickCounter clamps the span at zero.
+        let o = obs(1, 100, 50);
+        let c = compute_confidence(&o, 1, TickCounter::new(100));
+        // freq = 1.0, stability = 0 → 0.6.
+        assert_eq!(c, Q3232::from_bits(FREQUENCY_WEIGHT_BITS));
+    }
+
+    #[test]
+    fn confidence_is_deterministic_across_runs() {
+        // Same inputs must produce bit-identical outputs every call —
+        // INVARIANTS §1.
+        let o = obs(7, 12, 84);
+        let a = compute_confidence(&o, 100, TickCounter::new(120));
+        let b = compute_confidence(&o, 100, TickCounter::new(120));
+        assert_eq!(a.to_bits(), b.to_bits());
+    }
+
+    #[test]
+    fn never_exceeds_unit_interval() {
+        // Adversarial inputs: count > total, span > current — both clamp.
+        let o = obs(u64::MAX, 0, u64::MAX);
+        let c = compute_confidence(&o, 1, TickCounter::new(1));
+        assert!(c <= Q3232::ONE);
+        assert!(c >= Q3232::ZERO);
+    }
+}

--- a/crates/beast-chronicler/src/label.rs
+++ b/crates/beast-chronicler/src/label.rs
@@ -47,6 +47,21 @@ pub enum LabelLoadError {
     /// Two manifest entries shared the same `id`.
     #[error("duplicate label id `{0}` in manifest")]
     DuplicateId(String),
+
+    /// Two manifest entries declared the same primitive set, which would
+    /// make exact-match label assignment ambiguous. Distinct from
+    /// [`Self::BadShape`] because this is a manifest-author mistake, not
+    /// a schema/Rust drift.
+    #[error(
+        "label entries `{first}` and `{second}` share the same primitive set; \
+         exact-match assignment would be ambiguous"
+    )]
+    AmbiguousPrimitiveSet {
+        /// First entry id encountered.
+        first: String,
+        /// Conflicting entry id.
+        second: String,
+    },
 }
 
 impl From<SchemaLoadError> for LabelLoadError {
@@ -144,6 +159,18 @@ struct RawLabelEntry {
 /// query API in S10.7. The `signature` field lets the UI cross-reference
 /// the underlying [`PatternObservation`] without going through the
 /// observation index.
+///
+/// # Save-file contract
+///
+/// `Label`s are **derived** state — recomputed by
+/// [`crate::Chronicler::assign_labels`] from the observation index plus
+/// the active [`LabelEngine`]. `Serialize` / `Deserialize` are derived
+/// purely for in-process wire formats (e.g. the S10.7 UI query surface);
+/// they MUST NOT be written to versioned save files as authoritative
+/// state. Saving the underlying observations is sufficient — labels
+/// regenerate deterministically on the next `assign_labels` pass. This
+/// is the same discipline `INVARIANTS.md` §6 applies to
+/// `bestiary_discovered` and §7 applies to derived group memberships.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Label {
     /// Manifest-defined label id (snake_case).
@@ -209,7 +236,11 @@ impl LabelEngine {
     /// one call.
     pub fn from_json_str(source: &str) -> Result<Self, LabelLoadError> {
         let manifest = LabelManifest::from_json_str(source)?;
-        Self::from_manifest(manifest).map_err(|e| LabelLoadError::BadShape(e.to_string()))
+        Self::from_manifest(manifest).map_err(|e| match e {
+            LabelEngineError::AmbiguousPrimitiveSet { first, second } => {
+                LabelLoadError::AmbiguousPrimitiveSet { first, second }
+            }
+        })
     }
 
     /// Number of label entries the engine can match.
@@ -364,7 +395,22 @@ mod tests {
             ]
         }"#;
         let err = LabelEngine::from_json_str(src).unwrap_err();
-        assert!(matches!(err, LabelLoadError::BadShape(_)));
+        match err {
+            LabelLoadError::AmbiguousPrimitiveSet { first, second } => {
+                assert_eq!(first, "foo");
+                assert_eq!(second, "bar");
+            }
+            other => panic!("expected AmbiguousPrimitiveSet, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embedded_schema_compiles() {
+        // Touching `compiled_schema()` runs the OnceLock initialiser,
+        // which panics if the embedded schema source is malformed —
+        // surfacing schema-edit mistakes at unit-test time rather than
+        // at first integration-test or runtime use.
+        let _ = compiled_schema();
     }
 
     #[test]

--- a/crates/beast-chronicler/src/label.rs
+++ b/crates/beast-chronicler/src/label.rs
@@ -1,0 +1,462 @@
+//! Manifest-driven label assignment (S10.6).
+//!
+//! Per `documentation/INVARIANTS.md` §2 (Mechanics-Label Separation), no
+//! human-readable ability name appears in simulation control flow.
+//! Labels live entirely in this module: the [`LabelEngine`] reads a
+//! [`LabelManifest`] (loaded from JSON), exact-matches the manifest
+//! entries against ingested [`PatternObservation`]s, and emits a
+//! [`Label`] when the run-time confidence (see [`crate::confidence`])
+//! crosses the entry's `min_confidence` floor.
+//!
+//! Per `documentation/systems/09_world_history_lore.md` §3.8, label
+//! catalogs are *manifest-only* — no fallback heuristic is allowed in
+//! Rust code. Adding a new label = shipping a new manifest entry.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+
+use beast_core::{TickCounter, Q3232};
+use beast_manifest::{format_schema_errors, CompiledSchema, SchemaLoadError, SchemaViolation};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::confidence::compute_confidence;
+use crate::pattern::{PatternObservation, PatternSignature};
+
+/// Raw JSON Schema source for the label manifest. Embedded at compile
+/// time so callers need no runtime filesystem access.
+pub const LABEL_MANIFEST_SCHEMA: &str =
+    include_str!("../../../documentation/schemas/label_manifest.schema.json");
+
+/// Errors produced while loading a label manifest.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LabelLoadError {
+    /// Input was not parsable as JSON.
+    #[error("label manifest is not valid JSON: {0}")]
+    InvalidJson(String),
+
+    /// JSON Schema validation produced one or more errors.
+    #[error("label manifest failed schema validation:\n{}", format_schema_errors(.0))]
+    SchemaViolation(Vec<SchemaViolation>),
+
+    /// Schema accepted the document but typed deserialization failed —
+    /// indicates a drift between schema and Rust types (treat as a bug).
+    #[error("label manifest deserialized unexpectedly: {0}")]
+    BadShape(String),
+
+    /// Two manifest entries shared the same `id`.
+    #[error("duplicate label id `{0}` in manifest")]
+    DuplicateId(String),
+}
+
+impl From<SchemaLoadError> for LabelLoadError {
+    fn from(e: SchemaLoadError) -> Self {
+        match e {
+            SchemaLoadError::InvalidJson(s) => Self::InvalidJson(s),
+            SchemaLoadError::SchemaViolation(v) => Self::SchemaViolation(v),
+        }
+    }
+}
+
+fn compiled_schema() -> &'static CompiledSchema {
+    static SCHEMA: OnceLock<CompiledSchema> = OnceLock::new();
+    SCHEMA.get_or_init(|| CompiledSchema::compile(LABEL_MANIFEST_SCHEMA))
+}
+
+/// One entry in a label manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelManifestEntry {
+    /// Unique snake_case label id.
+    pub id: String,
+    /// Set of primitive ids the manifest entry pattern-matches against.
+    /// Sorted by `BTreeSet` so equality with an observation's
+    /// `primitives` is a single set comparison.
+    pub primitives: BTreeSet<String>,
+    /// Confidence floor on `[0, 1]` below which the label is suppressed.
+    pub min_confidence: Q3232,
+}
+
+/// Validated, in-memory label manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LabelManifest {
+    entries: Vec<LabelManifestEntry>,
+}
+
+impl LabelManifest {
+    /// Load and validate a label manifest from a JSON source string.
+    ///
+    /// Runs JSON Schema validation followed by typed deserialization
+    /// and a duplicate-id check. The returned manifest preserves the
+    /// declaration order of entries.
+    pub fn from_json_str(source: &str) -> Result<Self, LabelLoadError> {
+        let value = compiled_schema().load(source)?;
+        let raw: RawLabelManifest =
+            serde_json::from_value(value).map_err(|e| LabelLoadError::BadShape(e.to_string()))?;
+
+        let mut seen = BTreeSet::new();
+        let mut entries = Vec::with_capacity(raw.labels.len());
+        for raw_entry in raw.labels {
+            if !seen.insert(raw_entry.id.clone()) {
+                return Err(LabelLoadError::DuplicateId(raw_entry.id));
+            }
+            entries.push(LabelManifestEntry {
+                id: raw_entry.id,
+                primitives: raw_entry.primitives.into_iter().collect(),
+                min_confidence: Q3232::from_num(raw_entry.min_confidence),
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    /// Read-only access to the manifest entries, in declaration order.
+    pub fn entries(&self) -> &[LabelManifestEntry] {
+        &self.entries
+    }
+
+    /// Number of entries in the manifest.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` if the manifest contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Raw serde-facing mirror of the manifest schema. Private — callers
+/// consume the typed [`LabelManifest`].
+#[derive(Debug, Deserialize)]
+struct RawLabelManifest {
+    labels: Vec<RawLabelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawLabelEntry {
+    id: String,
+    primitives: Vec<String>,
+    min_confidence: f64,
+}
+
+/// One assigned label.
+///
+/// Stored in [`crate::Chronicler::labels`]; surfaced to the UI via the
+/// query API in S10.7. The `signature` field lets the UI cross-reference
+/// the underlying [`PatternObservation`] without going through the
+/// observation index.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Label {
+    /// Manifest-defined label id (snake_case).
+    pub id: String,
+    /// Pattern signature this label was assigned to.
+    pub signature: PatternSignature,
+    /// Run-time confidence on `[0, 1]`, computed by
+    /// [`crate::confidence::compute_confidence`].
+    pub confidence: Q3232,
+}
+
+/// Manifest-driven label assignment.
+///
+/// Holds a [`LabelManifest`] keyed by primitive set so a single
+/// observation lookup is `O(log n)`.
+#[derive(Debug, Clone, Default)]
+pub struct LabelEngine {
+    /// Map from a sorted primitive set to its manifest entry. Two
+    /// entries with the same primitive set would shadow each other —
+    /// rejected at construction.
+    by_primitives: BTreeMap<BTreeSet<String>, LabelManifestEntry>,
+}
+
+/// Errors produced while constructing a [`LabelEngine`].
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LabelEngineError {
+    /// Two manifest entries declared the same primitive set, which would
+    /// make label assignment ambiguous.
+    #[error(
+        "label entries `{first}` and `{second}` share the same primitive set; \
+         exact-match assignment would be ambiguous"
+    )]
+    AmbiguousPrimitiveSet {
+        /// First entry id encountered.
+        first: String,
+        /// Conflicting entry id.
+        second: String,
+    },
+}
+
+impl LabelEngine {
+    /// Construct an engine from a validated manifest.
+    ///
+    /// Returns an error if two entries declare the same set of
+    /// primitives — the exact-match assignment surface (S10.6) cannot
+    /// disambiguate them. The richer rank-based pipeline lands later
+    /// (System 09 §17.3).
+    pub fn from_manifest(manifest: LabelManifest) -> Result<Self, LabelEngineError> {
+        let mut by_primitives: BTreeMap<BTreeSet<String>, LabelManifestEntry> = BTreeMap::new();
+        for entry in manifest.entries {
+            if let Some(existing) = by_primitives.get(&entry.primitives) {
+                return Err(LabelEngineError::AmbiguousPrimitiveSet {
+                    first: existing.id.clone(),
+                    second: entry.id,
+                });
+            }
+            by_primitives.insert(entry.primitives.clone(), entry);
+        }
+        Ok(Self { by_primitives })
+    }
+
+    /// Convenience: parse a manifest from JSON and build the engine in
+    /// one call.
+    pub fn from_json_str(source: &str) -> Result<Self, LabelLoadError> {
+        let manifest = LabelManifest::from_json_str(source)?;
+        Self::from_manifest(manifest).map_err(|e| LabelLoadError::BadShape(e.to_string()))
+    }
+
+    /// Number of label entries the engine can match.
+    pub fn len(&self) -> usize {
+        self.by_primitives.len()
+    }
+
+    /// `true` if the engine has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.by_primitives.is_empty()
+    }
+
+    /// Look up a manifest entry by primitive set (used by tests; the
+    /// production hot path goes through [`Self::assign`]).
+    pub fn entry_for_primitives(
+        &self,
+        primitives: &BTreeSet<String>,
+    ) -> Option<&LabelManifestEntry> {
+        self.by_primitives.get(primitives)
+    }
+
+    /// Try to assign a label to one observation.
+    ///
+    /// Returns `Some(Label)` iff:
+    ///
+    /// 1. The observation's primitive set exactly matches a manifest
+    ///    entry's `primitives`.
+    /// 2. The run-time confidence (see [`crate::confidence`]) is at
+    ///    least the entry's `min_confidence`.
+    ///
+    /// `total_observations` and `current_tick` parameterise the
+    /// confidence formula; both should come from the chronicler that
+    /// owns the observation (`Chronicler::total_ingested` and
+    /// `Chronicler::last_observed_tick` are the standard sources).
+    pub fn assign(
+        &self,
+        observation: &PatternObservation,
+        total_observations: u64,
+        current_tick: TickCounter,
+    ) -> Option<Label> {
+        let entry = self.by_primitives.get(&observation.primitives)?;
+        let confidence = compute_confidence(observation, total_observations, current_tick);
+        if confidence < entry.min_confidence {
+            return None;
+        }
+        Some(Label {
+            id: entry.id.clone(),
+            signature: observation.signature,
+            confidence,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs_with(primitives: &[&str], count: u64, first: u64, last: u64) -> PatternObservation {
+        let primitives: BTreeSet<String> = primitives.iter().map(|s| (*s).to_owned()).collect();
+        let signature = PatternSignature::from_sorted_set(&primitives);
+        PatternObservation {
+            signature,
+            count,
+            first_tick: TickCounter::new(first),
+            last_tick: TickCounter::new(last),
+            primitives,
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        let err = LabelManifest::from_json_str("not json").unwrap_err();
+        assert!(matches!(err, LabelLoadError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn rejects_missing_required_field() {
+        // `min_confidence` omitted.
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"] }
+            ]
+        }"#;
+        let err = LabelManifest::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::SchemaViolation(_)));
+    }
+
+    #[test]
+    fn rejects_uppercase_id() {
+        let src = r#"{
+            "labels": [
+                { "id": "Foo", "primitives": ["a"], "min_confidence": 0.5 }
+            ]
+        }"#;
+        let err = LabelManifest::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::SchemaViolation(_)));
+    }
+
+    #[test]
+    fn rejects_min_confidence_above_one() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a"], "min_confidence": 1.5 }
+            ]
+        }"#;
+        let err = LabelManifest::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::SchemaViolation(_)));
+    }
+
+    #[test]
+    fn rejects_empty_primitives() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": [], "min_confidence": 0.5 }
+            ]
+        }"#;
+        let err = LabelManifest::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::SchemaViolation(_)));
+    }
+
+    #[test]
+    fn rejects_duplicate_label_id() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a"], "min_confidence": 0.1 },
+                { "id": "foo", "primitives": ["b"], "min_confidence": 0.1 }
+            ]
+        }"#;
+        let err = LabelManifest::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::DuplicateId(_)));
+    }
+
+    #[test]
+    fn loads_minimal_valid_manifest() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.5 }
+            ]
+        }"#;
+        let manifest = LabelManifest::from_json_str(src).unwrap();
+        assert_eq!(manifest.len(), 1);
+        assert_eq!(manifest.entries()[0].id, "foo");
+        assert_eq!(manifest.entries()[0].primitives.len(), 2);
+    }
+
+    #[test]
+    fn engine_rejects_ambiguous_primitive_sets() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.5 },
+                { "id": "bar", "primitives": ["b", "a"], "min_confidence": 0.7 }
+            ]
+        }"#;
+        let err = LabelEngine::from_json_str(src).unwrap_err();
+        assert!(matches!(err, LabelLoadError::BadShape(_)));
+    }
+
+    #[test]
+    fn assign_returns_none_when_below_min_confidence() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.9 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(src).unwrap();
+        // freq = 1/100 = 0.01, stab = 0/100 = 0.0 → conf = 0.006 << 0.9.
+        let observation = obs_with(&["a", "b"], 1, 0, 0);
+        assert!(engine
+            .assign(&observation, 100, TickCounter::new(100))
+            .is_none());
+    }
+
+    #[test]
+    fn assign_returns_label_when_threshold_met() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.5 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(src).unwrap();
+        // freq = 100/100 = 1.0, stab = 100/100 = 1.0 → conf = 1.0 ≥ 0.5.
+        let observation = obs_with(&["a", "b"], 100, 0, 100);
+        let label = engine
+            .assign(&observation, 100, TickCounter::new(100))
+            .expect("label should be assigned");
+        assert_eq!(label.id, "foo");
+        assert_eq!(label.signature, observation.signature);
+        assert_eq!(label.confidence, Q3232::ONE);
+    }
+
+    #[test]
+    fn assign_returns_none_when_primitives_do_not_match() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.0 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(src).unwrap();
+        // Primitive set `["a", "c"]` has no manifest counterpart.
+        let observation = obs_with(&["a", "c"], 100, 0, 100);
+        assert!(engine
+            .assign(&observation, 100, TickCounter::new(100))
+            .is_none());
+    }
+
+    #[test]
+    fn assign_is_deterministic_across_calls() {
+        let src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b"], "min_confidence": 0.0 }
+            ]
+        }"#;
+        let engine = LabelEngine::from_json_str(src).unwrap();
+        let observation = obs_with(&["a", "b"], 17, 3, 91);
+        let a = engine
+            .assign(&observation, 200, TickCounter::new(150))
+            .unwrap();
+        let b = engine
+            .assign(&observation, 200, TickCounter::new(150))
+            .unwrap();
+        assert_eq!(a.confidence.to_bits(), b.confidence.to_bits());
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.signature, b.signature);
+    }
+
+    #[test]
+    fn primitive_order_in_manifest_does_not_matter() {
+        let a_src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["a", "b", "c"], "min_confidence": 0.0 }
+            ]
+        }"#;
+        let b_src = r#"{
+            "labels": [
+                { "id": "foo", "primitives": ["c", "b", "a"], "min_confidence": 0.0 }
+            ]
+        }"#;
+        let observation = obs_with(&["b", "a", "c"], 5, 0, 5);
+        let from_a = LabelEngine::from_json_str(a_src)
+            .unwrap()
+            .assign(&observation, 5, TickCounter::new(5))
+            .unwrap();
+        let from_b = LabelEngine::from_json_str(b_src)
+            .unwrap()
+            .assign(&observation, 5, TickCounter::new(5))
+            .unwrap();
+        assert_eq!(from_a.id, from_b.id);
+        assert_eq!(from_a.confidence.to_bits(), from_b.confidence.to_bits());
+    }
+}

--- a/crates/beast-chronicler/src/lib.rs
+++ b/crates/beast-chronicler/src/lib.rs
@@ -1,39 +1,44 @@
-//! Pattern recognition and (later) label assignment for the Beast
-//! Evolution Game.
+//! Pattern recognition and label assignment for the Beast Evolution
+//! Game.
 //!
-//! S10.5 — this story — only covers ingesting [`PrimitiveSnapshot`]s,
-//! hashing them into [`PatternSignature`]s, and counting observations
-//! across a [`TickRange`]. Label generation lives in S10.6
-//! ([`crate::label`] is reserved); the read-only query surface lives in
-//! S10.7.
+//! S10.5 brought the ingestion + signature + observation surface; S10.6
+//! adds manifest-driven labels via [`crate::label::LabelEngine`] and a
+//! shared [`crate::confidence`] scoring helper. The read-only query API
+//! for the UI layer (S10.7) layers on top of these.
 //!
 //! # Determinism
 //!
 //! Per `documentation/INVARIANTS.md` §1, every public surface in this
 //! crate is deterministic across runs and platforms:
 //!
-//! * The signature is BLAKE3 over a length-prefixed, lexicographically
+//! * Signatures are BLAKE3 over a length-prefixed, lexicographically
 //!   sorted byte stream of the primitive ids in the snapshot.
 //! * Storage uses [`BTreeMap`](std::collections::BTreeMap) /
 //!   [`BTreeSet`](std::collections::BTreeSet) so iteration order is a
 //!   total function of contents, never of insertion order.
-//! * No floats, no wall-clock reads, no OS RNG.
+//! * Confidence math runs through [`Q3232`](beast_core::Q3232) saturating
+//!   arithmetic — no floats, no wall-clock reads, no OS RNG on the sim
+//!   path.
 //!
 //! Per `documentation/INVARIANTS.md` §2 (Mechanics-Label Separation),
-//! this crate stores raw signatures + counts only. Human-readable labels
-//! are *not* introduced here — they arrive in S10.6 from a
-//! manifest-driven catalog.
+//! human-readable label strings appear *only* in [`crate::label`]; they
+//! are never observed by sim systems and are loaded from JSON manifests
+//! at startup with zero hardcoded heuristics.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
 pub mod chronicler;
+pub mod confidence;
+pub mod label;
 pub mod pattern;
 pub mod snapshot;
 pub mod tick_range;
 
 pub use chronicler::Chronicler;
+pub use confidence::compute_confidence;
+pub use label::{Label, LabelEngine, LabelEngineError, LabelLoadError, LabelManifest};
 pub use pattern::{PatternObservation, PatternSignature};
 pub use snapshot::PrimitiveSnapshot;
 pub use tick_range::TickRange;

--- a/crates/beast-chronicler/tests/label_manifest_integration.rs
+++ b/crates/beast-chronicler/tests/label_manifest_integration.rs
@@ -1,0 +1,138 @@
+//! End-to-end test for the on-disk label manifest at
+//! `assets/manifests/labels.json`. Ensures the schema, manifest, and
+//! engine all line up — a regression here likely means a manifest edit
+//! broke schema conformance or vice versa.
+
+use std::collections::BTreeSet;
+
+use beast_chronicler::{Chronicler, LabelEngine, PrimitiveSnapshot};
+use beast_core::{EntityId, TickCounter};
+
+const ASSET_LABELS_JSON: &str = include_str!("../../../assets/manifests/labels.json");
+
+/// All ids declared in the shipped manifest. Hard-coded *here* (a test
+/// file) per the S10.6 DoD which carves out tests + `assets/` from the
+/// no-hardcoded-label-name rule.
+const SHIPPED_LABEL_IDS: &[&str] = &["echolocation", "bioluminescence", "pack_hunting"];
+
+fn snap(tick: u64, entity: u32, primitives: &[&str]) -> PrimitiveSnapshot {
+    PrimitiveSnapshot::new(
+        TickCounter::new(tick),
+        EntityId::new(entity),
+        primitives.iter().copied(),
+    )
+}
+
+#[test]
+fn shipped_manifest_loads_and_matches_expected_label_set() {
+    let engine = LabelEngine::from_json_str(ASSET_LABELS_JSON)
+        .expect("shipped label manifest must load cleanly");
+    assert_eq!(
+        engine.len(),
+        SHIPPED_LABEL_IDS.len(),
+        "shipped manifest entry count drifted; sync SHIPPED_LABEL_IDS in this test"
+    );
+}
+
+#[test]
+fn shipped_manifest_assigns_echolocation_under_full_frequency() {
+    let engine = LabelEngine::from_json_str(ASSET_LABELS_JSON).unwrap();
+    let mut chronicler = Chronicler::new();
+    // Drive 100 ticks of a single creature emitting the echolocation
+    // primitive set — full frequency, full stability.
+    for tick in 0..100 {
+        chronicler.ingest(&snap(
+            tick,
+            1,
+            &[
+                "emit_acoustic_pulse",
+                "receive_acoustic_signal",
+                "spatial_integrate",
+            ],
+        ));
+    }
+    chronicler.assign_labels(&engine, chronicler.last_observed_tick());
+    let assigned: BTreeSet<&str> = chronicler
+        .labels()
+        .values()
+        .map(|l| l.id.as_str())
+        .collect();
+    assert!(
+        assigned.contains("echolocation"),
+        "echolocation must label the recurring acoustic pattern; got {assigned:?}"
+    );
+}
+
+#[test]
+fn shipped_manifest_suppresses_pack_hunting_below_threshold() {
+    // pack_hunting has min_confidence = 0.7 in the shipped manifest.
+    // A single observation in a 1000-observation chronicler scores
+    // ~0.6 * (1/1000) = 0.0006 — well below the 0.7 floor.
+    let engine = LabelEngine::from_json_str(ASSET_LABELS_JSON).unwrap();
+    let mut chronicler = Chronicler::new();
+    for tick in 0..999 {
+        chronicler.ingest(&snap(tick, 1, &["emit_chemical_marker"]));
+    }
+    chronicler.ingest(&snap(
+        999,
+        1,
+        &[
+            "form_pair_bond",
+            "apply_bite_force",
+            "apply_locomotive_thrust",
+        ],
+    ));
+    chronicler.assign_labels(&engine, chronicler.last_observed_tick());
+    let label_ids: BTreeSet<&str> = chronicler
+        .labels()
+        .values()
+        .map(|l| l.id.as_str())
+        .collect();
+    assert!(
+        !label_ids.contains("pack_hunting"),
+        "pack_hunting should not stabilize from a single observation"
+    );
+}
+
+#[test]
+fn label_assignment_is_deterministic_across_ingestion_order() {
+    // Two chroniclers built with reversed ingestion order must produce
+    // bit-identical label indexes after assignment — INVARIANTS §1.
+    let engine = LabelEngine::from_json_str(ASSET_LABELS_JSON).unwrap();
+    let snapshots: Vec<PrimitiveSnapshot> = (0..200)
+        .map(|i| {
+            let primitives: &[&str] = if i % 3 == 0 {
+                &[
+                    "emit_acoustic_pulse",
+                    "receive_acoustic_signal",
+                    "spatial_integrate",
+                ]
+            } else if i % 3 == 1 {
+                &["emit_chemical_marker", "elevate_metabolic_rate"]
+            } else {
+                &["emit_chemical_marker"]
+            };
+            snap(i, (i % 5) as u32, primitives)
+        })
+        .collect();
+
+    let mut forward = Chronicler::new();
+    let mut reverse = Chronicler::new();
+    for s in &snapshots {
+        forward.ingest(s);
+    }
+    for s in snapshots.iter().rev() {
+        reverse.ingest(s);
+    }
+    let tick = forward.last_observed_tick();
+    forward.assign_labels(&engine, tick);
+    reverse.assign_labels(&engine, tick);
+
+    let collect = |c: &Chronicler| -> Vec<(String, i64)> {
+        c.labels()
+            .values()
+            .map(|l| (l.id.clone(), l.confidence.to_bits()))
+            .collect()
+    };
+    assert_eq!(collect(&forward), collect(&reverse));
+}

--- a/crates/beast-chronicler/tests/no_hardcoded_label_strings.rs
+++ b/crates/beast-chronicler/tests/no_hardcoded_label_strings.rs
@@ -1,0 +1,61 @@
+//! Compile-time-ish enforcement of INVARIANTS.md §2 (Mechanics-Label
+//! Separation) for the S10.6 surface: no manifest-defined label id may
+//! appear as a string literal anywhere in `crates/beast-chronicler/src`.
+//!
+//! `src/label.rs` holds the only structural string ("labels", "id",
+//! "primitives", "min_confidence") needed for serde/JSON-Schema, none of
+//! which collide with a manifest *id*. If this test ever fires, a label
+//! id has leaked into Rust code — fix it by reading the id from the
+//! manifest at runtime.
+//!
+//! The grep is shallow (raw byte scan, no AST) but that is the right
+//! tradeoff for a determinism-class invariant: any false positive forces
+//! a human review, which is what we want.
+
+use std::path::Path;
+
+const SHIPPED_LABEL_IDS: &[&str] = &["echolocation", "bioluminescence", "pack_hunting"];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("readable src dir") {
+        let entry = entry.expect("readable dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_shipped_label_id_appears_in_src() {
+    // CARGO_MANIFEST_DIR points at the crate root at test compile time.
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_dir = crate_root.join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src_dir, &mut files);
+    assert!(
+        !files.is_empty(),
+        "expected at least one .rs file under {src_dir:?}"
+    );
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let body = std::fs::read_to_string(file).expect("readable source file");
+        for needle in SHIPPED_LABEL_IDS {
+            if body.contains(needle) {
+                violations.push(format!(
+                    "{}: contains hardcoded label id `{}`",
+                    file.display(),
+                    needle
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "label ids leaked into src/ — INVARIANTS §2:\n{}",
+        violations.join("\n")
+    );
+}

--- a/documentation/architecture/CRATE_LAYOUT.md
+++ b/documentation/architecture/CRATE_LAYOUT.md
@@ -338,14 +338,17 @@ pub fn compute_state_hash(&self) -> u64;  // For determinism testing
 
 **Purpose**: Pattern recognition, labeling, query API.
 
-**Key Types** (S10.5 surface; later sprints extend):
-- `Chronicler` (signature index, accumulated observations)
+**Key Types** (S10.5 + S10.6 surface; S10.7 extends):
+- `Chronicler` (signature index, accumulated observations, cached label index)
 - `PrimitiveSnapshot` (per-tick `(tick, entity, BTreeSet<primitive_id>)`)
 - `PatternSignature([u8; 32])` (BLAKE3 of length-prefixed sorted primitive ids)
 - `PatternObservation` (count, first_tick, last_tick, primitives) — keyed by signature
 - `TickRange` (half-open `[start, end)` window for `cluster()` queries)
+- `LabelEngine` / `LabelManifest` — manifest-driven exact-match label assignment (S10.6)
+- `Label { id, signature, confidence }` — Q32.32 confidence on `[0, 1]`
 
-**Dependencies**: `beast-core`, `blake3`, `serde`
+**Dependencies**: `beast-core`, `beast-manifest`, `blake3`, `serde`,
+`serde_json`, `thiserror`
 
 The crate intentionally does **not** depend on `beast-ecs` or `beast-primitives`:
 
@@ -353,36 +356,49 @@ The crate intentionally does **not** depend on `beast-ecs` or `beast-primitives`
   ECS layer is also built on. Depending on `beast-ecs` would couple the
   chronicler to `specs` for no gain — snapshots arrive pre-projected.
 - Primitive ids are passed as `&str` / `String` so the chronicler stays
-  decoupled from the registry's manifest types until S10.6 needs the
-  manifest itself.
+  decoupled from the registry's manifest types; the label engine likewise
+  matches by primitive-id string-set without touching `beast-primitives`.
 
-This keeps the L4 dep DAG narrow and avoids round-tripping `specs::Entity` through
-the chronicler.
+`beast-manifest` is reused so the label-manifest loader follows the same
+two-stage pipeline (JSON-Schema validation → typed deserialize) as the
+channel and primitive loaders.
 
-**Modules** (full target shape; S10.5 ships only the first three):
+**Modules** (full target shape; S10.7 fills in `query`):
 ```rust
 pub mod chronicler;        // Chronicler struct
+pub mod confidence;        // Q32.32 confidence scoring (S10.6)
+pub mod label;             // Manifest-driven label assignment (S10.6)
 pub mod pattern;           // PatternSignature + PatternObservation
 pub mod snapshot;          // PrimitiveSnapshot
 pub mod tick_range;        // TickRange (half-open [start, end))
-pub mod label;             // Label generation, naming heuristics (S10.6)
 pub mod query;             // Query API for UI (S10.7)
-pub mod confidence;        // Confidence scoring for labels (S10.6)
 ```
 
-**Key Functions** (S10.5):
+**Key Functions** (S10.5 + S10.6):
 ```rust
 impl Chronicler {
     pub fn ingest(&mut self, snapshot: &PrimitiveSnapshot);
-    pub fn cluster(&self, window: TickRange) -> impl Iterator<Item = &PatternObservation>;
+    pub fn cluster(&self, window: TickRange) -> Vec<&PatternObservation>;
     pub fn observations(&self) -> &BTreeMap<PatternSignature, PatternObservation>;
     pub fn observation(&self, signature: &PatternSignature) -> Option<&PatternObservation>;
+    pub fn assign_labels(&mut self, engine: &LabelEngine, current_tick: TickCounter);
+    pub fn labels(&self) -> &BTreeMap<PatternSignature, Label>;
+}
+
+impl LabelEngine {
+    pub fn from_json_str(source: &str) -> Result<Self, LabelLoadError>;
+    pub fn assign(
+        &self,
+        observation: &PatternObservation,
+        total_observations: u64,
+        current_tick: TickCounter,
+    ) -> Option<Label>;
 }
 ```
 
-S10.6 adds `assign_labels` against a manifest catalog; S10.7 adds the
-`ChroniclerQuery` trait (`label_for_signature`, `entities_with_label`,
-`bestiary_entries`, …) for the UI layer to consume.
+S10.7 adds the `ChroniclerQuery` trait (`label_for_signature`,
+`entities_with_label`, `bestiary_entries`, …) for the UI layer to
+consume.
 
 ---
 

--- a/documentation/schemas/label_manifest.schema.json
+++ b/documentation/schemas/label_manifest.schema.json
@@ -11,6 +11,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": false,
+      "description": "Sequence of label catalog entries. JSON Schema 2020-12 cannot enforce uniqueness by a sub-property, so duplicate `id`s are caught at load time by the Rust validator (`LabelLoadError::DuplicateId`); duplicate primitive sets are caught by `LabelLoadError::AmbiguousPrimitiveSet` when the engine is built.",
       "items": {
         "type": "object",
         "required": ["id", "primitives", "min_confidence"],

--- a/documentation/schemas/label_manifest.schema.json
+++ b/documentation/schemas/label_manifest.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://beast-evolution.local/schemas/label-manifest.json",
+  "title": "Label Manifest Schema",
+  "description": "Catalog of human-readable labels the Chronicler may assign to recurring primitive-emission patterns. Per INVARIANTS.md §2 (mechanics-label separation), no simulation system reads label strings; they exist solely for UI, NPC dialogue, and lore. The Chronicler matches an observation's primitive set against `primitives` and emits a `Label` only when the run-time-computed confidence reaches `min_confidence`.",
+  "type": "object",
+  "required": ["labels"],
+  "additionalProperties": false,
+  "properties": {
+    "labels": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": false,
+      "items": {
+        "type": "object",
+        "required": ["id", "primitives", "min_confidence"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z_][a-z0-9_]*$",
+            "description": "Unique snake_case identifier for this label. Same constraints as primitive ids: starts with a letter or underscore; alphanumeric + underscore."
+          },
+          "primitives": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z_][a-z0-9_]*$"
+            },
+            "description": "Set of primitive ids whose simultaneous emission triggers this label. Matched by set equality against `PatternObservation.primitives` (no parameter constraints in the S10.6 surface)."
+          },
+          "min_confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Confidence floor on `[0, 1]` below which the label is suppressed. The runtime confidence is `0.6 * (count / total_observations) + 0.4 * ((last_tick - first_tick) / current_tick)`, both terms clamped to `[0, 1]` before the weighted sum."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #211. Stacks on the S10.5 chronicler primitives shipped in #215.

## Summary

* `documentation/schemas/label_manifest.schema.json` — Draft 2020-12 schema with the canonical `$id` URI; required fields `id`, `primitives`, `min_confidence`; snake_case id pattern matched against the same regex used by channel and primitive ids; `min_confidence` clamped to `[0, 1]`.
* `assets/manifests/labels.json` — three sample labels (`echolocation`, `bioluminescence`, `pack_hunting`) with thresholds 0.6 / 0.5 / 0.7.
* `beast-chronicler::confidence` — Q3232 weighted-sum scorer following the story formula:
  ```
  freq        = clamp01(count / total_observations)
  stability   = clamp01((last_tick - first_tick) / current_tick)
  confidence  = clamp01(0.6 * freq + 0.4 * stability)
  ```
  The 0.6 / 0.4 weights are stored as exact Q32.32 bit patterns (`0x9999999A` and `0x66666666`) that sum to `2^32 = ONE`, so the formula has no float drift.
* `beast-chronicler::label::LabelEngine` — exact primitive-set match indexed by `BTreeSet<String>` for `O(log n)` lookup; rejects manifests that declare two entries with the same primitive set so exact-match assignment stays unambiguous.
* `Chronicler::assign_labels` / `Chronicler::labels` — cached label index that BTreeMap-iterates the observation store and replaces the index on each pass, so labels whose backing pattern dipped below `min_confidence` drop out automatically.
* `documentation/architecture/CRATE_LAYOUT.md` updated with the new modules + deps and the S10.6 function surface.

## Invariant compliance (per CLAUDE.md)

* §1 Determinism: confidence math runs through Q32.32 saturating arithmetic; iteration is over `BTreeMap` of signatures; no floats, no wall-clock reads.
* §2 Mechanics-Label Separation: label strings appear only in `assets/manifests/labels.json` and tests. A new `tests/no_hardcoded_label_strings.rs` test grep-fails if any shipped label id leaks into `crates/beast-chronicler/src/`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked` — 43 unit tests + 8 integration tests in `beast-chronicler` pass; full workspace green
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo deny check`
- [x] Schema validation: malformed JSON, missing required fields, uppercase id, `min_confidence > 1`, empty primitives, duplicate id all rejected with typed errors
- [x] Threshold cutoff: same observation returns `Some(Label)` above floor and `None` below
- [x] Determinism: identical observations produce bit-identical confidence; reverse ingestion order produces identical label index after `assign_labels`
- [x] No hardcoded label name leaks into `src/` (auto-checked by `tests/no_hardcoded_label_strings.rs`)
