### PR TITLE
feat(beast-ecs): S11.2 5-slot continuous formation model

### DIFF
--- a/crates/beast-ecs/src/components.rs
+++ b/crates/beast-ecs/src/components.rs
@@ -17,10 +17,7 @@ pub mod spatial;
 pub mod traits;
 
 pub use biome::{BiomeCell, BiomeKind};
-pub use formation::{
-    compute_engagement, compute_exposure, slot_adjacency, Formation, FormationSlot, SLOT_COUNT,
-    SLOT_NAMES,
-};
+pub use formation::{Formation, FormationSlot, SLOT_COUNT, SLOT_NAMES};
 pub use markers::{Agent, Biome, Creature, Faction, Pathogen, Settlement};
 pub use physiology::{Age, DevelopmentalStage, HealthState, Mass, Species};
 pub use spatial::{Position, Velocity};

--- a/crates/beast-ecs/src/components.rs
+++ b/crates/beast-ecs/src/components.rs
@@ -10,12 +10,17 @@
 //! path (S7) can round-trip them without further plumbing.
 
 pub mod biome;
+pub mod formation;
 pub mod markers;
 pub mod physiology;
 pub mod spatial;
 pub mod traits;
 
 pub use biome::{BiomeCell, BiomeKind};
+pub use formation::{
+    compute_engagement, compute_exposure, slot_adjacency, Formation, FormationSlot, SLOT_COUNT,
+    SLOT_NAMES,
+};
 pub use markers::{Agent, Biome, Creature, Faction, Pathogen, Settlement};
 pub use physiology::{Age, DevelopmentalStage, HealthState, Mass, Species};
 pub use spatial::{Position, Velocity};
@@ -45,6 +50,8 @@ pub fn register_all(world: &mut crate::EcsWorld) {
     world.register_component::<PhenotypeComponent>();
 
     world.register_component::<BiomeCell>();
+
+    world.register_component::<Formation>();
 }
 
 #[cfg(test)]
@@ -94,5 +101,6 @@ mod tests {
         is_dense::<GenomeComponent>();
         is_dense::<PhenotypeComponent>();
         is_dense::<BiomeCell>();
+        is_dense::<Formation>();
     }
 }

--- a/crates/beast-ecs/src/components/formation.rs
+++ b/crates/beast-ecs/src/components/formation.rs
@@ -6,6 +6,12 @@
 //! cells — each slot has continuous `engagement` and `exposure` Q32.32
 //! values modulated by adjacent slot occupancy and terrain.
 //!
+//! This module owns the *data layout only*. The pure math that derives
+//! `engagement` / `exposure` from occupancy + terrain lives in
+//! `beast_sim::formation` (per `CRATE_LAYOUT.md`: domain logic belongs
+//! in L4, not L3). beast-ecs is the data-foundation crate; system code
+//! in L4 reads/writes these components.
+//!
 //! # Design choice — component, not resource
 //!
 //! The story (#252) lets us pick "resource" or "component on a
@@ -25,102 +31,34 @@
 //!
 //! * All math is Q32.32 (`beast_core::Q3232`); no `f32`/`f64` ever
 //!   appears in sim state per INVARIANTS §1.
-//! * Adjacency lookups go through [`slot_adjacency`], whose backing
-//!   store is a `BTreeMap<u8, BTreeSet<u8>>` — iteration is sorted by
-//!   slot index, so the order of contributions to a given slot's
-//!   exposure / engagement is fixed.
-//! * Slots are a fixed-size `[FormationSlot; 5]`; iteration is array
-//!   index order, never insertion order.
-
-use std::collections::{BTreeMap, BTreeSet};
+//! * Slots are a fixed-size `[FormationSlot; SLOT_COUNT]`; iteration is
+//!   array index order, never insertion order.
+//! * Adjacency tables (in `beast_sim::formation`) iterate sorted by
+//!   slot index via `BTreeMap`/`BTreeSet`.
 
 use beast_core::Q3232;
 use serde::{Deserialize, Serialize};
 use specs::{Component, DenseVecStorage};
 
-/// Number of slots in the canonical formation. Locked at five — the
-/// slot semantics in [`SLOT_NAMES`] are wired into the combat doc and
-/// every UI screen that reads formation state.
+/// Number of slots in the canonical formation. Locked at five.
 pub const SLOT_COUNT: usize = 5;
 
-/// Canonical slot names in index order.
+/// Canonical slot identifiers in index order.
+///
+/// These are *structural* names taken verbatim from combat doc §3 — used
+/// only for diagnostic messages, panic strings, and assertion failures.
+/// They are **not** a UI labelling vocabulary; the slot index (`u8` in
+/// `0..SLOT_COUNT`) is the canonical id on the sim path. UI / chronicler
+/// layers may localise these strings to player-facing text if and when
+/// they need to.
 ///
 /// * `0` — Vanguard (front line, melee contact)
 /// * `1` — Flank-Left  (forward-side, partial melee exposure)
 /// * `2` — Flank-Right (forward-side, partial melee exposure)
 /// * `3` — Center     (interior, support / AoE focus)
 /// * `4` — Rear       (back line, ranged / support)
-///
-/// String form is stable — UI screens and chronicler labels match on it.
 pub const SLOT_NAMES: [&str; SLOT_COUNT] =
     ["vanguard", "flank-left", "flank-right", "center", "rear"];
-
-/// Per-slot baseline `engagement` (proximity-to-melee, `[0, 1]`).
-///
-/// Used by [`compute_engagement`]: the template baseline gets bumped up
-/// when adjacent slots are empty (no allies to absorb threats) and
-/// stays put when they're occupied. Values are calibration knobs and
-/// may shift across stories, but the relative ordering — vanguard >
-/// flanks > center > rear — is locked by the combat doc §3.
-///
-/// `Q3232::from_num` is not `const`, so we keep the float literals
-/// alongside `baseline_engagement()` and pay the (negligible) cost of
-/// rebuilding the array per `recompute` call. Using literals here also
-/// dodges the bit-pattern fragility of round-to-nearest in
-/// `saturating_from_num`.
-const BASE_ENGAGEMENT: [f64; SLOT_COUNT] = [
-    0.9, // vanguard
-    0.6, // flank-left
-    0.6, // flank-right
-    0.4, // center
-    0.1, // rear
-];
-
-/// Per-slot baseline `exposure` (targetability, `[0, 1]`).
-///
-/// Used by [`compute_exposure`]: terrain adds, occupied adjacent slots
-/// subtract (shielding), and the result is clamped back into `[0, 1]`.
-const BASE_EXPOSURE: [f64; SLOT_COUNT] = [
-    0.8, // vanguard
-    0.7, // flank-left
-    0.7, // flank-right
-    0.5, // center
-    0.3, // rear
-];
-
-/// Engagement bump per *empty* adjacent slot.
-///
-/// `0.1` per missing neighbour: a vanguard with both flanks empty is
-/// drawing more melee attention than one with flanks held.
-const ENGAGEMENT_GAP: f64 = 0.1;
-
-/// Exposure reduction per *occupied* adjacent slot. Locked at `0.1` —
-/// a flanking ally provides ~10% shielding for an in-formation slot.
-const EXPOSURE_SHIELD: f64 = 0.1;
-
-/// The five baseline engagement values as Q32.32. Computed once per
-/// call; bit-identical across calls for a given build of the `fixed`
-/// crate.
-fn baseline_engagement() -> [Q3232; SLOT_COUNT] {
-    [
-        Q3232::from_num(BASE_ENGAGEMENT[0]),
-        Q3232::from_num(BASE_ENGAGEMENT[1]),
-        Q3232::from_num(BASE_ENGAGEMENT[2]),
-        Q3232::from_num(BASE_ENGAGEMENT[3]),
-        Q3232::from_num(BASE_ENGAGEMENT[4]),
-    ]
-}
-
-/// The five baseline exposure values as Q32.32.
-fn baseline_exposure() -> [Q3232; SLOT_COUNT] {
-    [
-        Q3232::from_num(BASE_EXPOSURE[0]),
-        Q3232::from_num(BASE_EXPOSURE[1]),
-        Q3232::from_num(BASE_EXPOSURE[2]),
-        Q3232::from_num(BASE_EXPOSURE[3]),
-        Q3232::from_num(BASE_EXPOSURE[4]),
-    ]
-}
 
 /// One slot in the formation.
 ///
