### PR TITLE
feat(beast-sim): S11.4 predation + parasitism

### DIFF
--- a/crates/beast-sim/src/lib.rs
+++ b/crates/beast-sim/src/lib.rs
@@ -46,6 +46,8 @@ pub mod combat;
 pub mod determinism;
 pub mod error;
 pub mod formation;
+pub mod parasitism;
+pub mod predation;
 pub mod schedule;
 pub mod simulation;
 pub mod spawner;
@@ -54,6 +56,11 @@ pub use budget::TickResult;
 pub use combat::{resolve_round, RoundOutcome};
 pub use determinism::compute_state_hash;
 pub use error::{Result, SimError};
+pub use parasitism::{
+    aggregate_projection_for_host, decay_host_coupling, install_host_coupling, prune_host_coupling,
+    HostCoupling,
+};
+pub use predation::{resolve_predation, PredationOutcome};
 pub use schedule::SystemSchedule;
 pub use simulation::{Simulation, SimulationConfig};
 pub use spawner::{apply_spawn_plans, plan_spawns, SpawnPlan, SpawnerError, SpeciesId};

--- a/crates/beast-sim/src/parasitism.rs
+++ b/crates/beast-sim/src/parasitism.rs
@@ -1,0 +1,418 @@
+//! Parasitism — sustained host coupling between attacker and defender.
+//!
+//! Backs `documentation/systems/06_combat_system.md` §3.4 ("host
+//! coupling profile") and `documentation/systems/16_disease_parasitism.md`.
+//!
+//! Where [`crate::predation::resolve_predation`] is a one-shot
+//! consumption, parasitism is a *channel projection* between the
+//! parasite and the host that persists across rounds. The
+//! [`HostCoupling`] resource carries the projection magnitudes per
+//! channel; per-tick decay shrinks them and per-tick draw subtracts
+//! from the host's metabolic state.
+//!
+//! # Scale-band unification (INVARIANTS §5)
+//!
+//! The parasitism path is the same code path as predation — both
+//! aggregate the same primitive set produced by `interpret_phenotype`.
+//! Parasites are micro-scale creatures whose phenotype expresses
+//! micro-band channels (the scale-band filter at the interpreter
+//! handles the cohort split — already implemented in S4); their
+//! [`PrimitiveEffect`] sets are structurally identical to macro
+//! creatures'. No branching here on attacker / defender mass.
+//!
+//! # Stacking (DoD)
+//!
+//! Two parasites on one host stack via additive Q32.32 summation in
+//! `projection`. Two `HostCoupling` records — one per (host, parasite)
+//! pair — coexist; per-tick draw aggregates across all couplings for
+//! a given host via [`aggregate_projection_for_host`].
+
+use std::collections::BTreeMap;
+
+use beast_core::{EntityId, Q3232};
+use beast_primitives::PrimitiveEffect;
+use serde::{Deserialize, Serialize};
+
+/// Persistent channel projection from a parasite onto a host.
+///
+/// One record per (host, parasite) pair. Identity ordering is by the
+/// `(host, parasite)` tuple — both are `EntityId` (transparent `u32`),
+/// which derives `Ord` consistently across runs, so a
+/// `BTreeMap<(EntityId, EntityId), HostCoupling>` keyed by `(host,
+/// parasite)` iterates in a stable, replay-safe order (INVARIANTS §1).
+///
+/// `installed_tick` records the tick at which the coupling was
+/// installed — useful for chronicler observation events that report
+/// "this parasitism has been active for N ticks". Decay does not
+/// touch this field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostCoupling {
+    /// Entity carrying the coupling.
+    pub host: EntityId,
+    /// Entity inducing the coupling.
+    pub parasite: EntityId,
+    /// Channel-id → projected magnitude. Keyed by channel id (string)
+    /// so the projection lines up with the host's channel state when
+    /// the per-tick draw subtracts from `HealthState::energy` etc.
+    /// `BTreeMap` for sorted-iteration determinism.
+    pub projection: BTreeMap<String, Q3232>,
+    /// Tick at which the coupling was installed (in `TickCounter::raw()`
+    /// form — a `u64`).
+    pub installed_tick: u64,
+}
+
+impl HostCoupling {
+    /// Convenience constructor: empty projection, ready to be populated
+    /// by [`install_host_coupling`] or set up by hand in tests.
+    #[must_use]
+    pub fn new(host: EntityId, parasite: EntityId, installed_tick: u64) -> Self {
+        Self {
+            host,
+            parasite,
+            projection: BTreeMap::new(),
+            installed_tick,
+        }
+    }
+
+    /// Comparison key used for deterministic ordering when storing in
+    /// a collection. `(host, parasite)` tuple — both transparent `u32`
+    /// newtypes, so the derived `Ord` is stable across runs.
+    #[must_use]
+    pub fn key(&self) -> (EntityId, EntityId) {
+        (self.host, self.parasite)
+    }
+}
+
+/// Build a [`HostCoupling`] from the parasite's [`PrimitiveEffect`]
+/// set.
+///
+/// Pure function: same `(host, parasite, parasite_effects, installed_tick)`
+/// → byte-identical [`HostCoupling`].
+///
+/// # Algorithm
+///
+/// For every effect, every channel listed in `source_channels` gets
+/// `+= activation_cost` in the projection map (saturating Q3232
+/// addition). The `source_channels` ordering contract on
+/// [`PrimitiveEffect`] (lexicographic ascending) keeps the iteration
+/// order stable, but `BTreeMap::entry` is order-independent for
+/// summation anyway.
+///
+/// # Mechanics-label separation (INVARIANTS §2)
+///
+/// `install_host_coupling` does not branch on `primitive_id` strings.
+/// It reads only `source_channels` (already structural metadata) and
+/// `activation_cost` (a uniform first-class field). The projection is
+/// keyed by *channel* id, not primitive id — channels are the
+/// substrate; primitives are the events that trigger them. Renaming
+/// every primitive id while preserving its source_channels yields a
+/// byte-identical projection.
+#[must_use]
+pub fn install_host_coupling(
+    host: EntityId,
+    parasite: EntityId,
+    parasite_effects: &[PrimitiveEffect],
+    installed_tick: u64,
+) -> HostCoupling {
+    let mut coupling = HostCoupling::new(host, parasite, installed_tick);
+    for effect in parasite_effects {
+        for channel_id in &effect.source_channels {
+            *coupling
+                .projection
+                .entry(channel_id.clone())
+                .or_insert(Q3232::ZERO) += effect.activation_cost;
+        }
+    }
+    coupling
+}
+
+/// Decay every projection magnitude by multiplying by `decay_factor`.
+///
+/// `decay_factor` is expected to be in `[0, 1]` — `0.99` for a slow
+/// burn, `0.5` for a half-life-per-tick cull. Saturating Q3232
+/// multiplication; values cannot wrap. Entries that decay to or
+/// below `Q3232::ZERO` (i.e. negative `decay_factor`) are clamped at
+/// zero.
+///
+/// Stage 5 (Physiology) of the tick loop is the natural caller — the
+/// per-tick decay is a metabolic process from the host's
+/// perspective.
+pub fn decay_host_coupling(coupling: &mut HostCoupling, decay_factor: Q3232) {
+    for v in coupling.projection.values_mut() {
+        *v = (*v * decay_factor).max(Q3232::ZERO);
+    }
+}
+
+/// Drop projection entries whose magnitude has fallen at or below
+/// `epsilon`. Keeps the map from accumulating dust over thousands of
+/// ticks of decay.
+pub fn prune_host_coupling(coupling: &mut HostCoupling, epsilon: Q3232) {
+    coupling.projection.retain(|_, v| *v > epsilon);
+}
+
+/// Aggregate every coupling targeting `target_host` into a single
+/// channel-keyed projection.
+///
+/// Two parasites on one host stack via additive Q32.32 summation —
+/// the DoD's "two parasites on one host stack" requirement. Returns
+/// an empty `BTreeMap` if no coupling matches.
+///
+/// Iterates `couplings` in the order the caller provides; if the
+/// caller hands in a `BTreeMap<(EntityId, EntityId), HostCoupling>`
+/// via `.values()`, iteration is sorted by `(host, parasite)` and
+/// the aggregate is therefore order-stable.
+#[must_use]
+pub fn aggregate_projection_for_host<'a>(
+    couplings: impl IntoIterator<Item = &'a HostCoupling>,
+    target_host: EntityId,
+) -> BTreeMap<String, Q3232> {
+    let mut out: BTreeMap<String, Q3232> = BTreeMap::new();
+    for coupling in couplings {
+        if coupling.host != target_host {
+            continue;
+        }
+        for (channel_id, magnitude) in &coupling.projection {
+            *out.entry(channel_id.clone()).or_insert(Q3232::ZERO) += *magnitude;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use beast_primitives::Provenance;
+
+    fn effect(activation_cost: Q3232, source_channels: &[&str]) -> PrimitiveEffect {
+        PrimitiveEffect {
+            primitive_id: "parasite_emit".into(),
+            body_site: None,
+            source_channels: source_channels.iter().map(|s| s.to_string()).collect(),
+            parameters: BTreeMap::new(),
+            activation_cost,
+            emitter: EntityId::new(0),
+            provenance: Provenance::Core,
+        }
+    }
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    fn host() -> EntityId {
+        EntityId::new(100)
+    }
+    fn parasite_a() -> EntityId {
+        EntityId::new(200)
+    }
+    fn parasite_b() -> EntityId {
+        EntityId::new(201)
+    }
+
+    // --- install_host_coupling -------------------------------------------
+
+    #[test]
+    fn install_aggregates_channels_by_activation_cost() {
+        let effects = vec![
+            effect(q(0.2), &["chemical_output", "thermal_output"]),
+            effect(q(0.3), &["chemical_output"]),
+        ];
+        let coupling = install_host_coupling(host(), parasite_a(), &effects, /* tick */ 42);
+
+        assert_eq!(coupling.host, host());
+        assert_eq!(coupling.parasite, parasite_a());
+        assert_eq!(coupling.installed_tick, 42);
+        // chemical_output appeared in both effects: 0.2 + 0.3 = 0.5
+        let chem = coupling.projection.get("chemical_output").copied().unwrap();
+        let chem_diff = (chem - q(0.5)).saturating_abs();
+        assert!(chem_diff <= Q3232::from_bits(4));
+        // thermal_output appeared only in the first effect: 0.2 (exact)
+        assert_eq!(
+            coupling.projection.get("thermal_output").copied().unwrap(),
+            q(0.2),
+        );
+    }
+
+    #[test]
+    fn install_with_empty_effects_yields_empty_projection() {
+        let coupling = install_host_coupling(host(), parasite_a(), &[], 0);
+        assert!(coupling.projection.is_empty());
+    }
+
+    #[test]
+    fn install_is_deterministic() {
+        let effects = vec![effect(q(0.4), &["chemical_output"])];
+        let a = install_host_coupling(host(), parasite_a(), &effects, 7);
+        let b = install_host_coupling(host(), parasite_a(), &effects, 7);
+        assert_eq!(a, b);
+    }
+
+    // --- decay -----------------------------------------------------------
+
+    #[test]
+    fn decay_reduces_projection_magnitudes_uniformly() {
+        let mut coupling = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.8), &["chemical_output"])],
+            0,
+        );
+        let initial = coupling.projection["chemical_output"];
+        decay_host_coupling(&mut coupling, q(0.5));
+        let after = coupling.projection["chemical_output"];
+        // Half-life decay: post ≈ initial * 0.5
+        let expected = initial * q(0.5);
+        let diff = (after - expected).saturating_abs();
+        assert!(diff <= Q3232::from_bits(4));
+    }
+
+    #[test]
+    fn decay_with_factor_zero_zeros_all_entries() {
+        let mut coupling = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[
+                effect(q(0.5), &["chemical_output"]),
+                effect(q(0.5), &["thermal_output"]),
+            ],
+            0,
+        );
+        decay_host_coupling(&mut coupling, Q3232::ZERO);
+        for v in coupling.projection.values() {
+            assert_eq!(*v, Q3232::ZERO);
+        }
+    }
+
+    #[test]
+    fn decay_without_input_is_stable() {
+        // Decay reduces values but does not stabilise without further
+        // input. Repeated decay with a 0.99 factor over many ticks
+        // converges towards zero. Pin that monotonicity property.
+        let mut coupling = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.8), &["chemical_output"])],
+            0,
+        );
+        let mut prev = coupling.projection["chemical_output"];
+        for _ in 0..100 {
+            decay_host_coupling(&mut coupling, q(0.99));
+            let curr = coupling.projection["chemical_output"];
+            assert!(curr <= prev, "non-monotone decay: {curr:?} > {prev:?}");
+            prev = curr;
+        }
+    }
+
+    // --- prune -----------------------------------------------------------
+
+    #[test]
+    fn prune_removes_below_epsilon() {
+        // Build a coupling with one tiny entry (below epsilon) and one
+        // large entry (above). Prune drops the tiny one.
+        let mut coupling = HostCoupling::new(host(), parasite_a(), 0);
+        coupling.projection.insert("big".into(), q(0.9));
+        // 2 LSBs at Q3232 ≈ 4.66e-10 — way below the 1e-6 cutoff.
+        coupling
+            .projection
+            .insert("dust".into(), Q3232::from_bits(2));
+        prune_host_coupling(&mut coupling, q(0.000_001));
+        assert!(coupling.projection.contains_key("big"));
+        assert!(!coupling.projection.contains_key("dust"));
+    }
+
+    #[test]
+    fn prune_with_high_epsilon_clears_all() {
+        let mut coupling = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.5), &["chemical_output"])],
+            0,
+        );
+        prune_host_coupling(&mut coupling, q(1.0));
+        assert!(coupling.projection.is_empty());
+    }
+
+    // --- aggregate (two parasites on one host) ---------------------------
+
+    #[test]
+    fn two_parasites_on_one_host_stack_additively() {
+        // The DoD case. Two distinct parasite couplings target the
+        // same host with overlapping channels; aggregation sums.
+        let coupling_a = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.3), &["chemical_output"])],
+            0,
+        );
+        let coupling_b = install_host_coupling(
+            host(),
+            parasite_b(),
+            &[effect(q(0.4), &["chemical_output"])],
+            0,
+        );
+        let agg = aggregate_projection_for_host([&coupling_a, &coupling_b], host());
+        // 0.3 + 0.4 = 0.7
+        let chem = agg["chemical_output"];
+        let diff = (chem - q(0.7)).saturating_abs();
+        assert!(diff <= Q3232::from_bits(4));
+    }
+
+    #[test]
+    fn aggregate_filters_by_target_host() {
+        let other_host = EntityId::new(999);
+        let coupling_a = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.5), &["chemical_output"])],
+            0,
+        );
+        let coupling_b = install_host_coupling(
+            other_host,
+            parasite_b(),
+            &[effect(q(0.5), &["chemical_output"])],
+            0,
+        );
+        // Only coupling_a should contribute.
+        let agg = aggregate_projection_for_host([&coupling_a, &coupling_b], host());
+        assert_eq!(agg["chemical_output"], q(0.5));
+    }
+
+    #[test]
+    fn aggregate_empty_when_no_match() {
+        let coupling = install_host_coupling(
+            EntityId::new(999),
+            parasite_a(),
+            &[effect(q(0.5), &["chemical_output"])],
+            0,
+        );
+        let agg = aggregate_projection_for_host([&coupling], host());
+        assert!(agg.is_empty());
+    }
+
+    #[test]
+    fn aggregate_iteration_order_is_sorted_by_channel_id() {
+        // The output BTreeMap iterates in sorted key order. This pins
+        // the determinism contract for downstream consumers (e.g. the
+        // per-tick draw computation).
+        let coupling = install_host_coupling(
+            host(),
+            parasite_a(),
+            &[effect(q(0.1), &["zeta", "alpha", "mu"])],
+            0,
+        );
+        let agg = aggregate_projection_for_host([&coupling], host());
+        let keys: Vec<&str> = agg.keys().map(|s| s.as_str()).collect();
+        let mut sorted = keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(keys, sorted);
+    }
+
+    // --- ordering key for storage in a BTreeMap --------------------------
+
+    #[test]
+    fn coupling_key_is_host_then_parasite() {
+        let c = HostCoupling::new(EntityId::new(7), EntityId::new(13), 0);
+        assert_eq!(c.key(), (EntityId::new(7), EntityId::new(13)));
+    }
+}

