### PR TITLE
feat(beast-chronicler): S10.7 ChroniclerQuery API

### DIFF
--- a/crates/beast-chronicler/src/chronicler.rs
+++ b/crates/beast-chronicler/src/chronicler.rs
@@ -2,12 +2,16 @@
 //! snapshots and (S10.6) holds the latest manifest-driven label
 //! assignments. The read API for the UI layer (S10.7) layers on top.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use beast_core::TickCounter;
+use beast_core::{EntityId, TickCounter, Q3232};
 
 use crate::label::{Label, LabelEngine};
 use crate::pattern::{PatternObservation, PatternSignature};
+use crate::query::{
+    label_ids_match_search, sort_bestiary, BestiaryEntry, BestiaryFilter, ChroniclerQuery, LabelId,
+    SpeciesId,
+};
 use crate::snapshot::PrimitiveSnapshot;
 use crate::tick_range::TickRange;
 
@@ -26,6 +30,24 @@ use crate::tick_range::TickRange;
 pub struct Chronicler {
     observations: BTreeMap<PatternSignature, PatternObservation>,
     labels: BTreeMap<PatternSignature, Label>,
+    /// Reverse index from `EntityId` → per-signature ingestion count
+    /// for that entity. Built during [`Self::ingest`]; consumed by the
+    /// S10.7 query API.
+    ///
+    /// Per-entity counts are tracked separately from the global
+    /// `observations` count so the bestiary aggregator can attribute
+    /// snapshots to a single species without double-counting when two
+    /// entities of different species share a signature. The map per
+    /// entity is small (number of distinct primitive sets the entity
+    /// has ever produced), so the storage cost stays bounded.
+    entity_emissions: BTreeMap<EntityId, BTreeMap<PatternSignature, u64>>,
+    /// Map from `EntityId` → `SpeciesId`, populated by
+    /// [`Self::set_entity_species`]. The chronicler does not derive
+    /// species itself — higher-layer code (sim spawner, save loader) is
+    /// responsible for declaring it. Entities without a registered
+    /// species are excluded from bestiary queries; they still appear
+    /// under [`Self::labels_for_entity`].
+    entity_species: BTreeMap<EntityId, SpeciesId>,
 }
 
 impl Chronicler {
@@ -71,6 +93,34 @@ impl Chronicler {
         if snapshot.tick > entry.last_tick {
             entry.last_tick = snapshot.tick;
         }
+        // Maintain the entity → signatures reverse index for the S10.7
+        // query API, with per-entity per-signature counts so the
+        // bestiary aggregator can attribute snapshots to a single
+        // species without double-counting shared signatures.
+        let per_entity = self.entity_emissions.entry(snapshot.entity).or_default();
+        let count = per_entity.entry(signature).or_insert(0);
+        *count = count.saturating_add(1);
+    }
+
+    /// Register the species an entity belongs to.
+    ///
+    /// The chronicler does not derive species itself; higher-layer code
+    /// (sim spawner, save loader) is the source of truth. Repeated calls
+    /// for the same entity overwrite the prior species — useful for
+    /// speciation events where an entity transitions between species
+    /// ids over its lifetime.
+    pub fn set_entity_species(&mut self, entity: EntityId, species: SpeciesId) {
+        self.entity_species.insert(entity, species);
+    }
+
+    /// Read-only view of the entity → per-signature emission counts.
+    pub fn entity_emissions(&self) -> &BTreeMap<EntityId, BTreeMap<PatternSignature, u64>> {
+        &self.entity_emissions
+    }
+
+    /// Read-only view of the entity → species registration map.
+    pub fn entity_species(&self) -> &BTreeMap<EntityId, SpeciesId> {
+        &self.entity_species
     }
 
     /// All [`PatternObservation`]s whose `[first_tick, last_tick]` span
@@ -152,6 +202,119 @@ impl Chronicler {
     /// [`PatternSignature`].
     pub fn labels(&self) -> &BTreeMap<PatternSignature, Label> {
         &self.labels
+    }
+
+    /// Build a [`BestiaryEntry`] for one species by aggregating across
+    /// every registered entity that belongs to it.
+    ///
+    /// Returns `None` when no entity has been registered for `species`
+    /// or none of the registered entities have been ingested. Pulled out
+    /// of the [`ChroniclerQuery`] impl so [`Self::bestiary_entry`] and
+    /// [`Self::bestiary_entries`] share one aggregation pass.
+    fn build_bestiary_entry(&self, species: SpeciesId) -> Option<BestiaryEntry> {
+        let mut observation_count: u64 = 0;
+        let mut first_tick: Option<TickCounter> = None;
+        let mut confidence: Q3232 = Q3232::ZERO;
+        let mut label_ids: BTreeSet<LabelId> = BTreeSet::new();
+        let mut any_entity = false;
+
+        for (entity, registered_species) in &self.entity_species {
+            if *registered_species != species {
+                continue;
+            }
+            any_entity = true;
+            let Some(per_signature) = self.entity_emissions.get(entity) else {
+                continue;
+            };
+            for (sig, count) in per_signature {
+                observation_count = observation_count.saturating_add(*count);
+                if let Some(observation) = self.observations.get(sig) {
+                    first_tick = Some(match first_tick {
+                        Some(prev) if prev <= observation.first_tick => prev,
+                        _ => observation.first_tick,
+                    });
+                }
+                if let Some(label) = self.labels.get(sig) {
+                    label_ids.insert(label.id.clone());
+                    if label.confidence > confidence {
+                        confidence = label.confidence;
+                    }
+                }
+            }
+        }
+
+        if !any_entity {
+            return None;
+        }
+
+        Some(BestiaryEntry {
+            species,
+            label_ids: label_ids.into_iter().collect(),
+            observation_count,
+            confidence,
+            first_tick: first_tick.unwrap_or(TickCounter::ZERO),
+        })
+    }
+}
+
+impl ChroniclerQuery for Chronicler {
+    fn label_for_signature(&self, sig: &PatternSignature) -> Option<&Label> {
+        self.labels.get(sig)
+    }
+
+    fn labels_for_entity(&self, entity: EntityId) -> Vec<&Label> {
+        let Some(per_signature) = self.entity_emissions.get(&entity) else {
+            return Vec::new();
+        };
+        // Iterating the BTreeMap keys yields signatures in ascending
+        // byte order, so the resulting Vec is deterministic across calls.
+        per_signature
+            .keys()
+            .filter_map(|sig| self.labels.get(sig))
+            .collect()
+    }
+
+    fn entities_with_label(&self, label_id: &str) -> Vec<EntityId> {
+        // Collect signatures matching the requested label id first; the
+        // labels map is small relative to entity_emissions, so this
+        // narrows the work for the entity scan.
+        let signatures: BTreeSet<PatternSignature> = self
+            .labels
+            .iter()
+            .filter(|(_, label)| label.id == label_id)
+            .map(|(sig, _)| *sig)
+            .collect();
+        if signatures.is_empty() {
+            return Vec::new();
+        }
+        // Iteration over BTreeMap<EntityId, _> is ascending by EntityId,
+        // satisfying INVARIANTS §1.
+        self.entity_emissions
+            .iter()
+            .filter(|(_, per_signature)| per_signature.keys().any(|sig| signatures.contains(sig)))
+            .map(|(entity, _)| *entity)
+            .collect()
+    }
+
+    fn bestiary_entries(&self, filter: &BestiaryFilter) -> Vec<BestiaryEntry> {
+        // Distinct species, in ascending SpeciesId — gives a stable
+        // pre-sort baseline before applying the configured order.
+        let species_set: BTreeSet<SpeciesId> = self.entity_species.values().copied().collect();
+        let mut entries: Vec<BestiaryEntry> = species_set
+            .into_iter()
+            .filter_map(|s| self.build_bestiary_entry(s))
+            .filter(|entry| !filter.discovered_only || entry.observation_count >= 1)
+            .filter(|entry| match &filter.search {
+                None => true,
+                Some(needle) => label_ids_match_search(&entry.label_ids, needle),
+            })
+            .collect();
+        sort_bestiary(&mut entries, filter.sort_by);
+        entries
+    }
+
+    fn bestiary_entry(&self, species: SpeciesId) -> Option<BestiaryEntry> {
+        self.build_bestiary_entry(species)
     }
 }
 

--- a/crates/beast-chronicler/src/chronicler.rs
+++ b/crates/beast-chronicler/src/chronicler.rs
@@ -48,6 +48,17 @@ pub struct Chronicler {
     /// species are excluded from bestiary queries; they still appear
     /// under [`Self::labels_for_entity`].
     entity_species: BTreeMap<EntityId, SpeciesId>,
+    /// Reverse index of [`Self::entity_species`] — the set of entities
+    /// registered for each species. Maintained in lockstep with
+    /// `entity_species` by [`Self::set_entity_species`].
+    ///
+    /// Without this, [`ChroniclerQuery::bestiary_entries`] would scan
+    /// every entry of `entity_species` once per distinct species —
+    /// O(S * E) work on every render. With the reverse index a single
+    /// bestiary build is O(members) and the full sweep is O(E * P)
+    /// (each entity contributes its own signatures exactly once),
+    /// matching the optimal cost.
+    species_entities: BTreeMap<SpeciesId, BTreeSet<EntityId>>,
 }
 
 impl Chronicler {
@@ -108,9 +119,28 @@ impl Chronicler {
     /// (sim spawner, save loader) is the source of truth. Repeated calls
     /// for the same entity overwrite the prior species — useful for
     /// speciation events where an entity transitions between species
-    /// ids over its lifetime.
+    /// ids over its lifetime. The `species_entities` reverse index is
+    /// kept in sync: the entity is removed from the previous species'
+    /// set (and that set dropped if it became empty) before being
+    /// inserted into the new one.
     pub fn set_entity_species(&mut self, entity: EntityId, species: SpeciesId) {
-        self.entity_species.insert(entity, species);
+        if let Some(prev) = self.entity_species.insert(entity, species) {
+            if prev == species {
+                // Same species, set already contains the entity — fast
+                // path skips the reverse-index churn.
+                return;
+            }
+            if let Some(prev_members) = self.species_entities.get_mut(&prev) {
+                prev_members.remove(&entity);
+                if prev_members.is_empty() {
+                    self.species_entities.remove(&prev);
+                }
+            }
+        }
+        self.species_entities
+            .entry(species)
+            .or_default()
+            .insert(entity);
     }
 
     /// Read-only view of the entity → per-signature emission counts.
@@ -207,22 +237,30 @@ impl Chronicler {
     /// Build a [`BestiaryEntry`] for one species by aggregating across
     /// every registered entity that belongs to it.
     ///
-    /// Returns `None` when no entity has been registered for `species`
-    /// or none of the registered entities have been ingested. Pulled out
-    /// of the [`ChroniclerQuery`] impl so [`Self::bestiary_entry`] and
-    /// [`Self::bestiary_entries`] share one aggregation pass.
+    /// Returns `None` when no entity has been registered for `species`.
+    /// Pulled out of the [`ChroniclerQuery`] impl so
+    /// [`Self::bestiary_entry`] and [`Self::bestiary_entries`] share
+    /// one aggregation pass.
+    ///
+    /// Uses [`Self::species_entities`] for an O(members) member walk
+    /// instead of an O(E) scan over every registered entity — required
+    /// for the bestiary screen to stay within its render budget at
+    /// 1000+ species × 10000+ entities.
     fn build_bestiary_entry(&self, species: SpeciesId) -> Option<BestiaryEntry> {
+        let members = self.species_entities.get(&species)?;
+        if members.is_empty() {
+            // Defensive: the index invariant is "no empty sets" but
+            // returning None here keeps the contract identical to the
+            // pre-index version regardless.
+            return None;
+        }
+
         let mut observation_count: u64 = 0;
         let mut first_tick: Option<TickCounter> = None;
         let mut confidence: Q3232 = Q3232::ZERO;
         let mut label_ids: BTreeSet<LabelId> = BTreeSet::new();
-        let mut any_entity = false;
 
-        for (entity, registered_species) in &self.entity_species {
-            if *registered_species != species {
-                continue;
-            }
-            any_entity = true;
+        for entity in members {
             let Some(per_signature) = self.entity_emissions.get(entity) else {
                 continue;
             };
@@ -241,10 +279,6 @@ impl Chronicler {
                     }
                 }
             }
-        }
-
-        if !any_entity {
-            return None;
         }
 
         Some(BestiaryEntry {
@@ -297,11 +331,15 @@ impl ChroniclerQuery for Chronicler {
     }
 
     fn bestiary_entries(&self, filter: &BestiaryFilter) -> Vec<BestiaryEntry> {
-        // Distinct species, in ascending SpeciesId — gives a stable
-        // pre-sort baseline before applying the configured order.
-        let species_set: BTreeSet<SpeciesId> = self.entity_species.values().copied().collect();
-        let mut entries: Vec<BestiaryEntry> = species_set
-            .into_iter()
+        // BTreeMap iteration over species_entities yields species in
+        // ascending SpeciesId order — gives a stable pre-sort baseline
+        // before applying the configured order, and avoids the O(E)
+        // scan a `entity_species.values().copied().collect()` would
+        // otherwise cost.
+        let mut entries: Vec<BestiaryEntry> = self
+            .species_entities
+            .keys()
+            .copied()
             .filter_map(|s| self.build_bestiary_entry(s))
             .filter(|entry| !filter.discovered_only || entry.observation_count >= 1)
             .filter(|entry| match &filter.search {
@@ -330,6 +368,49 @@ mod tests {
             EntityId::new(entity),
             primitives.iter().copied(),
         )
+    }
+
+    #[test]
+    fn set_entity_species_maintains_reverse_index() {
+        let mut c = Chronicler::new();
+        c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+        c.set_entity_species(EntityId::new(2), SpeciesId::new(0));
+        c.set_entity_species(EntityId::new(3), SpeciesId::new(1));
+        assert_eq!(
+            c.species_entities.get(&SpeciesId::new(0)).map(|s| s.len()),
+            Some(2)
+        );
+        assert_eq!(
+            c.species_entities.get(&SpeciesId::new(1)).map(|s| s.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn set_entity_species_speciation_moves_entity_between_sets() {
+        // Speciation event: entity 1 starts as species 0, then transitions
+        // to species 1. The reverse index must follow.
+        let mut c = Chronicler::new();
+        c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+        c.set_entity_species(EntityId::new(1), SpeciesId::new(1));
+        assert!(
+            !c.species_entities.contains_key(&SpeciesId::new(0)),
+            "empty species set should be removed"
+        );
+        assert_eq!(
+            c.species_entities.get(&SpeciesId::new(1)).map(|s| s.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn set_entity_species_repeat_same_species_is_idempotent() {
+        let mut c = Chronicler::new();
+        c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+        c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+        let members = c.species_entities.get(&SpeciesId::new(0)).unwrap();
+        assert_eq!(members.len(), 1);
+        assert!(members.contains(&EntityId::new(1)));
     }
 
     #[test]

--- a/crates/beast-chronicler/src/lib.rs
+++ b/crates/beast-chronicler/src/lib.rs
@@ -33,6 +33,7 @@ pub mod chronicler;
 pub mod confidence;
 pub mod label;
 pub mod pattern;
+pub mod query;
 pub mod snapshot;
 pub mod tick_range;
 
@@ -40,5 +41,9 @@ pub use chronicler::Chronicler;
 pub use confidence::compute_confidence;
 pub use label::{Label, LabelEngine, LabelEngineError, LabelLoadError, LabelManifest};
 pub use pattern::{PatternObservation, PatternSignature};
+pub use query::{
+    BestiaryEntry, BestiaryFilter, BestiarySortBy, ChroniclerQuery, InMemoryChronicler, LabelId,
+    SpeciesId,
+};
 pub use snapshot::PrimitiveSnapshot;
 pub use tick_range::TickRange;

--- a/crates/beast-chronicler/src/query.rs
+++ b/crates/beast-chronicler/src/query.rs
@@ -1,0 +1,516 @@
+//! Read-only query surface for the UI layer (S10.7).
+//!
+//! Per `documentation/INVARIANTS.md` §6 the UI never mutates sim state and
+//! never reads primitive-level data. [`ChroniclerQuery`] is the only
+//! sanctioned channel: every method takes `&self` and returns owned data
+//! or borrows tied to `&self`. There is no mutating method on the trait.
+//!
+//! Per `documentation/systems/09_world_history_lore.md` §16, the UI
+//! consumes high-level catalogs (bestiary entries, labels) — it must not
+//! reach into [`PatternObservation`] directly. The trait shape here is the
+//! S10.7 MVP slice of the broader design in §16; the richer surface
+//! (factions, lineages, event feed) lands in S12+.
+//!
+//! Per `documentation/INVARIANTS.md` §6, `bestiary_discovered` is a *UI*
+//! flag, not sim state. [`BestiaryEntry`] therefore deliberately omits a
+//! `discovered` field: the UI computes it from `observation_count >= 1`.
+//! [`BestiaryFilter::discovered_only`] applies the same rule on the query
+//! side.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use beast_core::{EntityId, TickCounter, Q3232};
+use serde::{Deserialize, Serialize};
+
+use crate::label::Label;
+use crate::pattern::PatternSignature;
+
+/// Manifest-defined label id. Same string space as [`Label::id`]; a type
+/// alias keeps API call sites self-documenting without forcing a newtype
+/// conversion through every existing label site.
+pub type LabelId = String;
+
+/// Opaque species identifier used by the bestiary catalog.
+///
+/// Defined here (rather than imported from `beast-sim`) because
+/// `beast-chronicler` sits at L4 and cannot depend on simulation-layer
+/// crates. Higher-layer code is expected to bridge its own species id
+/// type into [`SpeciesId`] when it registers entities — see
+/// [`Chronicler::set_entity_species`](crate::Chronicler::set_entity_species).
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct SpeciesId(pub u32);
+
+impl SpeciesId {
+    /// Construct from a raw `u32`.
+    #[inline]
+    pub const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// The underlying `u32`.
+    #[inline]
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+/// Sort orderings for [`BestiaryFilter`].
+///
+/// All variants produce a *total* order on [`BestiaryEntry`]: when the
+/// primary key ties, the species id breaks the tie ascending. Without the
+/// secondary key, equal primary values would let `BTreeMap` insertion
+/// order leak into the rendered list — which violates determinism on the
+/// query surface (INVARIANTS §1).
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum BestiarySortBy {
+    /// Confidence descending (most-confident first); ties broken by
+    /// `species_id` ascending. Default for the bestiary screen.
+    #[default]
+    Confidence,
+    /// Earliest first-tick first; ties broken by `species_id` ascending.
+    FirstTick,
+    /// Highest observation count first; ties broken by `species_id`
+    /// ascending.
+    Observations,
+}
+
+/// Filter parameters for [`ChroniclerQuery::bestiary_entries`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BestiaryFilter {
+    /// If `true`, drop entries with `observation_count == 0`. Per
+    /// INVARIANTS §6 the UI is the canonical place that rephrases this
+    /// as `bestiary_discovered`; the query side simply enforces the
+    /// underlying numeric rule.
+    pub discovered_only: bool,
+    /// Sort order applied after filtering.
+    pub sort_by: BestiarySortBy,
+    /// Optional case-insensitive substring filter applied against
+    /// [`BestiaryEntry::label_ids`]. `None` means no text filter.
+    pub search: Option<String>,
+}
+
+impl BestiaryFilter {
+    /// All-defaults filter: include everything, sort by confidence desc.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Per-species summary surfaced on the bestiary screen.
+///
+/// Contains only *aggregate* sim-side state plus derivable fields. Notably
+/// **no `discovered` field** — that flag is derived at the UI layer per
+/// INVARIANTS §6.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BestiaryEntry {
+    /// Species this entry summarises.
+    pub species: SpeciesId,
+    /// All distinct label ids assigned to any signature this species has
+    /// emitted, sorted ascending. Sorted-ness is required for
+    /// determinism of the rendered bestiary list (INVARIANTS §1).
+    pub label_ids: Vec<LabelId>,
+    /// Total snapshot ingestions for entities of this species. Always
+    /// non-negative. Driven by [`Chronicler::ingest`](crate::Chronicler::ingest)
+    /// + the `entity → species` registration.
+    pub observation_count: u64,
+    /// Highest confidence across all assigned labels for this species.
+    /// `Q3232::ZERO` when no label has been assigned yet.
+    pub confidence: Q3232,
+    /// Earliest tick on which any signature emitted by this species was
+    /// observed. `TickCounter::ZERO` when there are no observations.
+    pub first_tick: TickCounter,
+}
+
+/// Read-only query surface consumed by the UI layer.
+///
+/// Per INVARIANTS §6 every method is `&self`. There is intentionally no
+/// `&mut self` method on this trait; mutation flows through
+/// [`Chronicler::ingest`](crate::Chronicler::ingest) /
+/// [`Chronicler::assign_labels`](crate::Chronicler::assign_labels) /
+/// [`Chronicler::set_entity_species`](crate::Chronicler::set_entity_species),
+/// none of which the UI is allowed to call.
+pub trait ChroniclerQuery {
+    /// Look up the assigned label for a single pattern signature. Returns
+    /// `None` if the chronicler has not assigned a label to that
+    /// signature (manifest miss, below `min_confidence`, or labels have
+    /// not been computed yet).
+    fn label_for_signature(&self, sig: &PatternSignature) -> Option<&Label>;
+
+    /// Every label assigned to any signature the given entity has been
+    /// observed emitting. Iteration order is ascending
+    /// [`PatternSignature`], which is the natural total order over the
+    /// underlying `BTreeMap` and stays stable across calls.
+    fn labels_for_entity(&self, entity: EntityId) -> Vec<&Label>;
+
+    /// Every entity that has been observed emitting any signature
+    /// labelled `label_id`, in ascending [`EntityId`] order. Per
+    /// INVARIANTS §1 the sort is required so iteration over the result
+    /// does not leak insertion order into downstream sim state.
+    fn entities_with_label(&self, label_id: &str) -> Vec<EntityId>;
+
+    /// Every species the chronicler has been told about, projected
+    /// through `filter`. Order is determined by [`BestiaryFilter::sort_by`]
+    /// with `species_id` as the secondary key, so two calls with the
+    /// same filter produce a byte-identical `Vec`.
+    fn bestiary_entries(&self, filter: &BestiaryFilter) -> Vec<BestiaryEntry>;
+
+    /// One bestiary entry by species id. Returns `None` when no entity
+    /// has been registered for that species.
+    fn bestiary_entry(&self, species: SpeciesId) -> Option<BestiaryEntry>;
+}
+
+/// Lightweight, hand-rolled fixture implementing [`ChroniclerQuery`].
+///
+/// Useful for downstream UI tests (S10.4 / S10.8) that want to exercise
+/// the bestiary / label rendering paths without standing up a full
+/// [`Chronicler`](crate::Chronicler) and ingesting snapshots. Push values
+/// into the public fields directly — none of them are checked for
+/// consistency, so test authors are responsible for keeping the maps
+/// coherent (e.g. don't reference an [`EntityId`] in
+/// `entities_by_label_id` that isn't in `entity_signatures`).
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryChronicler {
+    /// `signature → label` map mirroring [`Chronicler::labels`](crate::Chronicler::labels).
+    pub labels: BTreeMap<PatternSignature, Label>,
+    /// `entity → set of signatures the entity has emitted`.
+    pub entity_signatures: BTreeMap<EntityId, BTreeSet<PatternSignature>>,
+    /// Pre-computed bestiary catalog keyed by species id. Returned
+    /// (filtered + sorted) by [`Self::bestiary_entries`]; looked up by
+    /// [`Self::bestiary_entry`].
+    pub bestiary: BTreeMap<SpeciesId, BestiaryEntry>,
+}
+
+impl InMemoryChronicler {
+    /// Construct an empty fixture.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ChroniclerQuery for InMemoryChronicler {
+    fn label_for_signature(&self, sig: &PatternSignature) -> Option<&Label> {
+        self.labels.get(sig)
+    }
+
+    fn labels_for_entity(&self, entity: EntityId) -> Vec<&Label> {
+        let Some(sigs) = self.entity_signatures.get(&entity) else {
+            return Vec::new();
+        };
+        sigs.iter().filter_map(|sig| self.labels.get(sig)).collect()
+    }
+
+    fn entities_with_label(&self, label_id: &str) -> Vec<EntityId> {
+        let signatures: BTreeSet<PatternSignature> = self
+            .labels
+            .iter()
+            .filter(|(_, label)| label.id == label_id)
+            .map(|(sig, _)| *sig)
+            .collect();
+        if signatures.is_empty() {
+            return Vec::new();
+        }
+        // BTreeMap iteration is ascending by EntityId — sorted output
+        // falls out of the storage choice (INVARIANTS §1).
+        self.entity_signatures
+            .iter()
+            .filter(|(_, sigs)| !sigs.is_disjoint(&signatures))
+            .map(|(entity, _)| *entity)
+            .collect()
+    }
+
+    fn bestiary_entries(&self, filter: &BestiaryFilter) -> Vec<BestiaryEntry> {
+        let mut entries: Vec<BestiaryEntry> = self
+            .bestiary
+            .values()
+            .filter(|entry| !filter.discovered_only || entry.observation_count >= 1)
+            .filter(|entry| match &filter.search {
+                None => true,
+                Some(needle) => label_ids_match_search(&entry.label_ids, needle),
+            })
+            .cloned()
+            .collect();
+        sort_bestiary(&mut entries, filter.sort_by);
+        entries
+    }
+
+    fn bestiary_entry(&self, species: SpeciesId) -> Option<BestiaryEntry> {
+        self.bestiary.get(&species).cloned()
+    }
+}
+
+pub(crate) fn label_ids_match_search(label_ids: &[LabelId], needle: &str) -> bool {
+    let lc = needle.to_lowercase();
+    label_ids.iter().any(|id| id.to_lowercase().contains(&lc))
+}
+
+pub(crate) fn sort_bestiary(entries: &mut [BestiaryEntry], sort_by: BestiarySortBy) {
+    match sort_by {
+        BestiarySortBy::Confidence => entries.sort_by(|a, b| {
+            // Higher confidence first; tie-break by species id ascending.
+            b.confidence
+                .cmp(&a.confidence)
+                .then_with(|| a.species.cmp(&b.species))
+        }),
+        BestiarySortBy::FirstTick => entries.sort_by(|a, b| {
+            a.first_tick
+                .cmp(&b.first_tick)
+                .then_with(|| a.species.cmp(&b.species))
+        }),
+        BestiarySortBy::Observations => entries.sort_by(|a, b| {
+            b.observation_count
+                .cmp(&a.observation_count)
+                .then_with(|| a.species.cmp(&b.species))
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_label(id: &str, sig_byte: u8, conf: f64) -> Label {
+        Label {
+            id: id.to_owned(),
+            signature: PatternSignature([sig_byte; 32]),
+            confidence: Q3232::from_num(conf),
+        }
+    }
+
+    // Synthetic label ids used purely for unit-test fixtures. These
+    // intentionally do *not* match any shipped manifest id — the
+    // `tests/no_hardcoded_label_strings.rs` invariant test scans `src/`
+    // for shipped ids, and any leak there indicates an INVARIANTS §2
+    // violation rather than a fixture string.
+    const FIXTURE_ALPHA: &str = "fixture_alpha";
+    const FIXTURE_BETA: &str = "fixture_beta";
+    const FIXTURE_GAMMA: &str = "fixture_gamma";
+
+    fn populated_fixture() -> InMemoryChronicler {
+        let mut chronicler = InMemoryChronicler::new();
+        let alpha_sig = PatternSignature([1; 32]);
+        let beta_sig = PatternSignature([2; 32]);
+        let gamma_sig = PatternSignature([3; 32]);
+        chronicler
+            .labels
+            .insert(alpha_sig, make_label(FIXTURE_ALPHA, 1, 0.9));
+        chronicler
+            .labels
+            .insert(beta_sig, make_label(FIXTURE_BETA, 2, 0.7));
+        chronicler
+            .labels
+            .insert(gamma_sig, make_label(FIXTURE_GAMMA, 3, 0.5));
+        chronicler
+            .entity_signatures
+            .insert(EntityId::new(2), BTreeSet::from([alpha_sig, beta_sig]));
+        chronicler
+            .entity_signatures
+            .insert(EntityId::new(5), BTreeSet::from([gamma_sig]));
+        chronicler
+            .entity_signatures
+            .insert(EntityId::new(7), BTreeSet::from([alpha_sig]));
+        chronicler.bestiary.insert(
+            SpeciesId::new(0),
+            BestiaryEntry {
+                species: SpeciesId::new(0),
+                label_ids: vec![FIXTURE_ALPHA.to_owned(), FIXTURE_BETA.to_owned()],
+                observation_count: 200,
+                confidence: Q3232::from_num(0.9),
+                first_tick: TickCounter::new(10),
+            },
+        );
+        chronicler.bestiary.insert(
+            SpeciesId::new(1),
+            BestiaryEntry {
+                species: SpeciesId::new(1),
+                label_ids: vec![FIXTURE_GAMMA.to_owned()],
+                observation_count: 50,
+                confidence: Q3232::from_num(0.5),
+                first_tick: TickCounter::new(5),
+            },
+        );
+        chronicler.bestiary.insert(
+            SpeciesId::new(2),
+            BestiaryEntry {
+                species: SpeciesId::new(2),
+                label_ids: vec![],
+                observation_count: 0,
+                confidence: Q3232::ZERO,
+                first_tick: TickCounter::ZERO,
+            },
+        );
+        chronicler
+    }
+
+    #[test]
+    fn label_for_signature_returns_assigned_label() {
+        let c = populated_fixture();
+        let label = c.label_for_signature(&PatternSignature([1; 32])).unwrap();
+        assert_eq!(label.id, FIXTURE_ALPHA);
+        assert!(c.label_for_signature(&PatternSignature([99; 32])).is_none());
+    }
+
+    #[test]
+    fn labels_for_entity_collects_all_assigned_labels() {
+        let c = populated_fixture();
+        let labels = c.labels_for_entity(EntityId::new(2));
+        let ids: Vec<&str> = labels.iter().map(|l| l.id.as_str()).collect();
+        // Iteration order follows BTreeSet<PatternSignature> ascending →
+        // [1; 32] before [2; 32] → alpha before beta.
+        assert_eq!(ids, vec![FIXTURE_ALPHA, FIXTURE_BETA]);
+    }
+
+    #[test]
+    fn labels_for_entity_returns_empty_for_unknown_entity() {
+        let c = populated_fixture();
+        assert!(c.labels_for_entity(EntityId::new(999)).is_empty());
+    }
+
+    #[test]
+    fn entities_with_label_returns_ascending_entity_ids() {
+        let c = populated_fixture();
+        let entities = c.entities_with_label(FIXTURE_ALPHA);
+        // EntityId(2) and EntityId(7) both emit the alpha signature;
+        // result must be ascending (INVARIANTS §1).
+        assert_eq!(entities, vec![EntityId::new(2), EntityId::new(7)]);
+    }
+
+    #[test]
+    fn entities_with_label_handles_unknown_label() {
+        let c = populated_fixture();
+        assert!(c.entities_with_label("does_not_exist").is_empty());
+    }
+
+    #[test]
+    fn bestiary_entries_default_filter_returns_all_sorted_by_confidence_desc() {
+        let c = populated_fixture();
+        let entries = c.bestiary_entries(&BestiaryFilter::default());
+        let ids: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+        // confidence ordering: 0.9 (sp0), 0.5 (sp1), 0.0 (sp2)
+        assert_eq!(ids, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn bestiary_entries_discovered_only_drops_zero_observations() {
+        let c = populated_fixture();
+        let filter = BestiaryFilter {
+            discovered_only: true,
+            ..Default::default()
+        };
+        let entries = c.bestiary_entries(&filter);
+        let ids: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+        assert_eq!(ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn bestiary_entries_sort_by_first_tick() {
+        let c = populated_fixture();
+        let filter = BestiaryFilter {
+            sort_by: BestiarySortBy::FirstTick,
+            ..Default::default()
+        };
+        let entries = c.bestiary_entries(&filter);
+        let ticks: Vec<u64> = entries.iter().map(|e| e.first_tick.raw()).collect();
+        // ZERO, 5, 10 — ascending.
+        assert_eq!(ticks, vec![0, 5, 10]);
+    }
+
+    #[test]
+    fn bestiary_entries_sort_by_observations() {
+        let c = populated_fixture();
+        let filter = BestiaryFilter {
+            sort_by: BestiarySortBy::Observations,
+            ..Default::default()
+        };
+        let entries = c.bestiary_entries(&filter);
+        let counts: Vec<u64> = entries.iter().map(|e| e.observation_count).collect();
+        // 200, 50, 0 — descending.
+        assert_eq!(counts, vec![200, 50, 0]);
+    }
+
+    #[test]
+    fn bestiary_entries_search_is_case_insensitive_substring() {
+        let c = populated_fixture();
+        let filter = BestiaryFilter {
+            search: Some("GAMMA".to_owned()),
+            ..Default::default()
+        };
+        let entries = c.bestiary_entries(&filter);
+        let ids: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+        assert_eq!(ids, vec![1]);
+    }
+
+    #[test]
+    fn bestiary_entries_is_deterministic_across_calls() {
+        let c = populated_fixture();
+        let filter = BestiaryFilter::default();
+        let first = c.bestiary_entries(&filter);
+        let second = c.bestiary_entries(&filter);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn bestiary_entry_lookup() {
+        let c = populated_fixture();
+        let entry = c.bestiary_entry(SpeciesId::new(1)).unwrap();
+        assert_eq!(entry.observation_count, 50);
+        assert!(c.bestiary_entry(SpeciesId::new(99)).is_none());
+    }
+
+    #[test]
+    fn confidence_tie_break_uses_species_id_ascending() {
+        // Two entries with identical confidence — species id must break
+        // the tie so the rendered list is stable.
+        let mut c = InMemoryChronicler::new();
+        c.bestiary.insert(
+            SpeciesId::new(7),
+            BestiaryEntry {
+                species: SpeciesId::new(7),
+                label_ids: vec![],
+                observation_count: 1,
+                confidence: Q3232::from_num(0.5),
+                first_tick: TickCounter::new(0),
+            },
+        );
+        c.bestiary.insert(
+            SpeciesId::new(3),
+            BestiaryEntry {
+                species: SpeciesId::new(3),
+                label_ids: vec![],
+                observation_count: 1,
+                confidence: Q3232::from_num(0.5),
+                first_tick: TickCounter::new(0),
+            },
+        );
+        let entries = c.bestiary_entries(&BestiaryFilter::default());
+        let ids: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+        assert_eq!(ids, vec![3, 7]);
+    }
+
+    #[test]
+    fn bestiary_entry_has_no_discovered_field() {
+        // INVARIANTS §6: `discovered` is UI-derived state and must not
+        // leak into sim-side records. Compile-time check via field
+        // pattern: if a `discovered` field were ever added, this test
+        // would still pass — so we additionally enumerate the fields in
+        // a destructure that would fail to compile if a new field
+        // sneaked in.
+        let entry = BestiaryEntry {
+            species: SpeciesId::new(0),
+            label_ids: vec![],
+            observation_count: 0,
+            confidence: Q3232::ZERO,
+            first_tick: TickCounter::ZERO,
+        };
+        let BestiaryEntry {
+            species: _,
+            label_ids: _,
+            observation_count: _,
+            confidence: _,
+            first_tick: _,
+        } = entry;
+    }
+}

--- a/crates/beast-chronicler/src/query.rs
+++ b/crates/beast-chronicler/src/query.rs
@@ -170,8 +170,8 @@ pub trait ChroniclerQuery {
 /// [`Chronicler`](crate::Chronicler) and ingesting snapshots. Push values
 /// into the public fields directly — none of them are checked for
 /// consistency, so test authors are responsible for keeping the maps
-/// coherent (e.g. don't reference an [`EntityId`] in
-/// `entities_by_label_id` that isn't in `entity_signatures`).
+/// coherent (e.g. don't list an [`EntityId`] under a `bestiary` entry
+/// that isn't also in `entity_signatures`).
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryChronicler {
     /// `signature → label` map mirroring [`Chronicler::labels`](crate::Chronicler::labels).
@@ -243,8 +243,32 @@ impl ChroniclerQuery for InMemoryChronicler {
 }
 
 pub(crate) fn label_ids_match_search(label_ids: &[LabelId], needle: &str) -> bool {
-    let lc = needle.to_lowercase();
-    label_ids.iter().any(|id| id.to_lowercase().contains(&lc))
+    // The label-manifest schema constrains ids to `^[a-z][a-z0-9_]*$`
+    // (see `documentation/schemas/label_manifest.schema.json`), so the
+    // haystack is always ASCII. A user-typed needle may include
+    // uppercase, but ASCII case-insensitive byte comparison is enough
+    // to match the user's intent without allocating a lowercased copy
+    // per label id. The previous implementation called
+    // `id.to_lowercase()` once per id, which scaled the per-search
+    // allocation count with the bestiary catalog size.
+    label_ids
+        .iter()
+        .any(|id| ascii_icase_contains(id.as_bytes(), needle.as_bytes()))
+}
+
+fn ascii_icase_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|window| {
+        window
+            .iter()
+            .zip(needle.iter())
+            .all(|(h, n)| h.eq_ignore_ascii_case(n))
+    })
 }
 
 pub(crate) fn sort_bestiary(entries: &mut [BestiaryEntry], sort_by: BestiarySortBy) {

--- a/crates/beast-chronicler/tests/query_api_integration.rs
+++ b/crates/beast-chronicler/tests/query_api_integration.rs
@@ -1,0 +1,231 @@
+//! Integration coverage for the S10.7 [`ChroniclerQuery`] surface against
+//! a live [`Chronicler`].
+//!
+//! The unit tests in `src/query.rs` cover the [`InMemoryChronicler`]
+//! fixture; this file pins the contract for the production
+//! implementation by ingesting real snapshots and assigning labels.
+
+use std::collections::BTreeSet;
+
+use beast_chronicler::{
+    BestiaryEntry, BestiaryFilter, BestiarySortBy, Chronicler, ChroniclerQuery, LabelEngine,
+    PatternSignature, PrimitiveSnapshot, SpeciesId,
+};
+use beast_core::{EntityId, TickCounter};
+
+const ECHO_MANIFEST: &str = r#"{
+    "labels": [
+        { "id": "echolocation",   "primitives": ["echo", "spatial"], "min_confidence": 0.0 },
+        { "id": "bioluminescence", "primitives": ["glow"],            "min_confidence": 0.0 }
+    ]
+}"#;
+
+fn snap(tick: u64, entity: u32, primitives: &[&str]) -> PrimitiveSnapshot {
+    PrimitiveSnapshot::new(
+        TickCounter::new(tick),
+        EntityId::new(entity),
+        primitives.iter().copied(),
+    )
+}
+
+#[test]
+fn label_for_signature_returns_assigned_label_after_assign_pass() {
+    let mut c = Chronicler::new();
+    for tick in 0..50 {
+        c.ingest(&snap(tick, 1, &["echo", "spatial"]));
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let sig = PatternSignature::from_primitives(["spatial", "echo"]);
+    let label = c.label_for_signature(&sig).expect("label assigned");
+    assert_eq!(label.id, "echolocation");
+    assert_eq!(label.signature, sig);
+
+    // Unknown signature — no label.
+    assert!(c
+        .label_for_signature(&PatternSignature([0xff; 32]))
+        .is_none());
+}
+
+#[test]
+fn labels_for_entity_returns_all_assigned_labels_for_emissions() {
+    let mut c = Chronicler::new();
+    // Entity 4 emits both echo+spatial AND glow over time.
+    for tick in 0..20 {
+        c.ingest(&snap(tick, 4, &["echo", "spatial"]));
+    }
+    for tick in 20..40 {
+        c.ingest(&snap(tick, 4, &["glow"]));
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let labels = c.labels_for_entity(EntityId::new(4));
+    let ids: BTreeSet<&str> = labels.iter().map(|l| l.id.as_str()).collect();
+    assert_eq!(ids, BTreeSet::from(["echolocation", "bioluminescence"]),);
+}
+
+#[test]
+fn entities_with_label_returns_ascending_entity_ids() {
+    let mut c = Chronicler::new();
+    // Entities 9, 2, 5 all emit the echolocation pattern; 1 emits glow only.
+    for entity in [9u32, 2, 5] {
+        for tick in 0..10 {
+            c.ingest(&snap(tick, entity, &["echo", "spatial"]));
+        }
+    }
+    for tick in 0..10 {
+        c.ingest(&snap(tick, 1, &["glow"]));
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let entities = c.entities_with_label("echolocation");
+    assert_eq!(
+        entities,
+        vec![EntityId::new(2), EntityId::new(5), EntityId::new(9)],
+        "result must be ascending by EntityId per INVARIANTS §1",
+    );
+
+    // Unknown label.
+    assert!(c.entities_with_label("does_not_exist").is_empty());
+}
+
+#[test]
+fn bestiary_entries_aggregates_across_species() {
+    let mut c = Chronicler::new();
+    // Species 0: entities 1 + 2, both emit echolocation.
+    c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+    c.set_entity_species(EntityId::new(2), SpeciesId::new(0));
+    // Species 1: entity 3 emits glow only.
+    c.set_entity_species(EntityId::new(3), SpeciesId::new(1));
+    // Species 2: entity 4 — registered but ingests nothing (zero observations).
+    c.set_entity_species(EntityId::new(4), SpeciesId::new(2));
+
+    for tick in 0..60 {
+        c.ingest(&snap(tick, 1, &["echo", "spatial"]));
+        c.ingest(&snap(tick, 2, &["echo", "spatial"]));
+    }
+    for tick in 0..30 {
+        c.ingest(&snap(tick, 3, &["glow"]));
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let all = c.bestiary_entries(&BestiaryFilter::default());
+    let by_species: Vec<u32> = all.iter().map(|e| e.species.raw()).collect();
+    // Default sort is confidence descending; species 0 (echolocation
+    // assigned at full saturation) outranks species 1 (smaller share),
+    // and species 2 has zero confidence so it lands last.
+    assert_eq!(by_species, vec![0, 1, 2]);
+
+    let species0: &BestiaryEntry = all.iter().find(|e| e.species.raw() == 0).unwrap();
+    assert_eq!(species0.observation_count, 120);
+    assert_eq!(species0.label_ids, vec!["echolocation".to_owned()]);
+    assert_eq!(species0.first_tick, TickCounter::new(0));
+}
+
+#[test]
+fn bestiary_entries_discovered_only_drops_zero_observation_species() {
+    let mut c = Chronicler::new();
+    c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+    c.set_entity_species(EntityId::new(2), SpeciesId::new(1)); // no ingest
+    for tick in 0..10 {
+        c.ingest(&snap(tick, 1, &["echo", "spatial"]));
+    }
+
+    let filter = BestiaryFilter {
+        discovered_only: true,
+        ..Default::default()
+    };
+    let entries = c.bestiary_entries(&filter);
+    let species: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+    assert_eq!(species, vec![0]);
+}
+
+#[test]
+fn bestiary_entries_is_deterministic_across_calls() {
+    let mut c = Chronicler::new();
+    c.set_entity_species(EntityId::new(7), SpeciesId::new(2));
+    c.set_entity_species(EntityId::new(3), SpeciesId::new(1));
+    c.set_entity_species(EntityId::new(11), SpeciesId::new(0));
+    for entity in [7u32, 3, 11] {
+        for tick in 0..20 {
+            c.ingest(&snap(tick, entity, &["echo", "spatial"]));
+        }
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let filter = BestiaryFilter::default();
+    let first = c.bestiary_entries(&filter);
+    let second = c.bestiary_entries(&filter);
+    assert_eq!(first, second);
+
+    // Identical confidences across species → species_id ascending must
+    // determine the rendered order.
+    let species_order: Vec<u32> = first.iter().map(|e| e.species.raw()).collect();
+    assert_eq!(species_order, vec![0, 1, 2]);
+}
+
+#[test]
+fn bestiary_entry_lookup_returns_none_for_unknown_species() {
+    let mut c = Chronicler::new();
+    c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+    for tick in 0..5 {
+        c.ingest(&snap(tick, 1, &["echo", "spatial"]));
+    }
+    assert!(c.bestiary_entry(SpeciesId::new(0)).is_some());
+    assert!(c.bestiary_entry(SpeciesId::new(42)).is_none());
+}
+
+#[test]
+fn bestiary_filter_search_is_case_insensitive_substring() {
+    let mut c = Chronicler::new();
+    c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+    c.set_entity_species(EntityId::new(2), SpeciesId::new(1));
+    for tick in 0..30 {
+        c.ingest(&snap(tick, 1, &["echo", "spatial"]));
+    }
+    for tick in 0..30 {
+        c.ingest(&snap(tick, 2, &["glow"]));
+    }
+    let engine = LabelEngine::from_json_str(ECHO_MANIFEST).unwrap();
+    c.assign_labels(&engine, c.last_observed_tick());
+
+    let filter = BestiaryFilter {
+        search: Some("LUMIN".to_owned()),
+        ..Default::default()
+    };
+    let entries = c.bestiary_entries(&filter);
+    let species: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+    assert_eq!(species, vec![1]);
+}
+
+#[test]
+fn bestiary_sort_by_first_tick_orders_ascending() {
+    let mut c = Chronicler::new();
+    c.set_entity_species(EntityId::new(1), SpeciesId::new(0));
+    c.set_entity_species(EntityId::new(2), SpeciesId::new(1));
+    // Species 0 first observed at tick 50; species 1 at tick 5.
+    c.ingest(&snap(50, 1, &["echo", "spatial"]));
+    c.ingest(&snap(5, 2, &["glow"]));
+
+    let filter = BestiaryFilter {
+        sort_by: BestiarySortBy::FirstTick,
+        ..Default::default()
+    };
+    let entries = c.bestiary_entries(&filter);
+    let species: Vec<u32> = entries.iter().map(|e| e.species.raw()).collect();
+    assert_eq!(species, vec![1, 0]);
+}
+
+#[test]
+fn chronicler_query_trait_object_compiles() {
+    // Pinning that ChroniclerQuery is dyn-compatible — UI code holds
+    // `&dyn ChroniclerQuery` (per S10.4 screen builders) so a regression
+    // here would break the entire screens layer.
+    let chronicler = Chronicler::new();
+    let _: &dyn ChroniclerQuery = &chronicler;
+}

--- a/crates/beast-chronicler/tests/query_api_integration.rs
+++ b/crates/beast-chronicler/tests/query_api_integration.rs
@@ -13,6 +13,16 @@ use beast_chronicler::{
 };
 use beast_core::{EntityId, TickCounter};
 
+// Intentionally simplified fixture — does NOT match
+// `assets/manifests/labels.json`. The real `echolocation` entry uses a
+// three-primitive set (`emit_acoustic_pulse`, `receive_acoustic_signal`,
+// `spatial_integrate`) and a `min_confidence` of 0.6; this test stub
+// uses two short primitive ids and `min_confidence: 0.0` so the
+// integration test exercises the query API surface with a minimal
+// number of ingest calls per finding. Keep the names recognisable to
+// the shipped catalog (`echolocation`, `bioluminescence`) so test
+// failure traces still read clearly, but do not treat them as the
+// canonical definition.
 const ECHO_MANIFEST: &str = r#"{
     "labels": [
         { "id": "echolocation",   "primitives": ["echo", "spatial"], "min_confidence": 0.0 },


### PR DESCRIPTION
Closes #212.

## Summary

Read-only query surface the UI layer (S10.4) and integration test (S10.8) consume. Per INVARIANTS §6 every method takes `&self` and there is no mutating method on the trait.

- New `query` module: `ChroniclerQuery` trait, `BestiaryEntry` (no `discovered` field — derived at the UI layer), `BestiaryFilter` (`discovered_only`, `sort_by`, `search`), `BestiarySortBy`, `SpeciesId`, `LabelId` alias.
- `InMemoryChronicler` test fixture for downstream UI tests that want to exercise the bestiary path without ingesting real snapshots.
- Production impl on `Chronicler`:
  - `entity_emissions: BTreeMap<EntityId, BTreeMap<PatternSignature, u64>>` tracks per-entity per-signature counts during `ingest()`, so the bestiary aggregator attributes snapshots per species without double-counting shared signatures.
  - `set_entity_species(entity, species)` registers species membership. `SpeciesId` is defined in `beast-chronicler` rather than imported from `beast-sim` because the chronicler sits at L4 and cannot depend on simulation-layer crates.
- Integration test (`tests/query_api_integration.rs`) pins the contract against a live `Chronicler` ingesting real snapshots and assigning labels through `LabelEngine`.

## DoD checklist (issue #212)

- [x] Trait + impl compile and are exercised by unit tests.
- [x] `entities_with_label` returns entities in ascending `EntityId` order (sorted iteration per INVARIANTS §1) — verified by both the `InMemoryChronicler` and live-`Chronicler` tests.
- [x] `bestiary_entries` ordering is deterministic across two calls — verified for `InMemoryChronicler` and live `Chronicler`; ties are broken by ascending `species_id` for every sort variant.
- [x] `BestiaryEntry` does not contain a `discovered` field — verified by the `bestiary_entry_has_no_discovered_field` destructure test.
- [x] No mutating method on `ChroniclerQuery` (compile-time: every method takes `&self`).
- [x] `cargo clippy -p beast-chronicler --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked`
- [x] `cargo test -p beast-chronicler --doc --locked`
- [x] Claude review workflow run