@@ -128,29 +66,39 @@ fn baseline_exposure() -> [Q3232; SLOT_COUNT] {
 /// S13 — populates it from `specs::Entity::id()` when the encounter is
 /// built). Storing a bare `u32` keeps `FormationSlot` `Serialize` /
 /// `Deserialize` without bringing `specs::Entity` into the save path.
+///
+/// `engagement` / `exposure` are *derived* values: `Default` returns
+/// `Q3232::ZERO` for both, awaiting a call to
+/// `beast_sim::formation::recompute` before the slot is read.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormationSlot {
     /// Encounter-local id of whoever holds this slot, or `None` if the
     /// slot is empty.
     pub occupant: Option<u32>,
-    /// Proximity to melee threats. `[0, 1]`. Computed by
-    /// [`compute_engagement`].
+    /// Proximity to melee threats. `[0, 1]`. Derived field — set by
+    /// `beast_sim::formation::recompute`.
     pub engagement: Q3232,
-    /// Targetability by enemies. `[0, 1]`. Computed by
-    /// [`compute_exposure`].
+    /// Targetability by enemies. `[0, 1]`. Derived field — set by
+    /// `beast_sim::formation::recompute`.
     pub exposure: Q3232,
     /// Terrain bias added to exposure. Encounter assembler sets this
     /// when the formation drops into a particular tile (e.g. a forest
     /// tile lowers exposure across all slots; an open-plain tile
     /// raises it).
+    ///
+    /// Expected range: `[-1, 1]`. Out-of-range inputs are admitted (the
+    /// final `.clamp(0, 1)` on `exposure` keeps the *output* in the
+    /// unit interval) but they push the intermediate sum towards
+    /// `Q3232::MAX` / `Q3232::MIN` saturation, which is wasteful work.
+    /// The S13 encounter assembler should validate this range on input.
     pub terrain_modifier: Q3232,
 }
 
 impl FormationSlot {
     /// Convenience constructor: empty slot with the given terrain
     /// modifier and zero derived values. Engagement / exposure are
-    /// expected to be filled in by [`Formation::recompute`] before
-    /// the slot is read.
+    /// expected to be filled in by `beast_sim::formation::recompute`
+    /// before the slot is read.
     #[must_use]
     pub fn empty(terrain_modifier: Q3232) -> Self {
         Self {
@@ -167,38 +115,28 @@ impl FormationSlot {
 /// Slots are indexed 0..[`SLOT_COUNT`]; the index *is* the position —
 /// no separate ordering metadata. See [`SLOT_NAMES`] for the canonical
 /// labels.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Default` is intentionally **not** derived — a default-constructed
+/// `Formation` would have every slot's `engagement` / `exposure` at
+/// `Q3232::ZERO`, which is *uncomputed* state, not a meaningful zero.
+/// Construct via `beast_sim::formation::build` (which calls `recompute`)
+/// or by storing the array literal and calling `recompute` explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Formation {
     /// Slots in canonical index order. Always exactly five.
     pub slots: [FormationSlot; SLOT_COUNT],
 }
 
 impl Formation {
-    /// Build a formation from the five slot definitions, then recompute
-    /// engagement / exposure so the returned value is internally
-    /// consistent.
-    #[must_use]
-    pub fn new(slots: [FormationSlot; SLOT_COUNT]) -> Self {
-        let mut formation = Self { slots };
-        formation.recompute();
-        formation
-    }
-
-    /// Recompute every slot's `engagement` and `exposure` from the
-    /// current occupancy + terrain, using the canonical adjacency
-    /// table.
+    /// Wrap a slot array into a `Formation`. Engagement / exposure are
+    /// **not** computed by this constructor — call
+    /// `beast_sim::formation::recompute` afterwards.
     ///
-    /// Pure with respect to inputs: same `slots` array (occupancy +
-    /// terrain) → same Q32.32 bytes out, byte-for-byte. This is the
-    /// determinism property the unit tests pin.
-    pub fn recompute(&mut self) {
-        let adjacency = slot_adjacency();
-        let engagements = compute_engagement(&self.slots, &adjacency);
-        let exposures = compute_exposure(&self.slots, &adjacency);
-        for (idx, slot) in self.slots.iter_mut().enumerate() {
-            slot.engagement = engagements[idx];
-            slot.exposure = exposures[idx];
-        }
+    /// This is the data-only constructor; use `beast_sim::formation::build`
+    /// when you want a fully-derived formation in one step.
+    #[must_use]
+    pub fn from_slots(slots: [FormationSlot; SLOT_COUNT]) -> Self {
+        Self { slots }
     }
 }
 
@@ -206,385 +144,23 @@ impl Component for Formation {
     type Storage = DenseVecStorage<Self>;
 }
 
-/// Canonical adjacency table for the 5-slot formation.
-///
-/// Returns a fresh `BTreeMap` rather than a static — the sorted-iteration
-/// guarantee is what the determinism contract rests on, and `BTreeMap`'s
-/// `Default` cannot be made `const`. The map is small (five entries),
-/// so allocating one per `recompute` call is negligible.
-///
-/// Topology (matches combat doc §3 — vanguard up front, flanks beside
-/// it, center between flanks and rear, rear at the back):
-///
-/// ```text
-///         [0 vanguard]
-///        /            \
-///   [1 flank-L]   [2 flank-R]
-///        \            /
-///          [3 center]
-///              |
-///           [4 rear]
-/// ```
-#[must_use]
-pub fn slot_adjacency() -> BTreeMap<u8, BTreeSet<u8>> {
-    let mut m: BTreeMap<u8, BTreeSet<u8>> = BTreeMap::new();
-    m.insert(0, BTreeSet::from([1, 2]));
-    m.insert(1, BTreeSet::from([0, 3]));
-    m.insert(2, BTreeSet::from([0, 3]));
-    m.insert(3, BTreeSet::from([1, 2, 4]));
-    m.insert(4, BTreeSet::from([3]));
-    m
-}
-
-/// Compute the per-slot `engagement` value.
-///
-/// Pure function. Given the current occupancy of every slot and the
-/// adjacency table, returns `[Q3232; 5]` where index `i` is slot `i`'s
-/// engagement.
-///
-/// Formula: `engagement[i] = base_engagement[i] + 0.1 * empty_neighbours[i]`,
-/// then clamped to `[0, 1]`. An empty adjacent slot raises a slot's
-/// engagement (no ally to share melee pressure).
-///
-/// Iteration over `adjacency[&i]` is `BTreeSet` order — strictly
-/// ascending by slot index — so the order in which neighbour
-/// contributions are summed is deterministic. Q32.32 addition is
-/// associative, so this matters less for `+` than it does for, say,
-/// floating-point sums, but the contract is still cheaper to keep
-/// stable than to debug.
-#[must_use]
-pub fn compute_engagement(
-    slots: &[FormationSlot; SLOT_COUNT],
-    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
-) -> [Q3232; SLOT_COUNT] {
-    let gap = Q3232::from_num(ENGAGEMENT_GAP);
-    let baseline = baseline_engagement();
-    let mut out = [Q3232::ZERO; SLOT_COUNT];
-    for idx in 0..SLOT_COUNT {
-        let neighbours = adjacency.get(&(idx as u8));
-        let empty_count = neighbours
-            .map(|set| {
-                set.iter()
-                    .filter(|n| slots[**n as usize].occupant.is_none())
-                    .count()
-            })
-            .unwrap_or(0);
-        // Sum gap * empty_count via repeated addition rather than
-        // multiplying by an integer — keeps the saturating-add semantics
-        // explicit and avoids any int → Q3232 conversion ambiguity.
-        let mut bonus = Q3232::ZERO;
-        for _ in 0..empty_count {
-            bonus += gap;
-        }
-        out[idx] = (baseline[idx] + bonus).clamp(Q3232::ZERO, Q3232::ONE);
-    }
-    out
-}
-
-/// Compute the per-slot `exposure` value.
-///
-/// Pure function. Given the current occupancy + per-slot terrain
-/// modifier and the adjacency table, returns `[Q3232; 5]` where index
-/// `i` is slot `i`'s exposure.
-///
-/// Formula: `exposure[i] = base_exposure[i] + terrain_modifier[i] -
-/// 0.1 * occupied_neighbours[i]`, clamped to `[0, 1]`. An occupied
-/// adjacent slot reduces a slot's exposure (the ally provides cover);
-/// terrain raises or lowers it linearly.
-///
-/// Iteration over `adjacency[&i]` is sorted by slot index, matching
-/// [`compute_engagement`].
-#[must_use]
-pub fn compute_exposure(
-    slots: &[FormationSlot; SLOT_COUNT],
-    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
-) -> [Q3232; SLOT_COUNT] {
-    let shield = Q3232::from_num(EXPOSURE_SHIELD);
-    let baseline = baseline_exposure();
-    let mut out = [Q3232::ZERO; SLOT_COUNT];
-    for idx in 0..SLOT_COUNT {
-        let neighbours = adjacency.get(&(idx as u8));
-        let occupied_count = neighbours
-            .map(|set| {
-                set.iter()
-                    .filter(|n| slots[**n as usize].occupant.is_some())
-                    .count()
-            })
-            .unwrap_or(0);
-        let mut shielding = Q3232::ZERO;
-        for _ in 0..occupied_count {
-            shielding += shield;
-        }
-        let raw = baseline[idx] + slots[idx].terrain_modifier - shielding;
-        out[idx] = raw.clamp(Q3232::ZERO, Q3232::ONE);
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn q(v: f64) -> Q3232 {
-        Q3232::from_num(v)
-    }
-
-    /// Assert two `Q3232` values agree to within `2^-30 ≈ 1e-9`. The
-    /// exact bits drift by 1 LSB across `from_num(0.6)` vs
-    /// `from_num(0.5) + from_num(0.1)` because `0.6_f64` and
-    /// `0.5_f64 + 0.1_f64` aren't bit-identical IEEE-754 inputs to
-    /// `Q3232::from_num`. We don't need bit equality for the *value*
-    /// shape tests — `recompute_is_byte_identical_for_same_input` /
-    /// `recompute_is_idempotent` cover the bit-equality contract.
-    fn assert_q_close(actual: Q3232, expected: Q3232) {
-        let diff = (actual - expected).saturating_abs();
-        let tolerance = Q3232::from_bits(4); // 4 ULP at Q32.32
-        assert!(
-            diff <= tolerance,
-            "expected {expected:?}, got {actual:?} (diff {diff:?} > tol {tolerance:?})",
-        );
-    }
-
-    fn empty_formation() -> Formation {
-        Formation::new([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT])
-    }
-
-    fn full_formation() -> Formation {
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        for (idx, slot) in slots.iter_mut().enumerate() {
-            slot.occupant = Some(idx as u32);
-        }
-        Formation::new(slots)
-    }
-
-    // --- Adjacency --------------------------------------------------------
-
     #[test]
-    fn adjacency_is_symmetric_and_complete() {
-        // Every (a, b) edge must appear in both directions.
-        let adj = slot_adjacency();
-        for (&a, neighbours) in &adj {
-            for &b in neighbours {
-                assert!(
-                    adj.get(&b).is_some_and(|set| set.contains(&a)),
-                    "asymmetric edge: {a} -> {b} but not {b} -> {a}",
-                );
-            }
-        }
-        // Every slot must have at least one neighbour.
-        for idx in 0..SLOT_COUNT as u8 {
-            assert!(
-                !adj.get(&idx)
-                    .expect("slot index missing from adjacency")
-                    .is_empty(),
-                "slot {idx} has empty adjacency",
-            );
-        }
+    fn slot_count_is_five() {
+        assert_eq!(SLOT_COUNT, 5);
+        assert_eq!(SLOT_NAMES.len(), SLOT_COUNT);
     }
 
     #[test]
-    fn adjacency_iteration_is_sorted() {
-        // BTreeMap + BTreeSet guarantee sorted iteration; this test pins
-        // the contract so a future replacement (HashMap, indexmap, etc.)
-        // can't silently break determinism.
-        let adj = slot_adjacency();
-        let keys: Vec<u8> = adj.keys().copied().collect();
-        let mut sorted = keys.clone();
+    fn slot_names_are_distinct() {
+        let mut sorted: Vec<&str> = SLOT_NAMES.to_vec();
         sorted.sort_unstable();
-        assert_eq!(keys, sorted, "slot_adjacency keys must iterate sorted");
-
-        for set in adj.values() {
-            let xs: Vec<u8> = set.iter().copied().collect();
-            let mut s = xs.clone();
-            s.sort_unstable();
-            assert_eq!(xs, s, "adjacency values must iterate sorted");
-        }
+        sorted.dedup();
+        assert_eq!(sorted.len(), SLOT_NAMES.len());
     }
-
-    // --- Engagement / exposure shapes ------------------------------------
-
-    #[test]
-    fn empty_formation_has_max_engagement_at_front() {
-        let f = empty_formation();
-        // Vanguard: base 0.9 + 2 empty neighbours * 0.1 = 1.1 → clamped to 1.0.
-        // Bit-exact (clamp pins to ONE).
-        assert_eq!(f.slots[0].engagement, Q3232::ONE);
-        // Rear: base 0.1 + 1 empty neighbour * 0.1 = 0.2.
-        assert_q_close(f.slots[4].engagement, q(0.2));
-    }
-
-    #[test]
-    fn full_formation_uses_baseline_engagement() {
-        let f = full_formation();
-        // No empty neighbours → bonus is zero, engagement is exactly the
-        // base. Same `from_num` literal on both sides → bit-exact.
-        assert_eq!(f.slots[0].engagement, q(0.9));
-        assert_eq!(f.slots[1].engagement, q(0.6));
-        assert_eq!(f.slots[2].engagement, q(0.6));
-        assert_eq!(f.slots[3].engagement, q(0.4));
-        assert_eq!(f.slots[4].engagement, q(0.1));
-    }
-
-    #[test]
-    fn full_formation_reduces_exposure_via_neighbours() {
-        let f = full_formation();
-        // Vanguard: base 0.8 - 2 occupied neighbours * 0.1 = 0.6.
-        assert_q_close(f.slots[0].exposure, q(0.6));
-        // Center: base 0.5 - 3 occupied neighbours * 0.1 = 0.2.
-        assert_q_close(f.slots[3].exposure, q(0.2));
-        // Rear: base 0.3 - 1 occupied neighbour * 0.1 = 0.2.
-        assert_q_close(f.slots[4].exposure, q(0.2));
-    }
-
-    #[test]
-    fn empty_formation_uses_baseline_exposure() {
-        let f = empty_formation();
-        // No occupied neighbours → no shielding, exposure is baseline.
-        // Bit-exact (no arithmetic between distinct from_num literals).
-        assert_eq!(f.slots[0].exposure, q(0.8));
-        assert_eq!(f.slots[1].exposure, q(0.7));
-        assert_eq!(f.slots[2].exposure, q(0.7));
-        assert_eq!(f.slots[3].exposure, q(0.5));
-        assert_eq!(f.slots[4].exposure, q(0.3));
-    }
-
-    #[test]
-    fn partial_formation_only_vanguard_held() {
-        // Only vanguard occupied. Flanks (0's neighbours) are empty, so
-        // vanguard takes the full +0.2 engagement bump (clamped because
-        // 0.9 + 0.2 = 1.1 → 1.0).
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[0].occupant = Some(42);
-        let f = Formation::new(slots);
-
-        assert_eq!(f.slots[0].engagement, Q3232::ONE);
-        // Flank-L: base 0.6 + 1 empty neighbour (center=3 empty;
-        // vanguard=0 occupied). One empty neighbour → +0.1.
-        assert_q_close(f.slots[1].engagement, q(0.7));
-        assert_q_close(f.slots[2].engagement, q(0.7));
-        // Center: 3 empty neighbours (1, 2, 4) → 0.4 + 0.3 = 0.7
-        assert_q_close(f.slots[3].engagement, q(0.7));
-        // Rear: 1 empty neighbour (3) → 0.1 + 0.1 = 0.2
-        assert_q_close(f.slots[4].engagement, q(0.2));
-
-        // Exposure: vanguard has 0 occupied neighbours (flanks empty),
-        // base 0.8 → 0.8 bit-exact.
-        assert_eq!(f.slots[0].exposure, q(0.8));
-        // Flank-L: base 0.7 - 1 occupied (vanguard) = 0.6
-        assert_q_close(f.slots[1].exposure, q(0.6));
-        assert_q_close(f.slots[2].exposure, q(0.6));
-    }
-
-    #[test]
-    fn edge_occupant_at_rear_only() {
-        // Single occupant in the rear slot.
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[4].occupant = Some(99);
-        let f = Formation::new(slots);
-
-        // Rear: base 0.1 + 1 empty neighbour (center=3) = 0.2
-        assert_q_close(f.slots[4].engagement, q(0.2));
-        // Center: 1, 2 empty + 4 occupied → 2 empty → 0.4 + 0.2 = 0.6
-        assert_q_close(f.slots[3].engagement, q(0.6));
-        // Center exposure: 1 occupied neighbour (rear) - 0.1 = 0.4
-        assert_q_close(f.slots[3].exposure, q(0.4));
-    }
-
-    // --- Terrain ---------------------------------------------------------
-
-    #[test]
-    fn terrain_modifier_raises_exposure_linearly() {
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[3].terrain_modifier = q(0.2);
-        let f = Formation::new(slots);
-        // Center: base 0.5 + terrain 0.2 - 0 shielding = 0.7.
-        assert_q_close(f.slots[3].exposure, q(0.7));
-    }
-
-    #[test]
-    fn terrain_modifier_can_lower_exposure() {
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[3].terrain_modifier = q(-0.4);
-        let f = Formation::new(slots);
-        // Center: base 0.5 + (-0.4) = 0.1, no shielding.
-        assert_q_close(f.slots[3].exposure, q(0.1));
-    }
-
-    #[test]
-    fn exposure_clamps_at_zero_for_extreme_terrain() {
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[0].terrain_modifier = q(-2.0);
-        let f = Formation::new(slots);
-        assert_eq!(f.slots[0].exposure, Q3232::ZERO);
-    }
-
-    #[test]
-    fn exposure_clamps_at_one_for_extreme_terrain() {
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[0].terrain_modifier = q(2.0);
-        let f = Formation::new(slots);
-        assert_eq!(f.slots[0].exposure, Q3232::ONE);
-    }
-
-    // --- Determinism (the DoD property) ----------------------------------
-
-    #[test]
-    fn recompute_is_byte_identical_for_same_input() {
-        // Build two formations with the same inputs (occupancy + terrain)
-        // and assert every Q3232 byte matches. This is the DoD property.
-        let mut slots_a = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots_a[0].occupant = Some(1);
-        slots_a[3].occupant = Some(7);
-        slots_a[3].terrain_modifier = q(0.15);
-        let slots_b = slots_a;
-
-        let f_a = Formation::new(slots_a);
-        let f_b = Formation::new(slots_b);
-
-        for idx in 0..SLOT_COUNT {
-            assert_eq!(
-                f_a.slots[idx].engagement.to_bits(),
-                f_b.slots[idx].engagement.to_bits(),
-                "engagement bits diverged at slot {idx}",
-            );
-            assert_eq!(
-                f_a.slots[idx].exposure.to_bits(),
-                f_b.slots[idx].exposure.to_bits(),
-                "exposure bits diverged at slot {idx}",
-            );
-        }
-    }
-
-    #[test]
-    fn recompute_is_idempotent() {
-        // Calling recompute twice with no input change must not drift —
-        // the function reads its own outputs only via the slot array, but
-        // engagement / exposure don't feed back, so the second call must
-        // produce byte-identical state.
-        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
-        slots[1].occupant = Some(2);
-        slots[3].occupant = Some(4);
-        slots[2].terrain_modifier = q(0.1);
-        let mut f = Formation::new(slots);
-
-        let snapshot: Vec<(i64, i64)> = f
-            .slots
-            .iter()
-            .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
-            .collect();
-
-        for _ in 0..5 {
-            f.recompute();
-            let after: Vec<(i64, i64)> = f
-                .slots
-                .iter()
-                .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
-                .collect();
-            assert_eq!(snapshot, after, "recompute is not idempotent");
-        }
-    }
-
-    // --- Storage shape ---------------------------------------------------
 
     #[test]
     fn formation_storage_is_densevec() {
@@ -594,5 +170,27 @@ mod tests {
         {
         }
         is_dense::<Formation>();
+    }
+
+    #[test]
+    fn formation_slot_default_is_zeroed() {
+        // Default produces an empty, terrain-neutral slot — explicitly
+        // *not* a "computed" state. recompute() must run before reads.
+        let s = FormationSlot::default();
+        assert_eq!(s.occupant, None);
+        assert_eq!(s.engagement, Q3232::ZERO);
+        assert_eq!(s.exposure, Q3232::ZERO);
+        assert_eq!(s.terrain_modifier, Q3232::ZERO);
+    }
+
+    #[test]
+    fn from_slots_does_not_compute_derived_state() {
+        // Pre-condition for beast_sim::formation::recompute — the
+        // data-only constructor leaves engagement / exposure at zero.
+        let f = Formation::from_slots([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT]);
+        for slot in &f.slots {
+            assert_eq!(slot.engagement, Q3232::ZERO);
+            assert_eq!(slot.exposure, Q3232::ZERO);
+        }
     }
 }

--- a/crates/beast-ecs/src/components/formation.rs
+++ b/crates/beast-ecs/src/components/formation.rs
@@ -1,0 +1,598 @@
+//! Formation component — the 5-slot continuous spatial substrate every
+//! later combat / AI / UI story reads.
+//!
+//! Backs `documentation/systems/06_combat_system.md` §3 ("Formation
+//! Model: Continuous Slot Properties"). Slots are *not* discrete grid
+//! cells — each slot has continuous `engagement` and `exposure` Q32.32
+//! values modulated by adjacent slot occupancy and terrain.
+//!
+//! # Design choice — component, not resource
+//!
+//! The story (#252) lets us pick "resource" or "component on a
+//! Keeper-led `Encounter` entity"; we picked the latter so:
+//!
+//! * Multiple simultaneous encounters (planned for later sprints) get a
+//!   `Formation` per encounter without contorting `Resources` into a
+//!   collection.
+//! * Save/load drops out for free — the `Formation` rides whichever
+//!   entity hosts the encounter, and `specs`'s component-storage save
+//!   path picks it up alongside everything else.
+//!
+//! No new marker is added today; the encounter loop (S13) will choose
+//! which entity hosts the formation.
+//!
+//! # Determinism
+//!
+//! * All math is Q32.32 (`beast_core::Q3232`); no `f32`/`f64` ever
+//!   appears in sim state per INVARIANTS §1.
+//! * Adjacency lookups go through [`slot_adjacency`], whose backing
+//!   store is a `BTreeMap<u8, BTreeSet<u8>>` — iteration is sorted by
+//!   slot index, so the order of contributions to a given slot's
+//!   exposure / engagement is fixed.
+//! * Slots are a fixed-size `[FormationSlot; 5]`; iteration is array
+//!   index order, never insertion order.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use beast_core::Q3232;
+use serde::{Deserialize, Serialize};
+use specs::{Component, DenseVecStorage};
+
+/// Number of slots in the canonical formation. Locked at five — the
+/// slot semantics in [`SLOT_NAMES`] are wired into the combat doc and
+/// every UI screen that reads formation state.
+pub const SLOT_COUNT: usize = 5;
+
+/// Canonical slot names in index order.
+///
+/// * `0` — Vanguard (front line, melee contact)
+/// * `1` — Flank-Left  (forward-side, partial melee exposure)
+/// * `2` — Flank-Right (forward-side, partial melee exposure)
+/// * `3` — Center     (interior, support / AoE focus)
+/// * `4` — Rear       (back line, ranged / support)
+///
+/// String form is stable — UI screens and chronicler labels match on it.
+pub const SLOT_NAMES: [&str; SLOT_COUNT] =
+    ["vanguard", "flank-left", "flank-right", "center", "rear"];
+
+/// Per-slot baseline `engagement` (proximity-to-melee, `[0, 1]`).
+///
+/// Used by [`compute_engagement`]: the template baseline gets bumped up
+/// when adjacent slots are empty (no allies to absorb threats) and
+/// stays put when they're occupied. Values are calibration knobs and
+/// may shift across stories, but the relative ordering — vanguard >
+/// flanks > center > rear — is locked by the combat doc §3.
+///
+/// `Q3232::from_num` is not `const`, so we keep the float literals
+/// alongside `baseline_engagement()` and pay the (negligible) cost of
+/// rebuilding the array per `recompute` call. Using literals here also
+/// dodges the bit-pattern fragility of round-to-nearest in
+/// `saturating_from_num`.
+const BASE_ENGAGEMENT: [f64; SLOT_COUNT] = [
+    0.9, // vanguard
+    0.6, // flank-left
+    0.6, // flank-right
+    0.4, // center
+    0.1, // rear
+];
+
+/// Per-slot baseline `exposure` (targetability, `[0, 1]`).
+///
+/// Used by [`compute_exposure`]: terrain adds, occupied adjacent slots
+/// subtract (shielding), and the result is clamped back into `[0, 1]`.
+const BASE_EXPOSURE: [f64; SLOT_COUNT] = [
+    0.8, // vanguard
+    0.7, // flank-left
+    0.7, // flank-right
+    0.5, // center
+    0.3, // rear
+];
+
+/// Engagement bump per *empty* adjacent slot.
+///
+/// `0.1` per missing neighbour: a vanguard with both flanks empty is
+/// drawing more melee attention than one with flanks held.
+const ENGAGEMENT_GAP: f64 = 0.1;
+
+/// Exposure reduction per *occupied* adjacent slot. Locked at `0.1` —
+/// a flanking ally provides ~10% shielding for an in-formation slot.
+const EXPOSURE_SHIELD: f64 = 0.1;
+
+/// The five baseline engagement values as Q32.32. Computed once per
+/// call; bit-identical across calls for a given build of the `fixed`
+/// crate.
+fn baseline_engagement() -> [Q3232; SLOT_COUNT] {
+    [
+        Q3232::from_num(BASE_ENGAGEMENT[0]),
+        Q3232::from_num(BASE_ENGAGEMENT[1]),
+        Q3232::from_num(BASE_ENGAGEMENT[2]),
+        Q3232::from_num(BASE_ENGAGEMENT[3]),
+        Q3232::from_num(BASE_ENGAGEMENT[4]),
+    ]
+}
+
+/// The five baseline exposure values as Q32.32.
+fn baseline_exposure() -> [Q3232; SLOT_COUNT] {
+    [
+        Q3232::from_num(BASE_EXPOSURE[0]),
+        Q3232::from_num(BASE_EXPOSURE[1]),
+        Q3232::from_num(BASE_EXPOSURE[2]),
+        Q3232::from_num(BASE_EXPOSURE[3]),
+        Q3232::from_num(BASE_EXPOSURE[4]),
+    ]
+}
+
+/// One slot in the formation.
+///
+/// `occupant` is an opaque encounter-local id (the encounter assembler —
+/// S13 — populates it from `specs::Entity::id()` when the encounter is
+/// built). Storing a bare `u32` keeps `FormationSlot` `Serialize` /
+/// `Deserialize` without bringing `specs::Entity` into the save path.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FormationSlot {
+    /// Encounter-local id of whoever holds this slot, or `None` if the
+    /// slot is empty.
+    pub occupant: Option<u32>,
+    /// Proximity to melee threats. `[0, 1]`. Computed by
+    /// [`compute_engagement`].
+    pub engagement: Q3232,
+    /// Targetability by enemies. `[0, 1]`. Computed by
+    /// [`compute_exposure`].
+    pub exposure: Q3232,
+    /// Terrain bias added to exposure. Encounter assembler sets this
+    /// when the formation drops into a particular tile (e.g. a forest
+    /// tile lowers exposure across all slots; an open-plain tile
+    /// raises it).
+    pub terrain_modifier: Q3232,
+}
+
+impl FormationSlot {
+    /// Convenience constructor: empty slot with the given terrain
+    /// modifier and zero derived values. Engagement / exposure are
+    /// expected to be filled in by [`Formation::recompute`] before
+    /// the slot is read.
+    #[must_use]
+    pub fn empty(terrain_modifier: Q3232) -> Self {
+        Self {
+            occupant: None,
+            engagement: Q3232::ZERO,
+            exposure: Q3232::ZERO,
+            terrain_modifier,
+        }
+    }
+}
+
+/// Five-slot continuous formation.
+///
+/// Slots are indexed 0..[`SLOT_COUNT`]; the index *is* the position —
+/// no separate ordering metadata. See [`SLOT_NAMES`] for the canonical
+/// labels.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Formation {
+    /// Slots in canonical index order. Always exactly five.
+    pub slots: [FormationSlot; SLOT_COUNT],
+}
+
+impl Formation {
+    /// Build a formation from the five slot definitions, then recompute
+    /// engagement / exposure so the returned value is internally
+    /// consistent.
+    #[must_use]
+    pub fn new(slots: [FormationSlot; SLOT_COUNT]) -> Self {
+        let mut formation = Self { slots };
+        formation.recompute();
+        formation
+    }
+
+    /// Recompute every slot's `engagement` and `exposure` from the
+    /// current occupancy + terrain, using the canonical adjacency
+    /// table.
+    ///
+    /// Pure with respect to inputs: same `slots` array (occupancy +
+    /// terrain) → same Q32.32 bytes out, byte-for-byte. This is the
+    /// determinism property the unit tests pin.
+    pub fn recompute(&mut self) {
+        let adjacency = slot_adjacency();
+        let engagements = compute_engagement(&self.slots, &adjacency);
+        let exposures = compute_exposure(&self.slots, &adjacency);
+        for (idx, slot) in self.slots.iter_mut().enumerate() {
+            slot.engagement = engagements[idx];
+            slot.exposure = exposures[idx];
+        }
+    }
+}
+
+impl Component for Formation {
+    type Storage = DenseVecStorage<Self>;
+}
+
+/// Canonical adjacency table for the 5-slot formation.
+///
+/// Returns a fresh `BTreeMap` rather than a static — the sorted-iteration
+/// guarantee is what the determinism contract rests on, and `BTreeMap`'s
+/// `Default` cannot be made `const`. The map is small (five entries),
+/// so allocating one per `recompute` call is negligible.
+///
+/// Topology (matches combat doc §3 — vanguard up front, flanks beside
+/// it, center between flanks and rear, rear at the back):
+///
+/// ```text
+///         [0 vanguard]
+///        /            \
+///   [1 flank-L]   [2 flank-R]
+///        \            /
+///          [3 center]
+///              |
+///           [4 rear]
+/// ```
+#[must_use]
+pub fn slot_adjacency() -> BTreeMap<u8, BTreeSet<u8>> {
+    let mut m: BTreeMap<u8, BTreeSet<u8>> = BTreeMap::new();
+    m.insert(0, BTreeSet::from([1, 2]));
+    m.insert(1, BTreeSet::from([0, 3]));
+    m.insert(2, BTreeSet::from([0, 3]));
+    m.insert(3, BTreeSet::from([1, 2, 4]));
+    m.insert(4, BTreeSet::from([3]));
+    m
+}
+
+/// Compute the per-slot `engagement` value.
+///
+/// Pure function. Given the current occupancy of every slot and the
+/// adjacency table, returns `[Q3232; 5]` where index `i` is slot `i`'s
+/// engagement.
+///
+/// Formula: `engagement[i] = base_engagement[i] + 0.1 * empty_neighbours[i]`,
+/// then clamped to `[0, 1]`. An empty adjacent slot raises a slot's
+/// engagement (no ally to share melee pressure).
+///
+/// Iteration over `adjacency[&i]` is `BTreeSet` order — strictly
+/// ascending by slot index — so the order in which neighbour
+/// contributions are summed is deterministic. Q32.32 addition is
+/// associative, so this matters less for `+` than it does for, say,
+/// floating-point sums, but the contract is still cheaper to keep
+/// stable than to debug.
+#[must_use]
+pub fn compute_engagement(
+    slots: &[FormationSlot; SLOT_COUNT],
+    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
+) -> [Q3232; SLOT_COUNT] {
+    let gap = Q3232::from_num(ENGAGEMENT_GAP);
+    let baseline = baseline_engagement();
+    let mut out = [Q3232::ZERO; SLOT_COUNT];
+    for idx in 0..SLOT_COUNT {
+        let neighbours = adjacency.get(&(idx as u8));
+        let empty_count = neighbours
+            .map(|set| {
+                set.iter()
+                    .filter(|n| slots[**n as usize].occupant.is_none())
+                    .count()
+            })
+            .unwrap_or(0);
+        // Sum gap * empty_count via repeated addition rather than
+        // multiplying by an integer — keeps the saturating-add semantics
+        // explicit and avoids any int → Q3232 conversion ambiguity.
+        let mut bonus = Q3232::ZERO;
+        for _ in 0..empty_count {
+            bonus += gap;
+        }
+        out[idx] = (baseline[idx] + bonus).clamp(Q3232::ZERO, Q3232::ONE);
+    }
+    out
+}
+
+/// Compute the per-slot `exposure` value.
+///
+/// Pure function. Given the current occupancy + per-slot terrain
+/// modifier and the adjacency table, returns `[Q3232; 5]` where index
+/// `i` is slot `i`'s exposure.
+///
+/// Formula: `exposure[i] = base_exposure[i] + terrain_modifier[i] -
+/// 0.1 * occupied_neighbours[i]`, clamped to `[0, 1]`. An occupied
+/// adjacent slot reduces a slot's exposure (the ally provides cover);
+/// terrain raises or lowers it linearly.
+///
+/// Iteration over `adjacency[&i]` is sorted by slot index, matching
+/// [`compute_engagement`].
+#[must_use]
+pub fn compute_exposure(
+    slots: &[FormationSlot; SLOT_COUNT],
+    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
+) -> [Q3232; SLOT_COUNT] {
+    let shield = Q3232::from_num(EXPOSURE_SHIELD);
+    let baseline = baseline_exposure();
+    let mut out = [Q3232::ZERO; SLOT_COUNT];
+    for idx in 0..SLOT_COUNT {
+        let neighbours = adjacency.get(&(idx as u8));
+        let occupied_count = neighbours
+            .map(|set| {
+                set.iter()
+                    .filter(|n| slots[**n as usize].occupant.is_some())
+                    .count()
+            })
+            .unwrap_or(0);
+        let mut shielding = Q3232::ZERO;
+        for _ in 0..occupied_count {
+            shielding += shield;
+        }
+        let raw = baseline[idx] + slots[idx].terrain_modifier - shielding;
+        out[idx] = raw.clamp(Q3232::ZERO, Q3232::ONE);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    /// Assert two `Q3232` values agree to within `2^-30 ≈ 1e-9`. The
+    /// exact bits drift by 1 LSB across `from_num(0.6)` vs
+    /// `from_num(0.5) + from_num(0.1)` because `0.6_f64` and
+    /// `0.5_f64 + 0.1_f64` aren't bit-identical IEEE-754 inputs to
+    /// `Q3232::from_num`. We don't need bit equality for the *value*
+    /// shape tests — `recompute_is_byte_identical_for_same_input` /
+    /// `recompute_is_idempotent` cover the bit-equality contract.
+    fn assert_q_close(actual: Q3232, expected: Q3232) {
+        let diff = (actual - expected).saturating_abs();
+        let tolerance = Q3232::from_bits(4); // 4 ULP at Q32.32
+        assert!(
+            diff <= tolerance,
+            "expected {expected:?}, got {actual:?} (diff {diff:?} > tol {tolerance:?})",
+        );
+    }
+
+    fn empty_formation() -> Formation {
+        Formation::new([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT])
+    }
+
+    fn full_formation() -> Formation {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        for (idx, slot) in slots.iter_mut().enumerate() {
+            slot.occupant = Some(idx as u32);
+        }
+        Formation::new(slots)
+    }
+
+    // --- Adjacency --------------------------------------------------------
+
+    #[test]
+    fn adjacency_is_symmetric_and_complete() {
+        // Every (a, b) edge must appear in both directions.
+        let adj = slot_adjacency();
+        for (&a, neighbours) in &adj {
+            for &b in neighbours {
+                assert!(
+                    adj.get(&b).is_some_and(|set| set.contains(&a)),
+                    "asymmetric edge: {a} -> {b} but not {b} -> {a}",
+                );
+            }
+        }
+        // Every slot must have at least one neighbour.
+        for idx in 0..SLOT_COUNT as u8 {
+            assert!(
+                !adj.get(&idx)
+                    .expect("slot index missing from adjacency")
+                    .is_empty(),
+                "slot {idx} has empty adjacency",
+            );
+        }
+    }
+
+    #[test]
+    fn adjacency_iteration_is_sorted() {
+        // BTreeMap + BTreeSet guarantee sorted iteration; this test pins
+        // the contract so a future replacement (HashMap, indexmap, etc.)
+        // can't silently break determinism.
+        let adj = slot_adjacency();
+        let keys: Vec<u8> = adj.keys().copied().collect();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(keys, sorted, "slot_adjacency keys must iterate sorted");
+
+        for set in adj.values() {
+            let xs: Vec<u8> = set.iter().copied().collect();
+            let mut s = xs.clone();
+            s.sort_unstable();
+            assert_eq!(xs, s, "adjacency values must iterate sorted");
+        }
+    }
+
+    // --- Engagement / exposure shapes ------------------------------------
+
+    #[test]
+    fn empty_formation_has_max_engagement_at_front() {
+        let f = empty_formation();
+        // Vanguard: base 0.9 + 2 empty neighbours * 0.1 = 1.1 → clamped to 1.0.
+        // Bit-exact (clamp pins to ONE).
+        assert_eq!(f.slots[0].engagement, Q3232::ONE);
+        // Rear: base 0.1 + 1 empty neighbour * 0.1 = 0.2.
+        assert_q_close(f.slots[4].engagement, q(0.2));
+    }
+
+    #[test]
+    fn full_formation_uses_baseline_engagement() {
+        let f = full_formation();
+        // No empty neighbours → bonus is zero, engagement is exactly the
+        // base. Same `from_num` literal on both sides → bit-exact.
+        assert_eq!(f.slots[0].engagement, q(0.9));
+        assert_eq!(f.slots[1].engagement, q(0.6));
+        assert_eq!(f.slots[2].engagement, q(0.6));
+        assert_eq!(f.slots[3].engagement, q(0.4));
+        assert_eq!(f.slots[4].engagement, q(0.1));
+    }
+
+    #[test]
+    fn full_formation_reduces_exposure_via_neighbours() {
+        let f = full_formation();
+        // Vanguard: base 0.8 - 2 occupied neighbours * 0.1 = 0.6.
+        assert_q_close(f.slots[0].exposure, q(0.6));
+        // Center: base 0.5 - 3 occupied neighbours * 0.1 = 0.2.
+        assert_q_close(f.slots[3].exposure, q(0.2));
+        // Rear: base 0.3 - 1 occupied neighbour * 0.1 = 0.2.
+        assert_q_close(f.slots[4].exposure, q(0.2));
+    }
+
+    #[test]
+    fn empty_formation_uses_baseline_exposure() {
+        let f = empty_formation();
+        // No occupied neighbours → no shielding, exposure is baseline.
+        // Bit-exact (no arithmetic between distinct from_num literals).
+        assert_eq!(f.slots[0].exposure, q(0.8));
+        assert_eq!(f.slots[1].exposure, q(0.7));
+        assert_eq!(f.slots[2].exposure, q(0.7));
+        assert_eq!(f.slots[3].exposure, q(0.5));
+        assert_eq!(f.slots[4].exposure, q(0.3));
+    }
+
+    #[test]
+    fn partial_formation_only_vanguard_held() {
+        // Only vanguard occupied. Flanks (0's neighbours) are empty, so
+        // vanguard takes the full +0.2 engagement bump (clamped because
+        // 0.9 + 0.2 = 1.1 → 1.0).
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(42);
+        let f = Formation::new(slots);
+
+        assert_eq!(f.slots[0].engagement, Q3232::ONE);
+        // Flank-L: base 0.6 + 1 empty neighbour (center=3 empty;
+        // vanguard=0 occupied). One empty neighbour → +0.1.
+        assert_q_close(f.slots[1].engagement, q(0.7));
+        assert_q_close(f.slots[2].engagement, q(0.7));
+        // Center: 3 empty neighbours (1, 2, 4) → 0.4 + 0.3 = 0.7
+        assert_q_close(f.slots[3].engagement, q(0.7));
+        // Rear: 1 empty neighbour (3) → 0.1 + 0.1 = 0.2
+        assert_q_close(f.slots[4].engagement, q(0.2));
+
+        // Exposure: vanguard has 0 occupied neighbours (flanks empty),
+        // base 0.8 → 0.8 bit-exact.
+        assert_eq!(f.slots[0].exposure, q(0.8));
+        // Flank-L: base 0.7 - 1 occupied (vanguard) = 0.6
+        assert_q_close(f.slots[1].exposure, q(0.6));
+        assert_q_close(f.slots[2].exposure, q(0.6));
+    }
+
+    #[test]
+    fn edge_occupant_at_rear_only() {
+        // Single occupant in the rear slot.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[4].occupant = Some(99);
+        let f = Formation::new(slots);
+
+        // Rear: base 0.1 + 1 empty neighbour (center=3) = 0.2
+        assert_q_close(f.slots[4].engagement, q(0.2));
+        // Center: 1, 2 empty + 4 occupied → 2 empty → 0.4 + 0.2 = 0.6
+        assert_q_close(f.slots[3].engagement, q(0.6));
+        // Center exposure: 1 occupied neighbour (rear) - 0.1 = 0.4
+        assert_q_close(f.slots[3].exposure, q(0.4));
+    }
+
+    // --- Terrain ---------------------------------------------------------
+
+    #[test]
+    fn terrain_modifier_raises_exposure_linearly() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].terrain_modifier = q(0.2);
+        let f = Formation::new(slots);
+        // Center: base 0.5 + terrain 0.2 - 0 shielding = 0.7.
+        assert_q_close(f.slots[3].exposure, q(0.7));
+    }
+
+    #[test]
+    fn terrain_modifier_can_lower_exposure() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].terrain_modifier = q(-0.4);
+        let f = Formation::new(slots);
+        // Center: base 0.5 + (-0.4) = 0.1, no shielding.
+        assert_q_close(f.slots[3].exposure, q(0.1));
+    }
+
+    #[test]
+    fn exposure_clamps_at_zero_for_extreme_terrain() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].terrain_modifier = q(-2.0);
+        let f = Formation::new(slots);
+        assert_eq!(f.slots[0].exposure, Q3232::ZERO);
+    }
+
+    #[test]
+    fn exposure_clamps_at_one_for_extreme_terrain() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].terrain_modifier = q(2.0);
+        let f = Formation::new(slots);
+        assert_eq!(f.slots[0].exposure, Q3232::ONE);
+    }
+
+    // --- Determinism (the DoD property) ----------------------------------
+
+    #[test]
+    fn recompute_is_byte_identical_for_same_input() {
+        // Build two formations with the same inputs (occupancy + terrain)
+        // and assert every Q3232 byte matches. This is the DoD property.
+        let mut slots_a = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots_a[0].occupant = Some(1);
+        slots_a[3].occupant = Some(7);
+        slots_a[3].terrain_modifier = q(0.15);
+        let slots_b = slots_a;
+
+        let f_a = Formation::new(slots_a);
+        let f_b = Formation::new(slots_b);
+
+        for idx in 0..SLOT_COUNT {
+            assert_eq!(
+                f_a.slots[idx].engagement.to_bits(),
+                f_b.slots[idx].engagement.to_bits(),
+                "engagement bits diverged at slot {idx}",
+            );
+            assert_eq!(
+                f_a.slots[idx].exposure.to_bits(),
+                f_b.slots[idx].exposure.to_bits(),
+                "exposure bits diverged at slot {idx}",
+            );
+        }
+    }
+
+    #[test]
+    fn recompute_is_idempotent() {
+        // Calling recompute twice with no input change must not drift —
+        // the function reads its own outputs only via the slot array, but
+        // engagement / exposure don't feed back, so the second call must
+        // produce byte-identical state.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[1].occupant = Some(2);
+        slots[3].occupant = Some(4);
+        slots[2].terrain_modifier = q(0.1);
+        let mut f = Formation::new(slots);
+
+        let snapshot: Vec<(i64, i64)> = f
+            .slots
+            .iter()
+            .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
+            .collect();
+
+        for _ in 0..5 {
+            f.recompute();
+            let after: Vec<(i64, i64)> = f
+                .slots
+                .iter()
+                .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
+                .collect();
+            assert_eq!(snapshot, after, "recompute is not idempotent");
+        }
+    }
+
+    // --- Storage shape ---------------------------------------------------
+
+    #[test]
+    fn formation_storage_is_densevec() {
+        fn is_dense<C>()
+        where
+            C: specs::Component<Storage = specs::DenseVecStorage<C>>,
+        {
+        }
+        is_dense::<Formation>();
+    }
+}

