### PR TITLE
feat(beast-sim): S11.5 formation displacement + ZoC mobility

### DIFF
--- a/crates/beast-sim/src/formation.rs
+++ b/crates/beast-sim/src/formation.rs
@@ -364,6 +364,7 @@ pub struct DisplacementOutcome {
 /// caller (S13 encounter loop) should normalise indices before
 /// invoking; surfacing a hard panic on a stray index would let one
 /// bad command kill the whole encounter.
+#[must_use]
 pub fn apply_displacement(
     formation: &mut Formation,
     source: u8,
@@ -376,8 +377,11 @@ pub fn apply_displacement(
 
     let moved = match kind {
         DisplacementKind::Scatter => apply_scatter(formation),
-        DisplacementKind::Push | DisplacementKind::Pull => {
-            apply_directed_displacement(formation, source, target, kind)
+        DisplacementKind::Push => {
+            apply_directed_displacement(formation, source, target, DirectedKind::Push)
+        }
+        DisplacementKind::Pull => {
+            apply_directed_displacement(formation, source, target, DirectedKind::Pull)
         }
     };
 
@@ -391,11 +395,25 @@ pub fn apply_displacement(
     }
 }
 
+/// Internal-only kind for [`apply_directed_displacement`]. Encodes the
+/// invariant "this helper only handles Push or Pull, never Scatter"
+/// in the type system, eliminating the `unreachable!()` arms that
+/// would otherwise sit inside the picker loop.
+#[derive(Debug, Clone, Copy)]
+enum DirectedKind {
+    Push,
+    Pull,
+}
+
 /// Reverse occupant order in place. Returns `true` if anything
 /// actually moved (false only when the formation is symmetric
 /// already, e.g. all empty or palindromic occupancy).
 fn apply_scatter(formation: &mut Formation) -> bool {
     let mut moved = false;
+    // Integer division floors: SLOT_COUNT == 5 (odd) → `0..2`. Index 2
+    // is intentionally untouched — it is the pivot of the rank-reversal
+    // and stays in place. If SLOT_COUNT becomes even this loop swaps
+    // every pair, which is also correct.
     for i in 0..(SLOT_COUNT / 2) {
         let j = SLOT_COUNT - 1 - i;
         if formation.slots[i].occupant != formation.slots[j].occupant {
@@ -414,13 +432,13 @@ fn apply_directed_displacement(
     formation: &mut Formation,
     source: u8,
     target: u8,
-    kind: DisplacementKind,
+    kind: DirectedKind,
 ) -> bool {
     if source == target || (source as usize) >= SLOT_COUNT || (target as usize) >= SLOT_COUNT {
         return false;
     }
 
-    let distances = slot_distances(source);
+    let distances = slot_distances_table()[source as usize];
     let adjacency = slot_adjacency();
     let neighbours = match adjacency.get(&target) {
         Some(set) => set,
@@ -433,16 +451,14 @@ fn apply_directed_displacement(
     // distance comparison.
     let mut pick: Option<u8> = None;
     let mut pick_dist: i16 = match kind {
-        DisplacementKind::Push => -1, // start below any real distance, so first hit wins
-        DisplacementKind::Pull => i16::MAX,
-        DisplacementKind::Scatter => unreachable!(),
+        DirectedKind::Push => -1, // start below any real distance, so first hit wins
+        DirectedKind::Pull => i16::MAX,
     };
     for &n in neighbours {
         let d = i16::from(distances[n as usize]);
         let take = match kind {
-            DisplacementKind::Push => d > pick_dist,
-            DisplacementKind::Pull => d < pick_dist,
-            DisplacementKind::Scatter => unreachable!(),
+            DirectedKind::Push => d > pick_dist,
+            DirectedKind::Pull => d < pick_dist,
         };
         if take {
             pick = Some(n);
@@ -457,8 +473,33 @@ fn apply_directed_displacement(
     let tmp = formation.slots[target as usize].occupant;
     formation.slots[target as usize].occupant = formation.slots[neighbour as usize].occupant;
     formation.slots[neighbour as usize].occupant = tmp;
-    formation.slots[target as usize].occupant != formation.slots[neighbour as usize].occupant
-        || tmp.is_some()
+    // Pre-swap target ≠ post-swap target ⇒ something moved. Reads
+    // cleanly: `tmp` is the *old* target occupant, the slot now holds
+    // what came from `neighbour`. The two differ exactly when the
+    // swap was non-trivial.
+    tmp != formation.slots[target as usize].occupant
+}
+
+/// Full pairwise BFS distance matrix for the canonical adjacency
+/// graph. Built once via `OnceLock`; [`slot_distances_table`] returns
+/// a `&'static` reference. Removes the per-`Push`/`Pull`-call BFS
+/// allocations (two transient `BTreeSet<u8>`s per wave) — the
+/// adjacency is compile-time constant, so the matrix is too.
+static SLOT_DISTANCES: OnceLock<[[u8; SLOT_COUNT]; SLOT_COUNT]> = OnceLock::new();
+
+/// Borrow the canonical pairwise BFS distance matrix.
+///
+/// `[i][j]` is the BFS distance from slot `i` to slot `j` over
+/// [`slot_adjacency`]. Unreachable pairs would store `u8::MAX`; the
+/// canonical 5-slot graph is connected, so all entries are < 5.
+fn slot_distances_table() -> &'static [[u8; SLOT_COUNT]; SLOT_COUNT] {
+    SLOT_DISTANCES.get_or_init(|| {
+        let mut table = [[u8::MAX; SLOT_COUNT]; SLOT_COUNT];
+        for start in 0..(SLOT_COUNT as u8) {
+            table[start as usize] = slot_distances(start);
+        }
+        table
+    })
 }
 
 /// BFS distances from `start` to every slot in the canonical adjacency.
@@ -466,6 +507,12 @@ fn apply_directed_displacement(
 /// Returns `[u8; SLOT_COUNT]` indexed by slot. Unreachable slots get
 /// `u8::MAX` (cannot occur on the canonical 5-slot graph since it is
 /// connected, but keeps the function total).
+///
+/// This is the underlying single-source BFS. Hot-path callers should
+/// prefer [`slot_distances_table`], which caches the full pairwise
+/// matrix in a `OnceLock`. This single-source variant stays around
+/// because it is the primitive that builds the cache (and is small
+/// enough to keep useful for tests).
 fn slot_distances(start: u8) -> [u8; SLOT_COUNT] {
     let mut dist = [u8::MAX; SLOT_COUNT];
     if (start as usize) >= SLOT_COUNT {
@@ -860,7 +907,7 @@ mod tests {
 
         let snapshot: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
 
-        apply_displacement(
+        let _ = apply_displacement(
             &mut f,
             0,
             4,
@@ -868,7 +915,7 @@ mod tests {
             Q3232::ONE,
             Q3232::ZERO,
         );
-        apply_displacement(
+        let _ = apply_displacement(
             &mut f,
             0,
             4,
@@ -962,7 +1009,7 @@ mod tests {
         let snapshot: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
 
         for _ in 0..2 {
-            apply_displacement(
+            let _ = apply_displacement(
                 &mut f,
                 0,
                 0,
@@ -984,7 +1031,7 @@ mod tests {
         let mut f = build(slots);
 
         let before: usize = f.slots.iter().filter(|s| s.occupant.is_some()).count();
-        apply_displacement(
+        let _ = apply_displacement(
             &mut f,
             0,
             0,
@@ -1063,7 +1110,7 @@ mod tests {
             slots[3].occupant = Some(2);
             slots[3].terrain_modifier = q(0.1);
             let mut f = build(slots);
-            apply_displacement(&mut f, 0, 3, DisplacementKind::Push, Q3232::ONE, q(0.05));
+            let _ = apply_displacement(&mut f, 0, 3, DisplacementKind::Push, Q3232::ONE, q(0.05));
             f
         };
         let a = snapshot_run();

--- a/crates/beast-sim/src/formation.rs
+++ b/crates/beast-sim/src/formation.rs
@@ -270,6 +270,263 @@ pub fn build(slots: [FormationSlot; SLOT_COUNT]) -> Formation {
     f
 }
 
+// =====================================================================
+// S11.5 — Displacement and zone-of-control mobility checks
+// =====================================================================
+
+/// Kind of formation-disrupting displacement to apply.
+///
+/// Backs combat doc §4 ("Mobility & Zone-of-Control Checks") and the
+/// Into-the-Breach displacement-as-tactic inspiration cited in §2 — a
+/// scattered formation is as dangerous as a damaged one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplacementKind {
+    /// Shove the target's occupant *away* from the source — into the
+    /// neighbour of `target` that is **furthest** from `source` in the
+    /// adjacency graph (ties broken by smallest slot index). Occupants
+    /// swap if the destination is held; nothing happens if `target`
+    /// has no neighbours, no occupant, or is the source itself.
+    Push,
+    /// Drag the target's occupant *toward* the source — into the
+    /// neighbour of `target` that is **closest** to `source` (ties
+    /// broken by smallest slot index). Mirrors `Push`.
+    Pull,
+    /// Reverse the slot order: occupant of slot `0` ↔ `4`, `1` ↔ `3`,
+    /// `2` is its own image. Deterministic and self-inverse — applying
+    /// `Scatter` twice returns the original occupancy. `source` and
+    /// `target` are ignored.
+    Scatter,
+}
+
+/// Kind of mobility action a slot's occupant is trying to perform.
+///
+/// Backs combat doc §4: each kind reads the slot's terrain, exposure,
+/// and engagement scalars to compute a deterministic pass/fail.
+/// (The randomised variant — sigmoid-of-mobility-advantage — lands in
+/// a future story alongside the active-inference policy interface.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MobilityKind {
+    /// Move forward into a more-engaged slot. Easier when the
+    /// occupant is already engaged (i.e. close to melee contact) and
+    /// terrain doesn't bog them down.
+    Advance,
+    /// Withdraw to a less-engaged slot. Easier when the occupant is
+    /// not currently in melee and terrain isn't trapping them.
+    Retreat,
+    /// Move laterally. Easier when the slot is not heavily exposed
+    /// (an unexposed slot has cover allowing the swing) and terrain
+    /// is permissive.
+    Flank,
+}
+
+/// Outcome of an [`apply_displacement`] call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisplacementOutcome {
+    /// `true` if any slot's occupant changed as a result of the call.
+    /// `false` for no-op cases (target has no neighbours, source ==
+    /// target, source/target out of range, etc.).
+    pub moved: bool,
+    /// Stamina remaining after the action. Saturating Q32.32
+    /// subtraction floors at `Q3232::ZERO`.
+    pub stamina_remaining: Q3232,
+}
+
+/// Apply a [`DisplacementKind`] to `formation`, deducting `stamina_cost`
+/// from `stamina`.
+///
+/// Pure with respect to its inputs: same `(formation, source, target,
+/// kind, stamina, stamina_cost)` → byte-identical
+/// [`DisplacementOutcome`] and byte-identical mutated `formation`.
+/// No PRNG, no wall-clock — INVARIANTS §1.
+///
+/// # Determinism
+///
+/// * `slot_neighbours_sorted_by` walks `slot_adjacency()` in `BTreeSet`
+///   order (sorted by slot index), so the tie-breaking rule "smallest
+///   index wins" holds without a separate sort.
+/// * BFS distances are computed with a `BTreeSet` frontier, also for
+///   sorted-iteration determinism.
+/// * `recompute` runs at the end so engagement / exposure stay
+///   internally consistent with the new occupancy.
+///
+/// # Stamina
+///
+/// `stamina_cost` is subtracted via `Q3232::saturating_sub`, which
+/// saturates at `I32F32::MIN` (the type is signed). Wrap that in
+/// `.max(Q3232::ZERO)` so a cost greater than current stamina simply
+/// drains to zero rather than underflowing into a negative reserve.
+/// The cost is paid **regardless** of whether the displacement
+/// actually moved anyone — the action was attempted.
+///
+/// # Out-of-range slot indices
+///
+/// Returns a no-op outcome (`moved = false`) without panicking. The
+/// caller (S13 encounter loop) should normalise indices before
+/// invoking; surfacing a hard panic on a stray index would let one
+/// bad command kill the whole encounter.
+pub fn apply_displacement(
+    formation: &mut Formation,
+    source: u8,
+    target: u8,
+    kind: DisplacementKind,
+    stamina: Q3232,
+    stamina_cost: Q3232,
+) -> DisplacementOutcome {
+    let stamina_remaining = stamina.saturating_sub(stamina_cost).max(Q3232::ZERO);
+
+    let moved = match kind {
+        DisplacementKind::Scatter => apply_scatter(formation),
+        DisplacementKind::Push | DisplacementKind::Pull => {
+            apply_directed_displacement(formation, source, target, kind)
+        }
+    };
+
+    if moved {
+        recompute(formation);
+    }
+
+    DisplacementOutcome {
+        moved,
+        stamina_remaining,
+    }
+}
+
+/// Reverse occupant order in place. Returns `true` if anything
+/// actually moved (false only when the formation is symmetric
+/// already, e.g. all empty or palindromic occupancy).
+fn apply_scatter(formation: &mut Formation) -> bool {
+    let mut moved = false;
+    for i in 0..(SLOT_COUNT / 2) {
+        let j = SLOT_COUNT - 1 - i;
+        if formation.slots[i].occupant != formation.slots[j].occupant {
+            moved = true;
+        }
+        let tmp = formation.slots[i].occupant;
+        formation.slots[i].occupant = formation.slots[j].occupant;
+        formation.slots[j].occupant = tmp;
+    }
+    moved
+}
+
+/// Push or Pull: swap target's occupant with one of its neighbours
+/// chosen by distance from source.
+fn apply_directed_displacement(
+    formation: &mut Formation,
+    source: u8,
+    target: u8,
+    kind: DisplacementKind,
+) -> bool {
+    if source == target || (source as usize) >= SLOT_COUNT || (target as usize) >= SLOT_COUNT {
+        return false;
+    }
+
+    let distances = slot_distances(source);
+    let adjacency = slot_adjacency();
+    let neighbours = match adjacency.get(&target) {
+        Some(set) => set,
+        None => return false,
+    };
+
+    // Pick the neighbour by Push/Pull semantics. Iteration over
+    // `BTreeSet` is sorted by slot index, so the "ties broken by
+    // smallest index" rule is implicit when we use `<`/`>` on the
+    // distance comparison.
+    let mut pick: Option<u8> = None;
+    let mut pick_dist: i16 = match kind {
+        DisplacementKind::Push => -1, // start below any real distance, so first hit wins
+        DisplacementKind::Pull => i16::MAX,
+        DisplacementKind::Scatter => unreachable!(),
+    };
+    for &n in neighbours {
+        let d = i16::from(distances[n as usize]);
+        let take = match kind {
+            DisplacementKind::Push => d > pick_dist,
+            DisplacementKind::Pull => d < pick_dist,
+            DisplacementKind::Scatter => unreachable!(),
+        };
+        if take {
+            pick = Some(n);
+            pick_dist = d;
+        }
+    }
+    let Some(neighbour) = pick else {
+        return false; // no neighbours — impossible for the canonical 5-slot graph
+    };
+
+    // Swap occupants; engagement/exposure recomputed by caller.
+    let tmp = formation.slots[target as usize].occupant;
+    formation.slots[target as usize].occupant = formation.slots[neighbour as usize].occupant;
+    formation.slots[neighbour as usize].occupant = tmp;
+    formation.slots[target as usize].occupant != formation.slots[neighbour as usize].occupant
+        || tmp.is_some()
+}
+
+/// BFS distances from `start` to every slot in the canonical adjacency.
+///
+/// Returns `[u8; SLOT_COUNT]` indexed by slot. Unreachable slots get
+/// `u8::MAX` (cannot occur on the canonical 5-slot graph since it is
+/// connected, but keeps the function total).
+fn slot_distances(start: u8) -> [u8; SLOT_COUNT] {
+    let mut dist = [u8::MAX; SLOT_COUNT];
+    if (start as usize) >= SLOT_COUNT {
+        return dist;
+    }
+    dist[start as usize] = 0;
+    // Frontier as BTreeSet so iteration is sorted — keeps BFS layer
+    // exploration deterministic.
+    let mut frontier: BTreeSet<u8> = BTreeSet::new();
+    frontier.insert(start);
+    let adjacency = slot_adjacency();
+    while !frontier.is_empty() {
+        let mut next: BTreeSet<u8> = BTreeSet::new();
+        for &node in &frontier {
+            let Some(neighbours) = adjacency.get(&node) else {
+                continue;
+            };
+            let node_dist = dist[node as usize];
+            for &n in neighbours {
+                if dist[n as usize] == u8::MAX {
+                    dist[n as usize] = node_dist.saturating_add(1);
+                    next.insert(n);
+                }
+            }
+        }
+        frontier = next;
+    }
+    dist
+}
+
+/// Deterministic mobility check for the slot's occupant.
+///
+/// Returns `true` if the action succeeds. The check is a saturating
+/// Q32.32 comparison between an action-specific *bias* (based on the
+/// slot's `engagement` / `exposure`) and the slot's *resistance*
+/// (`terrain_modifier + exposure`):
+///
+/// ```text
+/// resistance = terrain_modifier + exposure         (zone-of-control + ground)
+/// bias = match kind {
+///     Advance  => engagement,                      // already engaged → easier to push forward
+///     Retreat  => 1 - engagement,                  // not in melee   → easier to step back
+///     Flank    => 1 - exposure,                    // covered slot  → easier to slip sideways
+/// }
+/// success = bias > resistance
+/// ```
+///
+/// All scalars are saturating Q3232; out-of-range `engagement` /
+/// `exposure` (the `Formation` keeps both clamped, but defensive
+/// coding here is cheap) cannot wrap into negative bias.
+#[must_use]
+pub fn mobility_check(slot: &FormationSlot, kind: MobilityKind) -> bool {
+    let resistance = slot.terrain_modifier + slot.exposure;
+    let bias = match kind {
+        MobilityKind::Advance => slot.engagement,
+        MobilityKind::Retreat => Q3232::ONE.saturating_sub(slot.engagement),
+        MobilityKind::Flank => Q3232::ONE.saturating_sub(slot.exposure),
+    };
+    bias > resistance
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,6 +775,398 @@ mod tests {
                 .map(|s| (s.engagement.to_bits(), s.exposure.to_bits()))
                 .collect();
             assert_eq!(snapshot, after, "recompute is not idempotent");
+        }
+    }
+
+    // --- BFS distance helper --------------------------------------------
+
+    #[test]
+    fn slot_distances_from_vanguard_match_canonical_topology() {
+        // From slot 0 (vanguard): 1=1, 2=1, 3=2, 4=3.
+        let d = slot_distances(0);
+        assert_eq!(d, [0, 1, 1, 2, 3]);
+    }
+
+    #[test]
+    fn slot_distances_from_rear_match_canonical_topology() {
+        // From slot 4 (rear): 3=1, 1=2, 2=2, 0=3.
+        let d = slot_distances(4);
+        assert_eq!(d, [3, 2, 2, 1, 0]);
+    }
+
+    #[test]
+    fn slot_distances_out_of_range_is_max() {
+        let d = slot_distances(99);
+        assert_eq!(d, [u8::MAX; SLOT_COUNT]);
+    }
+
+    // --- Displacement: Push / Pull --------------------------------------
+
+    #[test]
+    fn push_swaps_target_with_neighbour_furthest_from_source() {
+        // source=0 (vanguard), target=3 (center). 3's neighbours are
+        // {1, 2, 4}; distances from 0 are 1, 1, 3. Furthest is 4.
+        // Push should swap 3 ↔ 4.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].occupant = Some(11);
+        slots[4].occupant = Some(22);
+        let mut f = build(slots);
+
+        let outcome = apply_displacement(
+            &mut f,
+            /* source */ 0,
+            /* target */ 3,
+            DisplacementKind::Push,
+            Q3232::ONE,
+            q(0.1),
+        );
+        assert!(outcome.moved);
+        assert_eq!(f.slots[3].occupant, Some(22));
+        assert_eq!(f.slots[4].occupant, Some(11));
+    }
+
+    #[test]
+    fn pull_swaps_target_with_neighbour_closest_to_source() {
+        // source=0 (vanguard), target=3 (center). Closest neighbour of
+        // 3 to 0 is 1 (or 2) — tie at distance 1, smallest index wins
+        // → 1. Pull should swap 3 ↔ 1.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].occupant = Some(11);
+        slots[1].occupant = Some(22);
+        let mut f = build(slots);
+
+        let outcome = apply_displacement(
+            &mut f,
+            /* source */ 0,
+            /* target */ 3,
+            DisplacementKind::Pull,
+            Q3232::ONE,
+            q(0.1),
+        );
+        assert!(outcome.moved);
+        assert_eq!(f.slots[3].occupant, Some(22));
+        assert_eq!(f.slots[1].occupant, Some(11));
+    }
+
+    #[test]
+    fn push_then_pull_is_identity_for_unique_neighbour() {
+        // Symmetric setup: target=4 (rear) has only one neighbour (3).
+        // Both Push and Pull select that single neighbour, so the two
+        // ops are mutual inverses.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].occupant = Some(11);
+        slots[4].occupant = Some(22);
+        let mut f = build(slots);
+
+        let snapshot: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
+
+        apply_displacement(
+            &mut f,
+            0,
+            4,
+            DisplacementKind::Push,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        apply_displacement(
+            &mut f,
+            0,
+            4,
+            DisplacementKind::Pull,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+
+        let after: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
+        assert_eq!(snapshot, after, "push-then-pull is not identity");
+    }
+
+    #[test]
+    fn push_with_source_equal_target_is_noop() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[3].occupant = Some(11);
+        let mut f = build(slots);
+        let snapshot = f;
+
+        let outcome = apply_displacement(
+            &mut f,
+            3,
+            3,
+            DisplacementKind::Push,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        assert!(!outcome.moved);
+        assert_eq!(f.slots, snapshot.slots);
+    }
+
+    #[test]
+    fn push_with_out_of_range_indices_is_noop() {
+        let mut f = build([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT]);
+        let outcome = apply_displacement(
+            &mut f,
+            99,
+            3,
+            DisplacementKind::Push,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        assert!(!outcome.moved);
+        let outcome = apply_displacement(
+            &mut f,
+            0,
+            99,
+            DisplacementKind::Push,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        assert!(!outcome.moved);
+    }
+
+    // --- Displacement: Scatter -------------------------------------------
+
+    #[test]
+    fn scatter_reverses_occupant_order() {
+        // Occupant in slot 0 ↔ 4, 1 ↔ 3, 2 stays.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(10);
+        slots[1].occupant = Some(20);
+        slots[2].occupant = Some(30);
+        slots[3].occupant = Some(40);
+        slots[4].occupant = Some(50);
+        let mut f = build(slots);
+
+        let outcome = apply_displacement(
+            &mut f,
+            0,
+            0,
+            DisplacementKind::Scatter,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        assert!(outcome.moved);
+        assert_eq!(f.slots[0].occupant, Some(50));
+        assert_eq!(f.slots[1].occupant, Some(40));
+        assert_eq!(f.slots[2].occupant, Some(30));
+        assert_eq!(f.slots[3].occupant, Some(20));
+        assert_eq!(f.slots[4].occupant, Some(10));
+    }
+
+    #[test]
+    fn scatter_twice_is_identity() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(10);
+        slots[1].occupant = Some(20);
+        slots[3].occupant = Some(40);
+        let mut f = build(slots);
+        let snapshot: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
+
+        for _ in 0..2 {
+            apply_displacement(
+                &mut f,
+                0,
+                0,
+                DisplacementKind::Scatter,
+                Q3232::ONE,
+                Q3232::ZERO,
+            );
+        }
+        let after: Vec<Option<u32>> = f.slots.iter().map(|s| s.occupant).collect();
+        assert_eq!(snapshot, after);
+    }
+
+    #[test]
+    fn scatter_preserves_occupant_count() {
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(10);
+        slots[2].occupant = Some(30);
+        slots[4].occupant = Some(50);
+        let mut f = build(slots);
+
+        let before: usize = f.slots.iter().filter(|s| s.occupant.is_some()).count();
+        apply_displacement(
+            &mut f,
+            0,
+            0,
+            DisplacementKind::Scatter,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        let after: usize = f.slots.iter().filter(|s| s.occupant.is_some()).count();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn scatter_on_palindromic_formation_reports_no_movement() {
+        // Slots 0 and 4 hold the same occupant id; slot 2 stays. The
+        // reverse-order swap is a no-op on this configuration.
+        let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+        slots[0].occupant = Some(7);
+        slots[2].occupant = Some(9);
+        slots[4].occupant = Some(7);
+        let mut f = build(slots);
+        let outcome = apply_displacement(
+            &mut f,
+            0,
+            0,
+            DisplacementKind::Scatter,
+            Q3232::ONE,
+            Q3232::ZERO,
+        );
+        assert!(!outcome.moved);
+    }
+
+    // --- Stamina ---------------------------------------------------------
+
+    #[test]
+    fn stamina_drains_by_cost() {
+        let mut f = build([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT]);
+        let outcome =
+            apply_displacement(&mut f, 0, 0, DisplacementKind::Scatter, Q3232::ONE, q(0.3));
+        let diff = (outcome.stamina_remaining - q(0.7)).saturating_abs();
+        assert!(diff <= Q3232::from_bits(4));
+    }
+
+    #[test]
+    fn stamina_floors_at_zero_when_cost_exceeds_balance() {
+        // Cost > stamina: result must be ZERO, never negative.
+        let mut f = build([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT]);
+        let outcome = apply_displacement(&mut f, 0, 0, DisplacementKind::Scatter, q(0.2), q(0.5));
+        assert_eq!(outcome.stamina_remaining, Q3232::ZERO);
+    }
+
+    #[test]
+    fn stamina_charged_even_on_noop_displacement() {
+        // Action attempted = stamina spent, regardless of whether the
+        // formation actually changed.
+        let mut f = build([FormationSlot::empty(Q3232::ZERO); SLOT_COUNT]);
+        let outcome = apply_displacement(
+            &mut f,
+            3,
+            3, // source == target → no-op
+            DisplacementKind::Push,
+            Q3232::ONE,
+            q(0.4),
+        );
+        assert!(!outcome.moved);
+        let diff = (outcome.stamina_remaining - q(0.6)).saturating_abs();
+        assert!(diff <= Q3232::from_bits(4));
+    }
+
+    // --- Determinism ----------------------------------------------------
+
+    #[test]
+    fn apply_displacement_is_deterministic() {
+        let snapshot_run = || {
+            let mut slots = [FormationSlot::empty(Q3232::ZERO); SLOT_COUNT];
+            slots[0].occupant = Some(1);
+            slots[3].occupant = Some(2);
+            slots[3].terrain_modifier = q(0.1);
+            let mut f = build(slots);
+            apply_displacement(&mut f, 0, 3, DisplacementKind::Push, Q3232::ONE, q(0.05));
+            f
+        };
+        let a = snapshot_run();
+        let b = snapshot_run();
+        for idx in 0..SLOT_COUNT {
+            assert_eq!(a.slots[idx].occupant, b.slots[idx].occupant);
+            assert_eq!(
+                a.slots[idx].engagement.to_bits(),
+                b.slots[idx].engagement.to_bits(),
+            );
+            assert_eq!(
+                a.slots[idx].exposure.to_bits(),
+                b.slots[idx].exposure.to_bits(),
+            );
+        }
+    }
+
+    // --- Mobility check --------------------------------------------------
+
+    #[test]
+    fn mobility_advance_succeeds_when_engaged_and_terrain_permissive() {
+        // engagement > resistance(=terrain+exposure) ⇒ true
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.8),
+            exposure: q(0.2),
+            terrain_modifier: q(0.1),
+        };
+        // resistance = 0.3, bias = 0.8 → true
+        assert!(mobility_check(&slot, MobilityKind::Advance));
+    }
+
+    #[test]
+    fn mobility_advance_fails_when_terrain_dominates() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.2),
+            exposure: q(0.5),
+            terrain_modifier: q(0.4),
+        };
+        // resistance = 0.9, bias = 0.2 → false
+        assert!(!mobility_check(&slot, MobilityKind::Advance));
+    }
+
+    #[test]
+    fn mobility_retreat_succeeds_when_disengaged() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.1),
+            exposure: q(0.1),
+            terrain_modifier: q(0.1),
+        };
+        // resistance = 0.2, bias = (1 - 0.1) = 0.9 → true
+        assert!(mobility_check(&slot, MobilityKind::Retreat));
+    }
+
+    #[test]
+    fn mobility_retreat_fails_when_in_melee() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.95),
+            exposure: q(0.1),
+            terrain_modifier: q(0.1),
+        };
+        // resistance = 0.2, bias = (1 - 0.95) = 0.05 → false
+        assert!(!mobility_check(&slot, MobilityKind::Retreat));
+    }
+
+    #[test]
+    fn mobility_flank_succeeds_when_covered() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.5),
+            exposure: q(0.1),
+            terrain_modifier: q(0.1),
+        };
+        // resistance = 0.2, bias = (1 - 0.1) = 0.9 → true
+        assert!(mobility_check(&slot, MobilityKind::Flank));
+    }
+
+    #[test]
+    fn mobility_flank_fails_when_exposed() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.5),
+            exposure: q(0.95),
+            terrain_modifier: q(0.1),
+        };
+        // resistance = 1.05, bias = 0.05 → false
+        assert!(!mobility_check(&slot, MobilityKind::Flank));
+    }
+
+    #[test]
+    fn mobility_check_is_deterministic() {
+        let slot = FormationSlot {
+            occupant: Some(1),
+            engagement: q(0.7),
+            exposure: q(0.3),
+            terrain_modifier: q(0.2),
+        };
+        let first = mobility_check(&slot, MobilityKind::Advance);
+        for _ in 0..1000 {
+            assert_eq!(first, mobility_check(&slot, MobilityKind::Advance));
         }
     }
 }

--- a/crates/beast-sim/src/formation.rs
+++ b/crates/beast-sim/src/formation.rs
@@ -847,6 +847,28 @@ mod tests {
         assert_eq!(d, [u8::MAX; SLOT_COUNT]);
     }
 
+    #[test]
+    fn slot_distances_table_matches_canonical_topology() {
+        // The cached 5×5 matrix is what `Push` / `Pull` actually read on
+        // the hot path; the underlying single-source `slot_distances`
+        // is the cache builder. Pin every row so any future adjacency-
+        // graph change either lands a paired update here or fails fast.
+        let t = slot_distances_table();
+        assert_eq!(t[0], [0, 1, 1, 2, 3]); // vanguard
+        assert_eq!(t[1], [1, 0, 2, 1, 2]); // flank-L
+        assert_eq!(t[2], [1, 2, 0, 1, 2]); // flank-R
+        assert_eq!(t[3], [2, 1, 1, 0, 1]); // center
+        assert_eq!(t[4], [3, 2, 2, 1, 0]); // rear
+    }
+
+    #[test]
+    fn slot_distances_table_is_static() {
+        // OnceLock should produce the same allocation across calls.
+        let a = slot_distances_table() as *const _;
+        let b = slot_distances_table() as *const _;
+        assert_eq!(a, b);
+    }
+
     // --- Displacement: Push / Pull --------------------------------------
 
     #[test]


### PR DESCRIPTION
Closes #255. Stacks on (already-merged) S11.2.

## Summary

Implement formation **disruption** (push, pull, scatter) and **movement constraints** (zone-of-control mobility checks) per `documentation/systems/06_combat_system.md` §4. Disruption is a parallel threat track to damage — Into-the-Breach style (doc §2 inspiration).

## API additions to `beast_sim::formation`

```rust
pub enum DisplacementKind { Push, Pull, Scatter }
pub enum MobilityKind     { Advance, Retreat, Flank }
pub struct DisplacementOutcome { pub moved: bool, pub stamina_remaining: Q3232 }

pub fn apply_displacement(
    formation: &mut Formation,
    source: u8,
    target: u8,
    kind: DisplacementKind,
    stamina: Q3232,
    stamina_cost: Q3232,
) -> DisplacementOutcome;

pub fn mobility_check(slot: &FormationSlot, kind: MobilityKind) -> bool;
```

Pure functions — no PRNG, no wall-clock per INVARIANTS §1. Q32.32 only.

## Push / Pull semantics

- **Push**: swap target's occupant with target's neighbour **furthest** from source (BFS distance via `slot_distances`, ties broken by smallest slot index — `BTreeSet` iteration handles this implicitly).
- **Pull**: same with the **closest** neighbour.
- **Scatter**: reverse occupant order (slot 0 ↔ 4, 1 ↔ 3, 2 stays). Deterministic, self-inverse.

`source == target` and out-of-range indices are no-ops (no panic). Stamina cost is paid even when the displacement does nothing — the action was *attempted*.

## Mobility check

```text
resistance = terrain_modifier + exposure
bias = match kind {
    Advance => engagement,
    Retreat => 1 - engagement,
    Flank   => 1 - exposure,
}
success = bias > resistance
```

Saturating Q32.32; `Q3232::ONE.saturating_sub(...)` cannot wrap into negative bias.

## Stamina handling

`stamina.saturating_sub(stamina_cost).max(Q3232::ZERO)` — Q3232 is signed and `saturating_sub` saturates at `I32F32::MIN`, not zero, so the explicit `.max(ZERO)` is needed to avoid a negative reserve.

## DoD

- [x] Pure `apply_displacement` and `mobility_check` functions.
- [x] Q32.32 only.
- [x] Tests: displacement is reversible (push then pull yields identity for symmetric setups — `push_then_pull_is_identity_for_unique_neighbour`); scatter is sorted-index stable (`scatter_reverses_occupant_order`, `scatter_twice_is_identity`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test plan (23 new tests, all green)

BFS distance helper:
- [x] `slot_distances_from_vanguard_match_canonical_topology` (`[0, 1, 1, 2, 3]`)
- [x] `slot_distances_from_rear_match_canonical_topology` (`[3, 2, 2, 1, 0]`)
- [x] `slot_distances_out_of_range_is_max`

Push / Pull:
- [x] `push_swaps_target_with_neighbour_furthest_from_source`
- [x] `pull_swaps_target_with_neighbour_closest_to_source`
- [x] `push_then_pull_is_identity_for_unique_neighbour` — DoD reversibility property
- [x] `push_with_source_equal_target_is_noop`
- [x] `push_with_out_of_range_indices_is_noop`

Scatter:
- [x] `scatter_reverses_occupant_order`
- [x] `scatter_twice_is_identity`
- [x] `scatter_preserves_occupant_count`
- [x] `scatter_on_palindromic_formation_reports_no_movement`

Stamina:
- [x] `stamina_drains_by_cost`
- [x] `stamina_floors_at_zero_when_cost_exceeds_balance`
- [x] `stamina_charged_even_on_noop_displacement`

Determinism:
- [x] `apply_displacement_is_deterministic` — byte-identical formation after re-run

Mobility check:
- [x] `mobility_advance_succeeds_when_engaged_and_terrain_permissive`
- [x] `mobility_advance_fails_when_terrain_dominates`
- [x] `mobility_retreat_succeeds_when_disengaged`
- [x] `mobility_retreat_fails_when_in_melee`
- [x] `mobility_flank_succeeds_when_covered`
- [x] `mobility_flank_fails_when_exposed`
- [x] `mobility_check_is_deterministic` — 1000 invocations, all identical

Local gate runs:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked`
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo deny check`

## Out of scope (future stories)

- AI deciding to apply displacement — doc 57 active inference, not S11.
- Animations / tweening — UI/render layer, S13.
- Damage from collisions — slot occupants don't collide, the formation is abstract per doc §3.
- Randomised ZoC variant (sigmoid-of-mobility-advantage) — lands alongside the active-inference policy interface.