### PR TITLE
ci(claude-review): pin payload event to verdict + validate in script

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -391,6 +391,20 @@ jobs:
                    authoritative output. Inline-comment EVERY `new`
                    finding (no top-level summary substitute).
 
+                   The payload's `event` field MUST match the verdict
+                   you compute in the next section — `"APPROVE"` for
+                   an APPROVE verdict (including round-2+ advisory
+                   APPROVE with non-blocking MEDIUM/LOW findings),
+                   `"REQUEST_CHANGES"` for a REQUEST_CHANGES verdict,
+                   `"COMMENT"` only when you explicitly fall back to
+                   the COMMENT verdict per the rules below. Posting a
+                   verdict body line of `**APPROVE** — ...` while
+                   sending `event: COMMENT` leaves any prior
+                   `CHANGES_REQUESTED` review from
+                   `github-actions[bot]` active in GitHub's per-
+                   reviewer rollup, which is exactly what the round-2
+                   ratchet is meant to clear (#246).
+
                  * `new_findings == 0` AND prior_inline_comments.json
                    has at least one entry (i.e. a previous review run
                    left feedback) →
@@ -402,11 +416,24 @@ jobs:
                    any finding text in the comment body — by
                    definition there are no new findings to report.
 
+                   Note: this branch does NOT submit an APPROVE-event
+                   review, so a prior `CHANGES_REQUESTED` from the
+                   bot — if any — stays active. That is intentional
+                   when the prior findings are still applicable. If
+                   the prior findings have all been resolved on the
+                   new diff, the subagent should mark them
+                   `obsolete`, which moves all prior comments out of
+                   `prior_inline_comments.json`'s effective set and
+                   pushes you into the third branch (clean APPROVE).
+
                  * `new_findings == 0` AND prior_inline_comments.json
-                   is empty (clean diff, first review) →
+                   is empty (clean diff, OR every prior finding is
+                   `obsolete`) →
                    **submit an APPROVE-event REVIEW** via
                    `scripts/post-pr-review.sh` with an empty
-                   `comments[]` and a one-line body.
+                   `comments[]`, `event: "APPROVE"`, and a one-line
+                   body. This is what supersedes any prior
+                   `CHANGES_REQUESTED` from the bot.
 
                These three branches are mutually exclusive and
                exhaustive. The silent-failure guard expects EITHER
@@ -466,6 +493,29 @@ jobs:
               or
               `**APPROVE** — round 2 advisory — 0 CRITICAL · 0 HIGH · 2 MEDIUM · 1 LOW (non-blocking)`.
               The repo owner reads this line first.
+
+            ### Verdict ↔ payload `event` mapping
+
+            The verdict you state in the body's first line MUST match
+            the `event` field of the JSON payload posted via
+            `scripts/post-pr-review.sh`. The two strings drive
+            different things — the body line is human-readable, the
+            `event` field is what GitHub's per-reviewer review-state
+            rollup looks at — but they MUST agree:
+
+            | Verdict in body line | Required `event` value |
+            | -------------------- | ---------------------- |
+            | `**APPROVE** — ...` (any round, advisory or not) | `"APPROVE"` |
+            | `**REQUEST_CHANGES** — ...` | `"REQUEST_CHANGES"` |
+            | `**COMMENT** — ...` (explicit fallback only) | `"COMMENT"` |
+
+            Sending `event: "COMMENT"` while the body says `**APPROVE**`
+            leaves any prior `CHANGES_REQUESTED` review from
+            `github-actions[bot]` active, defeating the round-2
+            ratchet (see #246 for the regression that motivated this
+            rule). `scripts/post-pr-review.sh` rejects payloads whose
+            `event` is not one of the three values, so a typo will
+            fail loudly rather than silently degrade.
 
             ## Constraints
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,8 +58,8 @@ endpoint:
 
 ```json
 {
-  "body": "## Review summary\n\n- 1 HIGH, 2 MEDIUM, 1 LOW\n- ...",
-  "event": "COMMENT",
+  "body": "**REQUEST_CHANGES** — round 1 — 0 CRITICAL · 1 HIGH · 2 MEDIUM · 1 LOW",
+  "event": "REQUEST_CHANGES",
   "comments": [
     {
       "path": "crates/beast-ui/src/widget.rs",
@@ -85,8 +85,44 @@ Notes:
   range; both refer to the same `side`.
 - Omit `body` if the review is purely inline; omit `comments` if it's
   purely a top-level note.
-- Set `event` to `COMMENT` unless the agent is explicitly authorized to
-  approve / request-changes.
+
+#### Picking `event`
+
+The `event` field drives GitHub's per-reviewer review-state rollup —
+it is what determines whether the PR appears as
+`approved` / `changes_requested` / `commented` in the merge gate. It
+MUST match the verdict the agent states in the body's first line:
+
+| Verdict in body line | Required `event` value | When to use |
+| -------------------- | ---------------------- | ----------- |
+| `**APPROVE** — ...` (any round, advisory or not) | `"APPROVE"` | No CRITICAL/HIGH (round 1: also no MEDIUM). Supersedes any prior `CHANGES_REQUESTED` from the same `github-actions[bot]` reviewer. |
+| `**REQUEST_CHANGES** — ...` | `"REQUEST_CHANGES"` | Any new finding at the round's blocking tier (round 1: MEDIUM+; round 2+: HIGH+). |
+| `**COMMENT** — ...` | `"COMMENT"` | Explicit fallback only — diff too large to evaluate, or change is purely config without a rubric. Does NOT supersede a prior `CHANGES_REQUESTED`. |
+
+`COMMENT` is **not** the safe default. Sending `event: "COMMENT"` while
+the body says `**APPROVE**` leaves any prior `CHANGES_REQUESTED` from
+the same reviewer active, blocking the merge despite the verdict —
+this is the regression tracked in
+[#246](https://github.com/BemusedVermin/evolution-simulation/issues/246).
+
+`post-pr-review.sh` rejects payloads whose `event` is not one of
+`APPROVE` / `REQUEST_CHANGES` / `COMMENT`, so a typo (e.g.
+`"APPROVED"`) fails loudly rather than silently degrading to
+GitHub's default of `PENDING`.
+
+#### APPROVE example (clean diff or round-2 advisory)
+
+```json
+{
+  "body": "**APPROVE** — round 2 advisory — 0 CRITICAL · 0 HIGH · 1 MEDIUM · 1 LOW (non-blocking)",
+  "event": "APPROVE",
+  "comments": []
+}
+```
+
+A round-2 advisory APPROVE may still carry inline `comments[]`
+entries for the non-blocking MEDIUM/LOW findings — the
+`event: "APPROVE"` value is what supersedes the prior bot review.
 
 ### Author conventions for reviewer subagents
 

--- a/scripts/post-pr-review.sh
+++ b/scripts/post-pr-review.sh
@@ -36,6 +36,8 @@
 # Exit codes:
 #   0   success — review posted, prints the new review JSON to stdout.
 #   64  bad CLI usage.
+#   65  payload `event` field missing or not in
+#       {APPROVE, REQUEST_CHANGES, COMMENT}.
 #   66  payload file missing.
 #   non-zero (other) — `gh api` failure; stderr is forwarded.
 
@@ -55,6 +57,26 @@ if [[ ! -f "$PAYLOAD" ]]; then
   echo "error: payload file not found: $PAYLOAD" >&2
   exit 66
 fi
+
+# Validate the `event` field. GitHub's review-state rollup treats
+# anything other than APPROVE / REQUEST_CHANGES / COMMENT as PENDING,
+# which silently leaves the PR in whatever state the prior review put
+# it in — observed on PR #240 round 2, where the agent posted with
+# `event: COMMENT` for an APPROVE verdict and the prior round-1
+# CHANGES_REQUESTED stayed active (issue #246). A loud failure here
+# is much better than a silent merge-block.
+event=$(jq -r '.event // empty' "$PAYLOAD")
+case "$event" in
+  APPROVE|REQUEST_CHANGES|COMMENT) ;;
+  "")
+    echo "error: payload is missing the 'event' field; must be one of APPROVE / REQUEST_CHANGES / COMMENT" >&2
+    exit 65
+    ;;
+  *)
+    echo "error: payload 'event' is '$event'; must be one of APPROVE / REQUEST_CHANGES / COMMENT (see scripts/README.md)" >&2
+    exit 65
+    ;;
+esac
 
 gh api \
   --method POST \


### PR DESCRIPTION
## Summary

Fixes #246 — round-2+ APPROVE verdicts on the Claude rust-reviewer workflow were posting with `event: "COMMENT"`, leaving any prior `CHANGES_REQUESTED` from `github-actions[bot]` active in GitHub's per-reviewer review-state rollup. Observed on PR #240, where the author had to merge manually after dismissing the round-1 changes-requested review by hand.

## Changes
- `.github/workflows/claude-code-review.yml` — Step 7's `new_findings >= 1` branch now explicitly requires the JSON `event` to match the verdict (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`). New "Verdict ↔ payload `event` mapping" table next to the verdict rules.
- `scripts/README.md` — replaced the misleading "default to `COMMENT`" guidance with a verdict-mapping table and an APPROVE-event example payload (covers the round-2 advisory case where `comments[]` is populated but `event` is `APPROVE`). Cites #246.
- `scripts/post-pr-review.sh` — validates `event ∈ {APPROVE, REQUEST_CHANGES, COMMENT}` before calling `gh api`. Exit 65 on missing or wrong values so a typo (e.g. `"APPROVED"`) fails loudly rather than silently downgrading to GitHub's `PENDING` default.

## Test plan
- [x] `scripts/post-pr-review.sh` smoke-tested locally — invalid `event` returns 65 with a clear stderr; missing `event` returns 65; valid `event: "APPROVE"` falls through to `gh api` (which 404s on a bogus repo, as expected).
- [ ] CI passes on PR (rust-reviewer workflow doesn't re-trigger here because the diff is `.github/**` + `scripts/**` only — none of the path-trigger globs match — but lint/test/codeql still run).
- [ ] Confirmed on the next PR that touches `.rs` / `Cargo.{toml,lock}` that the round-2 APPROVE verdict now arrives as `state: APPROVED` rather than `state: COMMENTED`.

Closes #246.