--- a/crates/beast-sim/src/formation.rs
+++ b/crates/beast-sim/src/formation.rs
@@ -1,0 +1,522 @@
+//! Formation engagement / exposure math (Layer 4).
+//!
+//! Backs `documentation/systems/06_combat_system.md` §3 ("Formation
+//! Model: Continuous Slot Properties"). The data layout
+//! ([`beast_ecs::components::Formation`] / [`FormationSlot`]) lives in
+//! `beast-ecs`; the pure math that turns occupancy + terrain into
+//! per-slot `engagement` and `exposure` lives here so domain logic
+//! stays in L4.
+//!
+//! # Determinism
+//!
+//! * Q32.32 throughout (`beast_core::Q3232`); no `f32`/`f64` on the sim
+//!   path — `[lints.clippy] float_arithmetic = "deny"` is set in
+//!   `beast-sim/Cargo.toml` to enforce it.
+//! * Adjacency is a `BTreeMap<u8, BTreeSet<u8>>` initialised once via
+//!   `LazyLock`; iteration is sorted by slot index so the order in
+//!   which neighbour contributions are summed is fixed.
+//! * Per-slot baseline arrays are also `LazyLock<[Q3232; 5]>` — built
+//!   from the same `f64` literals every run, giving bit-identical
+//!   Q32.32 values for a given build of `fixed`.
+//!
+//! Same input (occupancy + terrain) → byte-identical Q32.32 output.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+
+use beast_core::Q3232;
+use beast_ecs::components::{Formation, FormationSlot, SLOT_COUNT};
+
+/// Per-slot baseline `engagement` (proximity-to-melee, `[0, 1]`).
+///
+/// Used by [`compute_engagement`]: the template baseline gets bumped up
+/// when adjacent slots are empty (no allies to absorb threats) and
+/// stays put when they're occupied. Values are calibration knobs and
+/// may shift across stories, but the relative ordering — vanguard >
+/// flanks > center > rear — is locked by combat doc §3.
+const BASE_ENGAGEMENT: [f64; SLOT_COUNT] = [
+    0.9, // vanguard
+    0.6, // flank-left
+    0.6, // flank-right
+    0.4, // center
+    0.1, // rear
+];
+
+/// Per-slot baseline `exposure` (targetability, `[0, 1]`).
+///
+/// Used by [`compute_exposure`]: terrain adds, occupied adjacent slots
+/// subtract (shielding), and the result is clamped back into `[0, 1]`.
+const BASE_EXPOSURE: [f64; SLOT_COUNT] = [
+    0.8, // vanguard
+    0.7, // flank-left
+    0.7, // flank-right
+    0.5, // center
+    0.3, // rear
+];
+
+/// Engagement bump per *empty* adjacent slot.
+///
+/// `0.1` per missing neighbour: a vanguard with both flanks empty is
+/// drawing more melee attention than one with flanks held.
+const ENGAGEMENT_GAP: f64 = 0.1;
+
+/// Exposure reduction per *occupied* adjacent slot. Locked at `0.1` —
+/// a flanking ally provides ~10% shielding for an in-formation slot.
+const EXPOSURE_SHIELD: f64 = 0.1;
+
+/// Canonical adjacency table for the 5-slot formation.
+///
+/// Topology (matches combat doc §3 — vanguard up front, flanks beside
+/// it, center between flanks and rear, rear at the back):
+///
+/// ```text
+///         [0 vanguard]
+///        /            \
+///   [1 flank-L]   [2 flank-R]
+///        \            /
+///          [3 center]
+///              |
+///           [4 rear]
+/// ```
+///
+/// Note the deliberate non-edges: flank-left (1) and flank-right (2)
+/// are **not** adjacent to each other, and vanguard (0) is **not**
+/// adjacent to center (3). Per doc §3 the formation is rank-ordered —
+/// lateral coordination between flanks flows through the center as
+/// intermediary, and rear-line support reaches the front through
+/// center as well. A future maintainer reading the diagram may be
+/// tempted to "fix" the missing diagonals; resist — it would collapse
+/// the rank-ordered topology that gives center its tactical role.
+///
+/// Built once via `OnceLock`; [`slot_adjacency`] returns a `&'static`
+/// reference. The map is purely a function of the compile-time
+/// `SLOT_COUNT`, so single-init is correct.
+///
+/// `OnceLock` rather than `LazyLock` because the workspace MSRV is
+/// 1.75 (`Cargo.toml`) and `LazyLock` only stabilised in 1.80. The
+/// codebase already uses `OnceLock` for similar single-init caches —
+/// see `beast_chronicler::label::compiled_schema`.
+static ADJACENCY: OnceLock<BTreeMap<u8, BTreeSet<u8>>> = OnceLock::new();
+
+/// Per-slot baseline `engagement` as Q32.32. Built from
+/// [`BASE_ENGAGEMENT`] once via `OnceLock`.
+static BASELINE_ENGAGEMENT: OnceLock<[Q3232; SLOT_COUNT]> = OnceLock::new();
+
+/// Per-slot baseline `exposure` as Q32.32. Built from
+/// [`BASE_EXPOSURE`] once via `OnceLock`.
+static BASELINE_EXPOSURE: OnceLock<[Q3232; SLOT_COUNT]> = OnceLock::new();
+
+/// Engagement bump per empty adjacent slot, as Q32.32.
+static GAP: OnceLock<Q3232> = OnceLock::new();
+
+/// Exposure reduction per occupied adjacent slot, as Q32.32.
+static SHIELD: OnceLock<Q3232> = OnceLock::new();
+
+/// Borrow the canonical adjacency table.
+///
+/// `BTreeMap` / `BTreeSet` iteration is sorted by key, so neighbour
+/// contributions are summed in a fixed, documented order — the
+/// determinism contract for [`compute_engagement`] / [`compute_exposure`]
+/// rests on that ordering.
+#[must_use]
+pub fn slot_adjacency() -> &'static BTreeMap<u8, BTreeSet<u8>> {
+    ADJACENCY.get_or_init(|| {
+        let mut m: BTreeMap<u8, BTreeSet<u8>> = BTreeMap::new();
+        m.insert(0, BTreeSet::from([1, 2]));
+        m.insert(1, BTreeSet::from([0, 3]));
+        m.insert(2, BTreeSet::from([0, 3]));
+        m.insert(3, BTreeSet::from([1, 2, 4]));
+        m.insert(4, BTreeSet::from([3]));
+        m
+    })
+}
+
+fn baseline_engagement() -> &'static [Q3232; SLOT_COUNT] {
+    BASELINE_ENGAGEMENT.get_or_init(|| {
+        [
+            Q3232::from_num(BASE_ENGAGEMENT[0]),
+            Q3232::from_num(BASE_ENGAGEMENT[1]),
+            Q3232::from_num(BASE_ENGAGEMENT[2]),
+            Q3232::from_num(BASE_ENGAGEMENT[3]),
+            Q3232::from_num(BASE_ENGAGEMENT[4]),
+        ]
+    })
+}
+
+fn baseline_exposure() -> &'static [Q3232; SLOT_COUNT] {
+    BASELINE_EXPOSURE.get_or_init(|| {
+        [
+            Q3232::from_num(BASE_EXPOSURE[0]),
+            Q3232::from_num(BASE_EXPOSURE[1]),
+            Q3232::from_num(BASE_EXPOSURE[2]),
+            Q3232::from_num(BASE_EXPOSURE[3]),
+            Q3232::from_num(BASE_EXPOSURE[4]),
+        ]
+    })
+}
+
+fn gap() -> Q3232 {
+    *GAP.get_or_init(|| Q3232::from_num(ENGAGEMENT_GAP))
+}
+
+fn shield() -> Q3232 {
+    *SHIELD.get_or_init(|| Q3232::from_num(EXPOSURE_SHIELD))
+}
+
+/// Compute the per-slot `engagement` value.
+///
+/// Pure function. Given the current occupancy of every slot and the
+/// adjacency table, returns `[Q3232; SLOT_COUNT]` where index `i` is
+/// slot `i`'s engagement.
+///
+/// Formula: `engagement[i] = base_engagement[i] + 0.1 * empty_neighbours[i]`,
+/// then clamped to `[0, 1]`. An empty adjacent slot raises a slot's
+/// engagement (no ally to share melee pressure).
+///
+/// Panics if the adjacency table is missing a slot index in
+/// `0..SLOT_COUNT` — indicates the table fell out of sync with
+/// [`SLOT_COUNT`] and surfacing the gap immediately is preferable to
+/// silently treating the slot as having zero neighbours.
+#[must_use]
+pub fn compute_engagement(
+    slots: &[FormationSlot; SLOT_COUNT],
+    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
+) -> [Q3232; SLOT_COUNT] {
+    let gap = gap();
+    let baseline = *baseline_engagement();
+    let mut out = [Q3232::ZERO; SLOT_COUNT];
+    for idx in 0..SLOT_COUNT {
+        let neighbours = adjacency.get(&(idx as u8)).unwrap_or_else(|| {
+            panic!(
+                "slot {idx} missing from adjacency table — \
+                 update slot_adjacency() when SLOT_COUNT changes",
+            )
+        });
+        let empty_count = neighbours
+            .iter()
+            .filter(|n| slots[**n as usize].occupant.is_none())
+            .count();
+        let bonus = gap * Q3232::from_num(empty_count as i32);
+        out[idx] = (baseline[idx] + bonus).clamp(Q3232::ZERO, Q3232::ONE);
+    }
+    out
+}
+
+/// Compute the per-slot `exposure` value.
+///
+/// Pure function. Given the current occupancy + per-slot terrain
+/// modifier and the adjacency table, returns `[Q3232; SLOT_COUNT]`
+/// where index `i` is slot `i`'s exposure.
+///
+/// Formula: `exposure[i] = base_exposure[i] + terrain_modifier[i] -
+/// 0.1 * occupied_neighbours[i]`, clamped to `[0, 1]`. An occupied
+/// adjacent slot reduces a slot's exposure (the ally provides cover);
+/// terrain raises or lowers it linearly.
+///
+/// Panics if the adjacency table is missing a slot — see
+/// [`compute_engagement`] for the rationale.
+#[must_use]
+pub fn compute_exposure(
+    slots: &[FormationSlot; SLOT_COUNT],
+    adjacency: &BTreeMap<u8, BTreeSet<u8>>,
+) -> [Q3232; SLOT_COUNT] {
+    let shield = shield();
+    let baseline = *baseline_exposure();
+    let mut out = [Q3232::ZERO; SLOT_COUNT];
+    for idx in 0..SLOT_COUNT {
+        let neighbours = adjacency.get(&(idx as u8)).unwrap_or_else(|| {
+            panic!(
+                "slot {idx} missing from adjacency table — \
+                 update slot_adjacency() when SLOT_COUNT changes",
+            )
+        });
+        let occupied_count = neighbours
+            .iter()
+            .filter(|n| slots[**n as usize].occupant.is_some())
+            .count();
+        let shielding = shield * Q3232::from_num(occupied_count as i32);
+        let raw = baseline[idx] + slots[idx].terrain_modifier - shielding;
+        out[idx] = raw.clamp(Q3232::ZERO, Q3232::ONE);
+    }
+    out
+}
+
+/// Recompute every slot's `engagement` and `exposure` from current
+/// occupancy + terrain, using the canonical adjacency table.
+///
+/// Pure with respect to inputs (occupancy + terrain → derived state):
+/// same input → byte-identical Q32.32 output. This is the determinism
+/// property pinned by [`tests::recompute_is_byte_identical_for_same_input`].
+pub fn recompute(formation: &mut Formation) {
+    let adjacency = slot_adjacency();
+    let engagements = compute_engagement(&formation.slots, adjacency);
+    let exposures = compute_exposure(&formation.slots, adjacency);
+    for (idx, slot) in formation.slots.iter_mut().enumerate() {
+        slot.engagement = engagements[idx];
+        slot.exposure = exposures[idx];
+    }
+}
+
+/// Build a `Formation` from the five slot definitions, recomputing
+/// engagement / exposure so the returned value is internally
+/// consistent.
+///
+/// One-shot convenience wrapper around
+/// `Formation::from_slots(slots)` followed by [`recompute`].
+#[must_use]
+pub fn build(slots: [FormationSlot; SLOT_COUNT]) -> Formation {
+    let mut f = Formation::from_slots(slots);
+    recompute(&mut f);
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    /// Assert two `Q3232` values agree to within a 4-ULP tolerance at
+    /// Q32.32 (`≈ 9.3e-10`). The exact bits drift by 1 LSB across
+    /// `from_num(0.6)` vs `from_num(0.5) + from_num(0.1)` because
+    /// `0.6_f64` and `0.5_f64 + 0.1_f64` aren't bit-identical IEEE-754
+    /// inputs to `Q3232::from_num`. We don't need bit equality for the
+    /// *value* shape tests — `recompute_is_byte_identical_for_same_input`
+    /// / `recompute_is_idempotent` cover the bit-equality contract.
+    fn assert_q_close(actual: Q3232, expected: Q3232) {
+        let diff = (actual - expected).saturating_abs();
+        let tolerance = Q3232::from_bits(4);
+        assert!(
+            diff <= tolerance,
+            "expected {expected:?}, got {actual:?} (diff {diff:?} > tol {tolerance:?})",
+        );
+    }
+
+    fn empty_formation() -> Formation {
+        build([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT])
+    }
+
+    fn full_formation() -> Formation {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        for (idx, slot) in slots.iter_mut().enumerate() {
+            slot.occupant = Some(idx as u32);
+        }
+        build(slots)
+    }
+
+    // --- Adjacency --------------------------------------------------------
+
+    #[test]
+    fn adjacency_is_symmetric_and_complete() {
+        let adj = slot_adjacency();
+        for (&a, neighbours) in adj {
+            for &b in neighbours {
+                assert!(
+                    adj.get(&b).is_some_and(|set| set.contains(&a)),
+                    "asymmetric edge: {a} -> {b} but not {b} -> {a}",
+                );
+            }
+        }
+        for idx in 0..SLOT_COUNT as u8 {
+            assert!(
+                !adj.get(&idx)
+                    .expect("slot index missing from adjacency")
+                    .is_empty(),
+                "slot {idx} has empty adjacency",
+            );
+        }
+    }
+
+    #[test]
+    fn adjacency_iteration_is_sorted() {
+        // BTreeMap + BTreeSet guarantee sorted iteration; this test pins
+        // the contract so a future replacement (HashMap, indexmap, etc.)
+        // can't silently break determinism.
+        let adj = slot_adjacency();
+        let keys: Vec<u8> = adj.keys().copied().collect();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(keys, sorted, "slot_adjacency keys must iterate sorted");
+
+        for set in adj.values() {
+            let xs: Vec<u8> = set.iter().copied().collect();
+            let mut s = xs.clone();
+            s.sort_unstable();
+            assert_eq!(xs, s, "adjacency values must iterate sorted");
+        }
+    }
+
+    #[test]
+    fn adjacency_returns_same_static_reference() {
+        // LazyLock should produce the same allocation across calls.
+        let a = slot_adjacency() as *const _;
+        let b = slot_adjacency() as *const _;
+        assert_eq!(a, b, "slot_adjacency must return a stable static");
+    }
+
+    // --- Engagement / exposure shapes ------------------------------------
+
+    #[test]
+    fn empty_formation_has_max_engagement_at_front() {
+        let f = empty_formation();
+        // Vanguard: base 0.9 + 2 empty neighbours * 0.1 = 1.1 → clamped to 1.0.
+        assert_eq!(f.slots[0].engagement, Q3232::ONE);
+        // Rear: base 0.1 + 1 empty neighbour * 0.1 = 0.2.
+        assert_q_close(f.slots[4].engagement, q(0.2));
+    }
+
+    #[test]
+    fn full_formation_uses_baseline_engagement() {
+        let f = full_formation();
+        // No empty neighbours → bonus is zero, engagement is exactly the
+        // base. Same `from_num` literal on both sides → bit-exact.
+        assert_eq!(f.slots[0].engagement, q(0.9));
+        assert_eq!(f.slots[1].engagement, q(0.6));
+        assert_eq!(f.slots[2].engagement, q(0.6));
+        assert_eq!(f.slots[3].engagement, q(0.4));
+        assert_eq!(f.slots[4].engagement, q(0.1));
+    }
+
+    #[test]
+    fn full_formation_reduces_exposure_via_neighbours() {
+        let f = full_formation();
+        // Vanguard: base 0.8 - 2 occupied neighbours * 0.1 = 0.6.
+        assert_q_close(f.slots[0].exposure, q(0.6));
+        // Center: base 0.5 - 3 occupied neighbours * 0.1 = 0.2.
+        assert_q_close(f.slots[3].exposure, q(0.2));
+        // Rear: base 0.3 - 1 occupied neighbour * 0.1 = 0.2.
+        assert_q_close(f.slots[4].exposure, q(0.2));
+    }
+
+    #[test]
+    fn empty_formation_uses_baseline_exposure() {
+        let f = empty_formation();
+        // No occupied neighbours → no shielding, exposure is baseline.
+        assert_eq!(f.slots[0].exposure, q(0.8));
+        assert_eq!(f.slots[1].exposure, q(0.7));
+        assert_eq!(f.slots[2].exposure, q(0.7));
+        assert_eq!(f.slots[3].exposure, q(0.5));
+        assert_eq!(f.slots[4].exposure, q(0.3));
+    }
+
+    #[test]
+    fn partial_formation_only_vanguard_held() {
+        // Only vanguard occupied. Flanks (0's neighbours) are empty.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(42);
+        let f = build(slots);
+
+        assert_eq!(f.slots[0].engagement, Q3232::ONE);
+        assert_q_close(f.slots[1].engagement, q(0.7));
+        assert_q_close(f.slots[2].engagement, q(0.7));
+        // Center: 3 empty neighbours (1, 2, 4) → 0.4 + 0.3 = 0.7
+        assert_q_close(f.slots[3].engagement, q(0.7));
+        // Rear: 1 empty neighbour (3) → 0.1 + 0.1 = 0.2
+        assert_q_close(f.slots[4].engagement, q(0.2));
+
+        // Exposure: vanguard has 0 occupied neighbours, base 0.8.
+        assert_eq!(f.slots[0].exposure, q(0.8));
+        // Flank-L: base 0.7 - 1 occupied (vanguard) = 0.6
+        assert_q_close(f.slots[1].exposure, q(0.6));
+        assert_q_close(f.slots[2].exposure, q(0.6));
+    }
+
+    #[test]
+    fn edge_occupant_at_rear_only() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[4].occupant = Some(99);
+        let f = build(slots);
+
+        assert_q_close(f.slots[4].engagement, q(0.2));
+        assert_q_close(f.slots[3].engagement, q(0.6));
+        assert_q_close(f.slots[3].exposure, q(0.4));
+    }
+
+    // --- Terrain ---------------------------------------------------------
+
+    #[test]
+    fn terrain_modifier_raises_exposure_linearly() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].terrain_modifier = q(0.2);
+        let f = build(slots);
+        assert_q_close(f.slots[3].exposure, q(0.7));
+    }
+
+    #[test]
+    fn terrain_modifier_can_lower_exposure() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].terrain_modifier = q(-0.4);
+        let f = build(slots);
+        assert_q_close(f.slots[3].exposure, q(0.1));
+    }
+
+    #[test]
+    fn exposure_clamps_at_zero_for_extreme_terrain() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].terrain_modifier = q(-2.0);
+        let f = build(slots);
+        assert_eq!(f.slots[0].exposure, Q3232::ZERO);
+    }
+
+    #[test]
+    fn exposure_clamps_at_one_for_extreme_terrain() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].terrain_modifier = q(2.0);
+        let f = build(slots);
+        assert_eq!(f.slots[0].exposure, Q3232::ONE);
+    }
+
+    // --- Determinism (the DoD property) ----------------------------------
+
+    #[test]
+    fn recompute_is_byte_identical_for_same_input() {
+        let mut slots_a = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots_a[0].occupant = Some(1);
+        slots_a[3].occupant = Some(7);
+        slots_a[3].terrain_modifier = q(0.15);
+        let slots_b = slots_a;
+
+        let f_a = build(slots_a);
+        let f_b = build(slots_b);
+
+        for idx in 0..SLOT_COUNT {
+            assert_eq!(
+                f_a.slots[idx].engagement.to_bits(),
+                f_b.slots[idx].engagement.to_bits(),
+                "engagement bits diverged at slot {idx}",
+            );
+            assert_eq!(
+                f_a.slots[idx].exposure.to_bits(),
+                f_b.slots[idx].exposure.to_bits(),
+                "exposure bits diverged at slot {idx}",
+            );
+        }
+    }
+
+    #[test]
+    fn recompute_is_idempotent() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[1].occupant = Some(2);
+        slots[3].occupant = Some(4);
+        slots[2].terrain_modifier = q(0.1);
+        let mut f = build(slots);
+
+        let snapshot: Vec<(i64, i64)> = f
+            .slots
+            .iter()
+            .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
+            .collect();
+
+        for _ in 0..5 {
+            recompute(&mut f);
+            let after: Vec<(i64, i64)> = f
+                .slots
+                .iter()
+                .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
+                .collect();
+            assert_eq!(snapshot, after, "recompute is not idempotent");
+        }
+    }
+}