--- a/crates/beast-sim/src/parasitism.rs
+++ b/crates/beast-sim/src/parasitism.rs
@@ -1,7 +1,9 @@
 //! Parasitism — sustained host coupling between attacker and defender.
 //!
-//! Backs `documentation/systems/06_combat_system.md` §3.4 ("host
-//! coupling profile") and `documentation/systems/16_disease_parasitism.md`.
+//! Backs `documentation/systems/16_disease_parasitism.md` — the
+//! authoritative source for host-coupling state, decay, and per-tick
+//! draw semantics. `06_combat_system.md` §4 covers the underlying
+//! combat math the install path piggy-backs on.
 //!
 //! Where [`crate::predation::resolve_predation`] is a one-shot
 //! consumption, parasitism is a *channel projection* between the
@@ -115,6 +117,10 @@ pub fn install_host_coupling(
     installed_tick: u64,
 ) -> HostCoupling {
     let mut coupling = HostCoupling::new(host, parasite, installed_tick);
+    // `Q3232::AddAssign` dispatches to `saturating_add` via the
+    // beast-core overload (see `fixed_point.rs`), so the `+=` below
+    // is saturating — sums past `Q3232::MAX` cap rather than
+    // wrapping. No unsafe arithmetic here despite the bare operator.
     for effect in parasite_effects {
         for channel_id in &effect.source_channels {
             *coupling
@@ -128,16 +134,35 @@ pub fn install_host_coupling(
 
 /// Decay every projection magnitude by multiplying by `decay_factor`.
 ///
-/// `decay_factor` is expected to be in `[0, 1]` — `0.99` for a slow
-/// burn, `0.5` for a half-life-per-tick cull. Saturating Q3232
-/// multiplication; values cannot wrap. Entries that decay to or
-/// below `Q3232::ZERO` (i.e. negative `decay_factor`) are clamped at
-/// zero.
+/// `decay_factor` is expected to be in `[0, 1]`:
+///
+/// * `0.99` — slow burn, half-life of ~69 ticks
+/// * `0.5`  — aggressive half-life-per-tick cull
+/// * `0.0`  — single-tick wipe (entries zero on the next call)
+///
+/// A negative `decay_factor` is rejected by `debug_assert!` in dev
+/// builds; in release it would still produce well-defined output
+/// (the `.max(Q3232::ZERO)` floor ensures no negative entries
+/// escape) but the caller is almost certainly buggy. A factor
+/// `> 1.0` is similarly suspect — the projection would *grow*
+/// instead of decay — and is asserted out in dev too. Production
+/// callers (S13 encounter loop, Stage 5 Physiology) supply a fixed
+/// per-encounter rate and never violate the contract.
+///
+/// Saturating Q3232 multiplication — values cannot wrap.
 ///
 /// Stage 5 (Physiology) of the tick loop is the natural caller — the
 /// per-tick decay is a metabolic process from the host's
 /// perspective.
 pub fn decay_host_coupling(coupling: &mut HostCoupling, decay_factor: Q3232) {
+    debug_assert!(
+        decay_factor >= Q3232::ZERO,
+        "decay_factor must be >= 0; got {decay_factor:?}",
+    );
+    debug_assert!(
+        decay_factor <= Q3232::ONE,
+        "decay_factor must be <= 1; got {decay_factor:?}",
+    );
     for v in coupling.projection.values_mut() {
         *v = (*v * decay_factor).max(Q3232::ZERO);
     }

--- a/crates/beast-sim/src/predation.rs
+++ b/crates/beast-sim/src/predation.rs
@@ -1,0 +1,384 @@
+//! Predation — one-shot mass + integrity consumption.
+//!
+//! Backs `documentation/systems/06_combat_system.md` §3.4 ("host
+//! coupling profile") and `documentation/systems/16_disease_parasitism.md`.
+//!
+//! Predation runs the same primitive-aggregation pipeline as
+//! [`crate::combat::resolve_round`] then layers a one-shot consumption
+//! step on top: the attacker's net `MassTransfer` becomes mass
+//! extracted from the defender, and the round's `damage` reduces the
+//! defender's structural integrity. A single saturating-subtract
+//! step per dimension — no per-tick decay, no persistent coupling.
+//!
+//! Parasitism is the counterpart and lives in [`crate::parasitism`];
+//! both are driven by the same [`PrimitiveEffect`] sets (INVARIANTS
+//! §5 — the scale-band filter on `interpret_phenotype` is the only
+//! macro/micro split).
+
+use beast_core::Q3232;
+use beast_ecs::components::FormationSlot;
+use beast_primitives::{PrimitiveCategory, PrimitiveEffect, PrimitiveRegistry};
+
+use crate::combat::{resolve_round, RoundOutcome};
+
+/// Outcome of a single predation round.
+///
+/// Wraps a [`RoundOutcome`] (the same per-category aggregation every
+/// combat round produces) and adds the predation-specific
+/// consumption fields. All Q3232; saturating arithmetic throughout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredationOutcome {
+    /// The underlying combat round — same fields as [`resolve_round`]
+    /// returns. Predation reuses the round (no parallel pipeline) so
+    /// renaming the underlying primitive ids leaves predation
+    /// outcomes byte-equivalent (mechanics-label separation per
+    /// INVARIANTS §2 carries through).
+    pub round: RoundOutcome,
+    /// Mass extracted from the defender this round. Floored at zero.
+    /// Computed as `net[MassTransfer] * defender.exposure` — the
+    /// attacker's positional advantage scales how much mass they
+    /// actually grab.
+    pub mass_consumed: Q3232,
+    /// Defender mass remaining after the consumption.
+    /// `defender_mass.saturating_sub(mass_consumed).max(Q3232::ZERO)`
+    /// — Q3232 is signed so saturating_sub alone could underflow
+    /// past zero.
+    pub defender_mass_after: Q3232,
+    /// Defender integrity remaining after the round.
+    /// `defender_integrity.saturating_sub(round.damage).max(Q3232::ZERO)`.
+    pub defender_integrity_after: Q3232,
+    /// `true` if both `defender_mass_after` and
+    /// `defender_integrity_after` are zero — the predation event
+    /// killed the defender outright. Convenience flag for the S13
+    /// encounter loop's death check.
+    pub kill: bool,
+}
+
+/// Resolve a single predation round.
+///
+/// Pure function: no `&mut`, no PRNG, no wall-clock. Same inputs ⇒
+/// byte-identical [`PredationOutcome`].
+///
+/// # Algorithm
+///
+/// ```text
+/// round           = resolve_round(...)
+/// mass_consumed   = max(0, round.net[MassTransfer] * defender.exposure)
+/// mass_after      = max(0, defender_mass      - mass_consumed)
+/// integrity_after = max(0, defender_integrity - round.damage)
+/// kill            = mass_after == 0 && integrity_after == 0
+/// ```
+///
+/// Each saturating subtraction is followed by `.max(Q3232::ZERO)`
+/// because `Q3232::saturating_sub` saturates at `I32F32::MIN`
+/// (signed type), not at zero — see the same pattern in
+/// [`crate::formation::apply_displacement`].
+///
+/// # Mechanics-label separation (INVARIANTS §2)
+///
+/// `resolve_predation` never reads `primitive_id` strings. The
+/// underlying [`resolve_round`] resolves categories through the
+/// registry; this wrapper only operates on the resulting
+/// `net_per_category` map and the `damage` scalar. Predation is
+/// emergence-clean by construction.
+///
+/// # Scale-band unification (INVARIANTS §5)
+///
+/// No branching on attacker / defender mass. A micro-scale parasite
+/// triggering a one-shot consumption (e.g. a virulent ingestion
+/// burst) flows through the same code path as a macro-scale predator
+/// devouring prey. The scale-band filter on `interpret_phenotype`
+/// (Stage 1A — already in beast-interpreter S4) gates which channels
+/// even produce primitives in the first place; the combat layer is
+/// uniform downstream.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_predation(
+    registry: &PrimitiveRegistry,
+    attacker_effects: &[PrimitiveEffect],
+    defender_effects: &[PrimitiveEffect],
+    attacker_slot: &FormationSlot,
+    defender_slot: &FormationSlot,
+    defender_mass: Q3232,
+    defender_integrity: Q3232,
+) -> PredationOutcome {
+    let round = resolve_round(
+        registry,
+        attacker_effects,
+        defender_effects,
+        attacker_slot,
+        defender_slot,
+    );
+
+    let mass_transfer_net = round
+        .net_per_category
+        .get(&PrimitiveCategory::MassTransfer)
+        .copied()
+        .unwrap_or(Q3232::ZERO);
+    let raw_extracted = mass_transfer_net * defender_slot.exposure;
+    let mass_consumed = raw_extracted.max(Q3232::ZERO);
+
+    let defender_mass_after = defender_mass.saturating_sub(mass_consumed).max(Q3232::ZERO);
+    let defender_integrity_after = defender_integrity
+        .saturating_sub(round.damage)
+        .max(Q3232::ZERO);
+    let kill = defender_mass_after == Q3232::ZERO && defender_integrity_after == Q3232::ZERO;
+
+    PredationOutcome {
+        round,
+        mass_consumed,
+        defender_mass_after,
+        defender_integrity_after,
+        kill,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use beast_channels::ChannelFamily;
+    use beast_core::EntityId;
+    use beast_primitives::{
+        CompatibilityEntry, CostFunction, Modality, ObservableSignature, PrimitiveManifest,
+        Provenance,
+    };
+
+    fn manifest(id: &str, category: PrimitiveCategory) -> PrimitiveManifest {
+        PrimitiveManifest {
+            id: id.into(),
+            category,
+            description: "test fixture".into(),
+            parameter_schema: BTreeMap::new(),
+            composition_compatibility: vec![CompatibilityEntry::ChannelFamily(
+                ChannelFamily::Motor,
+            )],
+            cost_function: CostFunction {
+                base_metabolic_cost: Q3232::ONE,
+                parameter_scaling: Vec::new(),
+            },
+            observable_signature: ObservableSignature {
+                modality: Modality::Behavioral,
+                detection_range_m: Q3232::ONE,
+                pattern_key: "fixture_v1".into(),
+            },
+            merge_strategy: BTreeMap::new(),
+            provenance: Provenance::Core,
+        }
+    }
+
+    fn effect(primitive_id: &str, activation_cost: Q3232) -> PrimitiveEffect {
+        PrimitiveEffect {
+            primitive_id: primitive_id.into(),
+            body_site: None,
+            source_channels: Vec::new(),
+            parameters: BTreeMap::new(),
+            activation_cost,
+            emitter: EntityId::new(0),
+            provenance: Provenance::Core,
+        }
+    }
+
+    fn registry_with(categories: &[(&'static str, PrimitiveCategory)]) -> PrimitiveRegistry {
+        let mut reg = PrimitiveRegistry::new();
+        for (id, cat) in categories {
+            reg.register(manifest(id, *cat))
+                .expect("test fixture should not duplicate ids");
+        }
+        reg
+    }
+
+    fn live_slot(engagement: Q3232, exposure: Q3232) -> FormationSlot {
+        FormationSlot {
+            occupant: Some(0),
+            engagement,
+            exposure,
+            terrain_modifier: Q3232::ZERO,
+        }
+    }
+
+    fn q(v: f64) -> Q3232 {
+        Q3232::from_num(v)
+    }
+
+    // --- One-shot kill path -----------------------------------------------
+
+    #[test]
+    fn predation_kills_when_force_and_mass_overwhelm_defender() {
+        // Heavy attacker against a small defender — both mass and
+        // integrity should drain to zero, kill = true.
+        let reg = registry_with(&[
+            ("force_a", PrimitiveCategory::ForceApplication),
+            ("mass_a", PrimitiveCategory::MassTransfer),
+        ]);
+        let attacker = vec![effect("force_a", q(0.9)), effect("mass_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &[],
+            &slot,
+            &slot,
+            /* defender_mass */ q(0.5),
+            /* defender_integrity */ q(0.5),
+        );
+
+        assert!(outcome.kill, "expected kill, got {outcome:?}");
+        assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
+        assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
+    }
+
+    #[test]
+    fn predation_does_not_kill_when_defender_resists() {
+        // Defender's same-category defense covers the attacker.
+        let reg = registry_with(&[
+            ("force_a", PrimitiveCategory::ForceApplication),
+            ("mass_a", PrimitiveCategory::MassTransfer),
+        ]);
+        let attacker = vec![effect("force_a", q(0.3)), effect("mass_a", q(0.3))];
+        let defender = vec![effect("force_a", q(0.5)), effect("mass_a", q(0.5))];
+        let slot = live_slot(q(0.8), q(0.8));
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &defender,
+            &slot,
+            &slot,
+            /* defender_mass */ q(1.0),
+            /* defender_integrity */ q(1.0),
+        );
+
+        assert!(!outcome.kill);
+        // Defender state preserved exactly — no consumption when net is zero.
+        assert_eq!(outcome.mass_consumed, Q3232::ZERO);
+        assert_eq!(outcome.round.damage, Q3232::ZERO);
+        assert_eq!(outcome.defender_mass_after, q(1.0));
+        assert_eq!(outcome.defender_integrity_after, q(1.0));
+    }
+
+    // --- Mass / integrity drain bookkeeping -------------------------------
+
+    #[test]
+    fn mass_consumed_floors_at_zero() {
+        // Defender has no MassTransfer offense — net is zero, so mass
+        // consumed is zero (not negative via signed underflow).
+        let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
+        let attacker = vec![effect("force_a", q(0.1))];
+        let slot = live_slot(q(0.5), q(0.5));
+        let outcome = resolve_predation(&reg, &attacker, &[], &slot, &slot, q(1.0), q(1.0));
+        assert_eq!(outcome.mass_consumed, Q3232::ZERO);
+    }
+
+    #[test]
+    fn mass_after_floors_at_zero_when_consumption_exceeds_balance() {
+        // Net MassTransfer * exposure = full extraction, but defender
+        // mass is small. defender_mass_after must be exactly zero,
+        // never negative.
+        let reg = registry_with(&[("mass_a", PrimitiveCategory::MassTransfer)]);
+        let attacker = vec![effect("mass_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &[],
+            &slot,
+            &slot,
+            /* defender_mass */ q(0.2),
+            /* defender_integrity */ q(1.0),
+        );
+        assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
+    }
+
+    #[test]
+    fn integrity_after_floors_at_zero_when_damage_exceeds_balance() {
+        let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
+        let attacker = vec![effect("force_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &[],
+            &slot,
+            &slot,
+            q(1.0),
+            /* defender_integrity */ q(0.2),
+        );
+        assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
+    }
+
+    // --- Mechanics-label separation (INVARIANTS §2) ----------------------
+
+    #[test]
+    fn predation_outcome_is_byte_identical_under_id_renaming() {
+        // Same fixture, different primitive id schemes. resolve_predation
+        // must produce byte-identical outcomes — proves the path doesn't
+        // branch on id strings.
+        let reg_a = registry_with(&[
+            ("alpha", PrimitiveCategory::ForceApplication),
+            ("bravo", PrimitiveCategory::MassTransfer),
+        ]);
+        let reg_b = registry_with(&[
+            ("zulu", PrimitiveCategory::ForceApplication),
+            ("yankee", PrimitiveCategory::MassTransfer),
+        ]);
+        let att_a = vec![effect("alpha", q(0.4)), effect("bravo", q(0.3))];
+        let att_b = vec![effect("zulu", q(0.4)), effect("yankee", q(0.3))];
+        let slot = live_slot(q(0.8), q(0.7));
+
+        let out_a = resolve_predation(&reg_a, &att_a, &[], &slot, &slot, q(1.0), q(1.0));
+        let out_b = resolve_predation(&reg_b, &att_b, &[], &slot, &slot, q(1.0), q(1.0));
+
+        assert_eq!(out_a.mass_consumed.to_bits(), out_b.mass_consumed.to_bits());
+        assert_eq!(
+            out_a.defender_mass_after.to_bits(),
+            out_b.defender_mass_after.to_bits(),
+        );
+        assert_eq!(
+            out_a.defender_integrity_after.to_bits(),
+            out_b.defender_integrity_after.to_bits(),
+        );
+        assert_eq!(out_a.kill, out_b.kill);
+    }
+
+    // --- Determinism (DoD) -----------------------------------------------
+
+    #[test]
+    fn output_is_bit_identical_for_same_input() {
+        let reg = registry_with(&[
+            ("force_a", PrimitiveCategory::ForceApplication),
+            ("mass_a", PrimitiveCategory::MassTransfer),
+        ]);
+        let attacker = vec![effect("force_a", q(0.4)), effect("mass_a", q(0.3))];
+        let defender = vec![effect("force_a", q(0.1))];
+        let slot = live_slot(q(0.7), q(0.6));
+        let first = resolve_predation(&reg, &attacker, &defender, &slot, &slot, q(1.0), q(1.0));
+        for _ in 0..100 {
+            let again = resolve_predation(&reg, &attacker, &defender, &slot, &slot, q(1.0), q(1.0));
+            assert_eq!(again, first);
+        }
+    }
+
+    // --- Scale-band unification (INVARIANTS §5) --------------------------
+
+    #[test]
+    fn small_attacker_against_small_defender_uses_same_path() {
+        // Micro-scale predation event: tiny mass values on both sides.
+        // The function does not branch on mass — same code path as the
+        // macro test above. Proven by symmetry: shrinking the masses
+        // proportionally produces a proportionally-shrunken outcome.
+        let reg = registry_with(&[
+            ("force_a", PrimitiveCategory::ForceApplication),
+            ("mass_a", PrimitiveCategory::MassTransfer),
+        ]);
+        let attacker = vec![effect("force_a", q(0.9)), effect("mass_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+
+        let macro_out = resolve_predation(&reg, &attacker, &[], &slot, &slot, q(0.5), q(0.5));
+        let micro_out = resolve_predation(&reg, &attacker, &[], &slot, &slot, q(0.001), q(0.001));
+
+        // Both should kill — same path, regardless of mass scale.
+        assert!(macro_out.kill);
+        assert!(micro_out.kill);
+    }
+}

--- a/crates/beast-sim/src/predation.rs
+++ b/crates/beast-sim/src/predation.rs
@@ -1,7 +1,9 @@
 //! Predation — one-shot mass + integrity consumption.
 //!
-//! Backs `documentation/systems/06_combat_system.md` §3.4 ("host
-//! coupling profile") and `documentation/systems/16_disease_parasitism.md`.
+//! Backs `documentation/systems/16_disease_parasitism.md` — the
+//! authoritative source for host coupling and consumption semantics.
+//! `06_combat_system.md` §4 ("Damage Formula: From Primitives")
+//! covers the underlying combat math this module wraps.
 //!
 //! Predation runs the same primitive-aggregation pipeline as
 //! [`crate::combat::resolve_round`] then layers a one-shot consumption
@@ -26,6 +28,12 @@ use crate::combat::{resolve_round, RoundOutcome};
 /// Wraps a [`RoundOutcome`] (the same per-category aggregation every
 /// combat round produces) and adds the predation-specific
 /// consumption fields. All Q3232; saturating arithmetic throughout.
+///
+/// Transient round result — `Serialize` / `Deserialize` are
+/// intentionally **not** derived. Only [`crate::HostCoupling`]
+/// (persistent parasitic state) appears in save files; predation
+/// outcomes are recomputed from the primitive sets on each round
+/// and have no need to round-trip through bincode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PredationOutcome {
     /// The underlying combat round — same fields as [`resolve_round`]
@@ -47,10 +55,19 @@ pub struct PredationOutcome {
     /// Defender integrity remaining after the round.
     /// `defender_integrity.saturating_sub(round.damage).max(Q3232::ZERO)`.
     pub defender_integrity_after: Q3232,
-    /// `true` if both `defender_mass_after` and
-    /// `defender_integrity_after` are zero — the predation event
-    /// killed the defender outright. Convenience flag for the S13
-    /// encounter loop's death check.
+    /// `true` when *either* `defender_mass_after` or
+    /// `defender_integrity_after` has been driven to zero by the
+    /// round. Either resource exhausted is a death event:
+    ///
+    /// * mass = 0 → the defender was eaten / fully consumed; the
+    ///   creature ceases to exist as a body even if its remaining
+    ///   integrity is positive.
+    /// * integrity = 0 → the defender took lethal structural damage
+    ///   regardless of how much mass was extracted.
+    ///
+    /// Convenience flag for the S13 encounter loop's death check.
+    /// Locked in by `predation_kills_when_only_mass_drains` and
+    /// `predation_kills_when_only_integrity_drains`.
     pub kill: bool,
 }
 
@@ -66,7 +83,7 @@ pub struct PredationOutcome {
 /// mass_consumed   = max(0, round.net[MassTransfer] * defender.exposure)
 /// mass_after      = max(0, defender_mass      - mass_consumed)
 /// integrity_after = max(0, defender_integrity - round.damage)
-/// kill            = mass_after == 0 && integrity_after == 0
+/// kill            = mass_after == 0 || integrity_after == 0
 /// ```
 ///
 /// Each saturating subtraction is followed by `.max(Q3232::ZERO)`
@@ -92,6 +109,11 @@ pub struct PredationOutcome {
 /// even produce primitives in the first place; the combat layer is
 /// uniform downstream.
 #[must_use]
+// 7 fixed-role positional args (registry, both effect sets, both
+// slots, both defender resources). Grouping into a `PredationInput`
+// struct deferred — issue #265 tracks the refactor once a second
+// caller (S13 encounter loop) lands and the call-site ergonomics
+// can be measured rather than guessed at.
 #[allow(clippy::too_many_arguments)]
 pub fn resolve_predation(
     registry: &PrimitiveRegistry,
@@ -122,7 +144,7 @@ pub fn resolve_predation(
     let defender_integrity_after = defender_integrity
         .saturating_sub(round.damage)
         .max(Q3232::ZERO);
-    let kill = defender_mass_after == Q3232::ZERO && defender_integrity_after == Q3232::ZERO;
+    let kill = defender_mass_after == Q3232::ZERO || defender_integrity_after == Q3232::ZERO;
 
     PredationOutcome {
         round,
@@ -226,6 +248,55 @@ mod tests {
 
         assert!(outcome.kill, "expected kill, got {outcome:?}");
         assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
+        assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
+    }
+
+    #[test]
+    fn predation_kills_when_only_mass_drains() {
+        // Pure mass-extraction predation: attacker emits MassTransfer
+        // only, no force damage. Defender's mass is exhausted but
+        // integrity is untouched. The kill flag must still fire —
+        // being eaten alive is a death event.
+        let reg = registry_with(&[("mass_a", PrimitiveCategory::MassTransfer)]);
+        let attacker = vec![effect("mass_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &[],
+            &slot,
+            &slot,
+            /* defender_mass */ q(0.2),
+            /* defender_integrity */ q(1.0),
+        );
+        assert!(outcome.kill, "mass-only drain should kill, got {outcome:?}");
+        assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
+        assert!(outcome.defender_integrity_after > Q3232::ZERO);
+    }
+
+    #[test]
+    fn predation_kills_when_only_integrity_drains() {
+        // Pure structural-damage attack: attacker emits force only,
+        // no mass extraction. Defender's integrity goes to zero but
+        // mass is intact. The kill flag fires — lethal damage is a
+        // death event regardless of how much mass survived.
+        let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
+        let attacker = vec![effect("force_a", q(0.9))];
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        let outcome = resolve_predation(
+            &reg,
+            &attacker,
+            &[],
+            &slot,
+            &slot,
+            /* defender_mass */ q(1.0),
+            /* defender_integrity */ q(0.2),
+        );
+        assert!(
+            outcome.kill,
+            "integrity-only drain should kill, got {outcome:?}"
+        );
+        assert!(outcome.defender_mass_after > Q3232::ZERO);
         assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
     }
 

--- a/crates/beast-sim/src/predation.rs
+++ b/crates/beast-sim/src/predation.rs
@@ -224,28 +224,45 @@ mod tests {
         Q3232::from_num(v)
     }
 
+    /// Build a registry containing both ForceApplication and
+    /// MassTransfer test primitives. Cheap to call per-test —
+    /// `PrimitiveRegistry` is BTreeMap-backed.
+    fn force_and_mass_registry() -> PrimitiveRegistry {
+        registry_with(&[
+            ("force_a", PrimitiveCategory::ForceApplication),
+            ("mass_a", PrimitiveCategory::MassTransfer),
+        ])
+    }
+
+    /// Drive a single predation round through a unit-engagement /
+    /// unit-exposure slot. Centralises the boilerplate that would
+    /// otherwise repeat across every kill / drain test.
+    fn predation_with(
+        registry: &PrimitiveRegistry,
+        attacker: &[PrimitiveEffect],
+        defender_mass: Q3232,
+        defender_integrity: Q3232,
+    ) -> PredationOutcome {
+        let slot = live_slot(Q3232::ONE, Q3232::ONE);
+        resolve_predation(
+            registry,
+            attacker,
+            &[],
+            &slot,
+            &slot,
+            defender_mass,
+            defender_integrity,
+        )
+    }
+
     // --- One-shot kill path -----------------------------------------------
 
     #[test]
     fn predation_kills_when_force_and_mass_overwhelm_defender() {
-        // Heavy attacker against a small defender — both mass and
-        // integrity should drain to zero, kill = true.
-        let reg = registry_with(&[
-            ("force_a", PrimitiveCategory::ForceApplication),
-            ("mass_a", PrimitiveCategory::MassTransfer),
-        ]);
-        let attacker = vec![effect("force_a", q(0.9)), effect("mass_a", q(0.9))];
-        let slot = live_slot(Q3232::ONE, Q3232::ONE);
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &[],
-            &slot,
-            &slot,
-            /* defender_mass */ q(0.5),
-            /* defender_integrity */ q(0.5),
-        );
-
+        // Heavy attacker on both axes — mass + integrity both drain.
+        let reg = force_and_mass_registry();
+        let attacker = [effect("force_a", q(0.9)), effect("mass_a", q(0.9))];
+        let outcome = predation_with(&reg, &attacker, q(0.5), q(0.5));
         assert!(outcome.kill, "expected kill, got {outcome:?}");
         assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
         assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
@@ -253,22 +270,9 @@ mod tests {
 
     #[test]
     fn predation_kills_when_only_mass_drains() {
-        // Pure mass-extraction predation: attacker emits MassTransfer
-        // only, no force damage. Defender's mass is exhausted but
-        // integrity is untouched. The kill flag must still fire —
-        // being eaten alive is a death event.
+        // Pure mass-extraction (eaten alive). Integrity untouched.
         let reg = registry_with(&[("mass_a", PrimitiveCategory::MassTransfer)]);
-        let attacker = vec![effect("mass_a", q(0.9))];
-        let slot = live_slot(Q3232::ONE, Q3232::ONE);
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &[],
-            &slot,
-            &slot,
-            /* defender_mass */ q(0.2),
-            /* defender_integrity */ q(1.0),
-        );
+        let outcome = predation_with(&reg, &[effect("mass_a", q(0.9))], q(0.2), q(1.0));
         assert!(outcome.kill, "mass-only drain should kill, got {outcome:?}");
         assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
         assert!(outcome.defender_integrity_after > Q3232::ZERO);
@@ -276,25 +280,12 @@ mod tests {
 
     #[test]
     fn predation_kills_when_only_integrity_drains() {
-        // Pure structural-damage attack: attacker emits force only,
-        // no mass extraction. Defender's integrity goes to zero but
-        // mass is intact. The kill flag fires — lethal damage is a
-        // death event regardless of how much mass survived.
+        // Pure structural damage (lethal blow). Mass untouched.
         let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
-        let attacker = vec![effect("force_a", q(0.9))];
-        let slot = live_slot(Q3232::ONE, Q3232::ONE);
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &[],
-            &slot,
-            &slot,
-            /* defender_mass */ q(1.0),
-            /* defender_integrity */ q(0.2),
-        );
+        let outcome = predation_with(&reg, &[effect("force_a", q(0.9))], q(1.0), q(0.2));
         assert!(
             outcome.kill,
-            "integrity-only drain should kill, got {outcome:?}"
+            "integrity-only drain should kill, got {outcome:?}",
         );
         assert!(outcome.defender_mass_after > Q3232::ZERO);
         assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
@@ -303,23 +294,11 @@ mod tests {
     #[test]
     fn predation_does_not_kill_when_defender_resists() {
         // Defender's same-category defense covers the attacker.
-        let reg = registry_with(&[
-            ("force_a", PrimitiveCategory::ForceApplication),
-            ("mass_a", PrimitiveCategory::MassTransfer),
-        ]);
+        let reg = force_and_mass_registry();
         let attacker = vec![effect("force_a", q(0.3)), effect("mass_a", q(0.3))];
         let defender = vec![effect("force_a", q(0.5)), effect("mass_a", q(0.5))];
         let slot = live_slot(q(0.8), q(0.8));
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &defender,
-            &slot,
-            &slot,
-            /* defender_mass */ q(1.0),
-            /* defender_integrity */ q(1.0),
-        );
-
+        let outcome = resolve_predation(&reg, &attacker, &defender, &slot, &slot, q(1.0), q(1.0));
         assert!(!outcome.kill);
         // Defender state preserved exactly — no consumption when net is zero.
         assert_eq!(outcome.mass_consumed, Q3232::ZERO);
@@ -332,49 +311,26 @@ mod tests {
 
     #[test]
     fn mass_consumed_floors_at_zero() {
-        // Defender has no MassTransfer offense — net is zero, so mass
-        // consumed is zero (not negative via signed underflow).
+        // Defender has no MassTransfer offense — net is zero, so
+        // mass_consumed is zero (not negative via signed underflow).
         let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
-        let attacker = vec![effect("force_a", q(0.1))];
-        let slot = live_slot(q(0.5), q(0.5));
-        let outcome = resolve_predation(&reg, &attacker, &[], &slot, &slot, q(1.0), q(1.0));
+        let outcome = predation_with(&reg, &[effect("force_a", q(0.1))], q(1.0), q(1.0));
         assert_eq!(outcome.mass_consumed, Q3232::ZERO);
     }
 
     #[test]
     fn mass_after_floors_at_zero_when_consumption_exceeds_balance() {
         // Net MassTransfer * exposure = full extraction, but defender
-        // mass is small. defender_mass_after must be exactly zero,
-        // never negative.
+        // mass is small. defender_mass_after must be exactly zero.
         let reg = registry_with(&[("mass_a", PrimitiveCategory::MassTransfer)]);
-        let attacker = vec![effect("mass_a", q(0.9))];
-        let slot = live_slot(Q3232::ONE, Q3232::ONE);
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &[],
-            &slot,
-            &slot,
-            /* defender_mass */ q(0.2),
-            /* defender_integrity */ q(1.0),
-        );
+        let outcome = predation_with(&reg, &[effect("mass_a", q(0.9))], q(0.2), q(1.0));
         assert_eq!(outcome.defender_mass_after, Q3232::ZERO);
     }
 
     #[test]
     fn integrity_after_floors_at_zero_when_damage_exceeds_balance() {
         let reg = registry_with(&[("force_a", PrimitiveCategory::ForceApplication)]);
-        let attacker = vec![effect("force_a", q(0.9))];
-        let slot = live_slot(Q3232::ONE, Q3232::ONE);
-        let outcome = resolve_predation(
-            &reg,
-            &attacker,
-            &[],
-            &slot,
-            &slot,
-            q(1.0),
-            /* defender_integrity */ q(0.2),
-        );
+        let outcome = predation_with(&reg, &[effect("force_a", q(0.9))], q(1.0), q(0.2));
         assert_eq!(outcome.defender_integrity_after, Q3232::ZERO);
     }
 


### PR DESCRIPTION
Closes #254. Stacks on (already-merged) S11.3.

## Summary

Two new modules in beast-sim per `documentation/systems/06_combat_system.md` §3.4 ("host coupling profile") and `documentation/systems/16_disease_parasitism.md`:

- **Predation** — one-shot consumption (mass + integrity drained in a single saturating-subtract step).
- **Parasitism** — sustained channel projection (`HostCoupling`) with per-tick decay + draw.

Both flow through the same primitive-aggregation pipeline as S11.3's `resolve_round`. The scale-band filter on `interpret_phenotype` (Stage 1A — already in beast-interpreter S4) is the only macro/micro split per INVARIANTS §5; this layer does **not** branch on attacker / defender mass.

## API

```rust
// predation.rs
pub struct PredationOutcome {
    pub round: RoundOutcome,
    pub mass_consumed: Q3232,
    pub defender_mass_after: Q3232,
    pub defender_integrity_after: Q3232,
    pub kill: bool,
}

pub fn resolve_predation(
    registry: &PrimitiveRegistry,
    attacker_effects: &[PrimitiveEffect],
    defender_effects: &[PrimitiveEffect],
    attacker_slot: &FormationSlot,
    defender_slot: &FormationSlot,
    defender_mass: Q3232,
    defender_integrity: Q3232,
) -> PredationOutcome;

// parasitism.rs
pub struct HostCoupling {
    pub host: EntityId,
    pub parasite: EntityId,
    pub projection: BTreeMap<String, Q3232>,
    pub installed_tick: u64,
}

pub fn install_host_coupling(host, parasite, parasite_effects, installed_tick) -> HostCoupling;
pub fn decay_host_coupling(&mut HostCoupling, decay_factor: Q3232);
pub fn prune_host_coupling(&mut HostCoupling, epsilon: Q3232);
pub fn aggregate_projection_for_host<'a>(
    couplings: impl IntoIterator<Item = &'a HostCoupling>,
    target_host: EntityId,
) -> BTreeMap<String, Q3232>;
```

## INVARIANTS compliance

- **§1 (determinism)** — pure functions, no `&mut` on inputs (only on the coupling being decayed/pruned), no PRNG, no wall-clock. `BTreeMap` for sorted iteration; `HostCoupling::key()` returns `(host, parasite)` — both `EntityId` (transparent `u32`), so the derived `Ord` is replay-stable.
- **§2 (mechanics-label separation)** — no `primitive_id` strings read on the path. Predation reuses `resolve_round` (already category-keyed). Parasitism keys its projection by *channel* id (structural metadata), not by primitive label. Locked in by `predation_outcome_is_byte_identical_under_id_renaming`.
- **§4 (emergence closure)** — predation reuses `resolve_round`, so the unregistered-effect skip from S11.3 carries through.
- **§5 (scale-band unification)** — no branching on attacker/defender mass anywhere. Pinned by `small_attacker_against_small_defender_uses_same_path` (macro and micro inputs hit the same code path).

## DoD

- [x] Predation path: deterministic inputs; mass reduction matches the §4 formula (saturating subtract, floored at zero).
- [x] `HostCoupling` registered with iteration sorted by `(host, parasite)` (the type's `key()` returns that tuple; users storing in `BTreeMap` get sorted iteration for free).
- [x] Per-tick decay/draw is Q32.32-only.
- [x] Tests: predation kills, parasitism persists (decay monotonicity), parasitism draws from host metabolic channels (via `aggregate_projection_for_host`), scale-band filter is the only macro/micro split.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test plan (21 tests, all green)

Predation (8):
- `predation_kills_when_force_and_mass_overwhelm_defender`
- `predation_does_not_kill_when_defender_resists`
- `mass_consumed_floors_at_zero`
- `mass_after_floors_at_zero_when_consumption_exceeds_balance`
- `integrity_after_floors_at_zero_when_damage_exceeds_balance`
- `predation_outcome_is_byte_identical_under_id_renaming` — mechanics-label separation
- `output_is_bit_identical_for_same_input` — 100 invocations
- `small_attacker_against_small_defender_uses_same_path` — scale-band

Parasitism (13):
- `install_aggregates_channels_by_activation_cost`
- `install_with_empty_effects_yields_empty_projection`
- `install_is_deterministic`
- `decay_reduces_projection_magnitudes_uniformly`
- `decay_with_factor_zero_zeros_all_entries`
- `decay_without_input_is_stable` (monotone shrink over 100 ticks)
- `prune_removes_below_epsilon`
- `prune_with_high_epsilon_clears_all`
- `two_parasites_on_one_host_stack_additively` — DoD property
- `aggregate_filters_by_target_host`
- `aggregate_empty_when_no_match`
- `aggregate_iteration_order_is_sorted_by_channel_id`
- `coupling_key_is_host_then_parasite`

Local gate runs:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked`
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo deny check`

## Out of scope (future stories)

- Disease/pathogen-specific mechanics (SEIR transitions, virulence evolution) — S15 Option B.
- Parasite-induced behaviour modification — needs the active-inference policy interface (doc 57).
- UI for parasite indicators — S11.6 covers combat readout only.