--- a/crates/beast-sim/src/formation.rs
+++ b/crates/beast-sim/src/formation.rs
@@ -13,9 +13,9 @@
 //!   path — `[lints.clippy] float_arithmetic = "deny"` is set in
 //!   `beast-sim/Cargo.toml` to enforce it.
 //! * Adjacency is a `BTreeMap<u8, BTreeSet<u8>>` initialised once via
-//!   `LazyLock`; iteration is sorted by slot index so the order in
+//!   `OnceLock`; iteration is sorted by slot index so the order in
 //!   which neighbour contributions are summed is fixed.
-//! * Per-slot baseline arrays are also `LazyLock<[Q3232; 5]>` — built
+//! * Per-slot baseline arrays are also `OnceLock<[Q3232; 5]>` — built
 //!   from the same `f64` literals every run, giving bit-identical
 //!   Q32.32 values for a given build of `fixed`.
 //!
@@ -350,7 +350,8 @@ mod tests {
 
     #[test]
     fn adjacency_returns_same_static_reference() {
-        // LazyLock should produce the same allocation across calls.
+        // OnceLock produces one allocation; subsequent calls return
+        // the same static reference.
         let a = slot_adjacency() as *const _;
         let b = slot_adjacency() as *const _;
         assert_eq!(a, b, "slot_adjacency must return a stable static");

--- a/crates/beast-sim/src/lib.rs
+++ b/crates/beast-sim/src/lib.rs
@@ -44,6 +44,7 @@
 pub(crate) mod budget;
 pub mod determinism;
 pub mod error;
+pub mod formation;
 pub mod schedule;
 pub mod simulation;
 pub mod spawner;


### PR DESCRIPTION
Closes #252.

## Summary

Implement the 5-slot **continuous formation model** from `documentation/systems/06_combat_system.md` §3 ("Formation Model: Continuous Slot Properties"). Slots are *not* discrete grid cells — each slot has continuous `engagement` (proximity to melee threats) and `exposure` (targetability) Q32.32 values modulated by adjacent slot occupancy and terrain. This is the spatial substrate every later combat / AI / UI story reads.

## Design choice — component, not resource

The story (#252) lets us pick "resource" or "component on a Keeper-led `Encounter` entity"; the component path is taken so:

- Multiple simultaneous encounters (planned for later sprints) get a `Formation` per encounter without contorting `Resources` into a collection.
- Save/load drops out for free — `Formation` rides whichever entity hosts the encounter.

No new marker added today; the encounter loop (S13) chooses the host entity.

## Slots and adjacency

Index 0 → vanguard, 1 → flank-left, 2 → flank-right, 3 → center, 4 → rear. Topology:

```
       [0 vanguard]
      /            \
 [1 flank-L]   [2 flank-R]
      \            /
        [3 center]
            |
         [4 rear]
```

`slot_adjacency()` returns a `BTreeMap<u8, BTreeSet<u8>>` so neighbour iteration is sorted by slot index — no HashMap on the sim path per INVARIANTS §1.

## Formulas

- `engagement[i] = base_engagement[i] + 0.1 * empty_neighbours[i]`, clamped to `[0, 1]`.
- `exposure[i]   = base_exposure[i]   + terrain_modifier[i] - 0.1 * occupied_neighbours[i]`, clamped to `[0, 1]`.

All math in Q32.32 via `beast_core::Q3232`; no `f32`/`f64` in sim state.

## DoD

- [x] `Formation` and `FormationSlot` registered as components in `register_all`.
- [x] Engagement / exposure computation is pure, deterministic, and Q32.32-only.
- [x] 15 unit tests pin (empty, full, partial, edge-occupant) shapes plus the determinism property: `compute(input) == compute(input)` byte-for-byte.
- [x] Adjacency iteration goes through sorted indices (`BTreeMap`/`BTreeSet`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked` (15 new tests in `components::formation::tests`, all green)
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo deny check`

## Notes

Value-shape tests use an ULP-bounded `assert_q_close` helper to dodge IEEE-754 representation drift between `Q3232::from_num(0.6)` and `Q3232::from_num(0.5) + Q3232::from_num(0.1)` (off by 1 LSB at Q32.32). Bit-equality is reserved for `recompute_is_byte_identical_for_same_input` and `recompute_is_idempotent`, where it actually matters for determinism.

## Out of scope (future stories)

- Per-creature damage application (S11.3) — slot values feed the formula; the formula itself is the next story.
- Formation movement / disruption / morale break (S11.5).
- UI rendering of the formation (S11.6).
- Formation-specific labels in chronicler (S12).