### PR TITLE
feat(beast-ui): S11.6 combat readout UI

### DIFF
--- a/crates/beast-ui/Cargo.toml
+++ b/crates/beast-ui/Cargo.toml
@@ -48,6 +48,12 @@ beast-render = { path = "../beast-render", default-features = false }
 # screen can render label / observation summaries without bridging
 # through a sim crate. Chronicler is L4 → ui (L5) is layer-safe.
 beast-chronicler = { workspace = true }
+# S11.6: `screens::data::FormationView::empty` iterates over the
+# canonical `beast_ecs::components::SLOT_NAMES` so the UI's view
+# stays in lockstep with the sim-side slot vocabulary. beast-ecs
+# is L3 → ui (L5) is layer-safe; the dep was already present
+# transitively via `beast-chronicler`.
+beast-ecs = { workspace = true }
 serde = { workspace = true }
 
 # S10.8 (#213) — the bestiary integration test wires the S10 stack
@@ -61,7 +67,8 @@ serde = { workspace = true }
 [dev-dependencies]
 beast-sim = { workspace = true }
 beast-genome = { workspace = true }
-beast-ecs = { workspace = true }
+# beast-ecs is now a production dependency (see above for S11.6
+# rationale); tests still pick it up via the prod entry.
 
 [lints.rust]
 # Forbid `unsafe`. The widget framework is pure data + dispatch; any unsafe

--- a/crates/beast-ui/src/screens/data.rs
+++ b/crates/beast-ui/src/screens/data.rs
@@ -180,12 +180,16 @@ pub struct FormationView {
 }
 
 impl FormationView {
-    /// Construct an empty formation — five empty slots labelled with
-    /// the canonical names. Useful as the encounter-not-yet-built
-    /// placeholder.
+    /// Construct an empty formation — `SLOT_COUNT` empty slots
+    /// labelled with the canonical names from
+    /// [`beast_ecs::components::SLOT_NAMES`]. Sourcing the names
+    /// from the sim layer keeps the UI's view in lockstep with the
+    /// canonical slot vocabulary; if `SLOT_COUNT` ever grows, both
+    /// the sim-side array and this constructor advance together.
     pub fn empty() -> Self {
+        use beast_ecs::components::SLOT_NAMES;
         Self {
-            slots: ["vanguard", "flank-left", "flank-right", "center", "rear"]
+            slots: SLOT_NAMES
                 .iter()
                 .map(|name| FormationSlotView::empty(*name))
                 .collect(),
@@ -363,9 +367,14 @@ mod tests {
     fn empty_snapshot_has_five_canonical_slots() {
         // S11.6 DoD: empty constructor stays panic-safe and seeds the
         // five canonical slots from `beast_ecs::components::SLOT_NAMES`.
+        // Pin every slot label so a typo in any middle entry surfaces
+        // here rather than slipping through.
         let snap = EncounterSnapshot::empty("forest");
         assert_eq!(snap.formation.slots.len(), 5);
         assert_eq!(snap.formation.slots[0].slot_label, "vanguard");
+        assert_eq!(snap.formation.slots[1].slot_label, "flank-left");
+        assert_eq!(snap.formation.slots[2].slot_label, "flank-right");
+        assert_eq!(snap.formation.slots[3].slot_label, "center");
         assert_eq!(snap.formation.slots[4].slot_label, "rear");
         assert_eq!(snap.keeper, KeeperView::empty());
     }

--- a/crates/beast-ui/src/screens/data.rs
+++ b/crates/beast-ui/src/screens/data.rs
@@ -119,6 +119,112 @@ pub struct EncounterCreatureSnapshot {
     pub hp_pct: f32,
 }
 
+/// One slot in a [`FormationView`] — render-only mirror of
+/// `beast_ecs::components::FormationSlot`.
+///
+/// Render-only DTO: must NOT be serialized into save files. The sim
+/// formation slot lives on `Formation`; this view is what the
+/// encounter screen paints. `f32` here is the *display* HP / stamina
+/// fraction — the underlying sim values are Q32.32 (INVARIANTS §1).
+/// `Serialize` / `Deserialize` are intentionally NOT derived.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FormationSlotView {
+    /// Encounter-local id of the occupant, or `None` if the slot is
+    /// empty. Mirrors `FormationSlot::occupant` on the sim side.
+    pub occupant: Option<u32>,
+    /// Display name of the occupant — already resolved to a string
+    /// (e.g. `"alpha"`). Empty when `occupant` is `None`.
+    pub occupant_name: String,
+    /// Slot label (e.g. `"vanguard"`, `"flank-left"`). Stable
+    /// structural identifier from `beast_ecs::components::SLOT_NAMES`;
+    /// the UI is free to localise it, but the encounter screen uses
+    /// the canonical form.
+    pub slot_label: String,
+    /// Hit-point fraction in `[0, 1]`. Out-of-range values are
+    /// clamped at the rendering layer.
+    pub hp_pct: f32,
+    /// Stamina fraction in `[0, 1]`.
+    pub stamina_pct: f32,
+    /// Engagement (`Q3232` upstream, normalised to `[0, 1]` here).
+    pub engagement_pct: f32,
+    /// Exposure, normalised likewise.
+    pub exposure_pct: f32,
+}
+
+impl FormationSlotView {
+    /// Empty slot at `slot_label` — no occupant, all bars at zero.
+    pub fn empty(slot_label: impl Into<String>) -> Self {
+        Self {
+            occupant: None,
+            occupant_name: String::new(),
+            slot_label: slot_label.into(),
+            hp_pct: 0.0,
+            stamina_pct: 0.0,
+            engagement_pct: 0.0,
+            exposure_pct: 0.0,
+        }
+    }
+}
+
+/// Read-only formation view — five slots, one per
+/// `beast_ecs::components::SLOT_COUNT` position. The encounter screen
+/// reads this; the encounter loop (S13) constructs it from the sim
+/// `Formation` component before painting a frame.
+///
+/// Render-only DTO. See [`FormationSlotView`] for the per-slot fields.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FormationView {
+    /// Slots in canonical index order: 0 = vanguard, 1 = flank-left,
+    /// 2 = flank-right, 3 = center, 4 = rear.
+    pub slots: Vec<FormationSlotView>,
+}
+
+impl FormationView {
+    /// Construct an empty formation — five empty slots labelled with
+    /// the canonical names. Useful as the encounter-not-yet-built
+    /// placeholder.
+    pub fn empty() -> Self {
+        Self {
+            slots: ["vanguard", "flank-left", "flank-right", "center", "rear"]
+                .iter()
+                .map(|name| FormationSlotView::empty(*name))
+                .collect(),
+        }
+    }
+}
+
+/// Read-only Keeper view — what the encounter screen reads when
+/// painting the leadership-budget bar.
+///
+/// `f32` percentages here mirror `beast_ecs::components::KeeperState`
+/// fields (`Q3232` on the sim side) normalised for display. The
+/// encounter loop (S13) computes `leadership_pct` from
+/// `leadership_presence(&KeeperState)` divided by the per-Keeper
+/// maximum; this DTO carries the already-normalised value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct KeeperView {
+    /// Display name of the Keeper. Empty for a not-yet-named Keeper.
+    pub name: String,
+    /// Leadership presence as a fraction of the per-Keeper max,
+    /// `[0, 1]`. The encounter screen renders this as a horizontal
+    /// bar in the screen frame.
+    pub leadership_pct: f32,
+    /// Stress fraction `[0, 1]` — surfaced as a small inline indicator
+    /// alongside the leadership bar.
+    pub stress_pct: f32,
+}
+
+impl KeeperView {
+    /// Empty placeholder: no name, both bars at zero.
+    pub fn empty() -> Self {
+        Self {
+            name: String::new(),
+            leadership_pct: 0.0,
+            stress_pct: 0.0,
+        }
+    }
+}
+
 /// Read-only snapshot of an active encounter — what the encounter
 /// renderer + creature list / action bar need to paint a frame.
 ///
@@ -136,15 +242,28 @@ pub struct EncounterSnapshot {
     /// `Some`; out-of-range values are treated as `None` by the
     /// screen builder.
     pub selected: Option<usize>,
+    /// UI-derived view of the sim `Formation` — one entry per slot.
+    /// The encounter screen renders this as a row of slot cards
+    /// (engagement / exposure / hp / stamina + ability labels from
+    /// the chronicler).
+    pub formation: FormationView,
+    /// UI-derived view of the Keeper's state. The screen renders
+    /// `leadership_pct` as a horizontal bar in the frame.
+    pub keeper: KeeperView,
 }
 
 impl EncounterSnapshot {
-    /// Construct an empty snapshot — no creatures, no selection.
+    /// Construct an empty snapshot — no creatures, no selection,
+    /// empty formation, empty Keeper. Stays panic-safe per the S11.6
+    /// DoD: the screen builder must not panic on an unbuilt
+    /// encounter.
     pub fn empty(biome_label: impl Into<String>) -> Self {
         Self {
             biome_label: biome_label.into(),
             creatures: Vec::new(),
             selected: None,
+            formation: FormationView::empty(),
+            keeper: KeeperView::empty(),
         }
     }
 
@@ -210,6 +329,8 @@ mod tests {
                 hp_pct: 1.0,
             }],
             selected: Some(99),
+            formation: FormationView::empty(),
+            keeper: KeeperView::empty(),
         };
         // Out-of-range index returns None rather than panicking.
         assert!(snap.selected_creature().is_none());
@@ -232,7 +353,20 @@ mod tests {
                 },
             ],
             selected: Some(1),
+            formation: FormationView::empty(),
+            keeper: KeeperView::empty(),
         };
         assert_eq!(snap.selected_creature().map(|c| c.id), Some(2));
+    }
+
+    #[test]
+    fn empty_snapshot_has_five_canonical_slots() {
+        // S11.6 DoD: empty constructor stays panic-safe and seeds the
+        // five canonical slots from `beast_ecs::components::SLOT_NAMES`.
+        let snap = EncounterSnapshot::empty("forest");
+        assert_eq!(snap.formation.slots.len(), 5);
+        assert_eq!(snap.formation.slots[0].slot_label, "vanguard");
+        assert_eq!(snap.formation.slots[4].slot_label, "rear");
+        assert_eq!(snap.keeper, KeeperView::empty());
     }
 }

--- a/crates/beast-ui/src/screens/encounter.rs
+++ b/crates/beast-ui/src/screens/encounter.rs
@@ -127,9 +127,12 @@ fn build_formation_slot_card(
             // (chronicler returns labels in PatternSignature order;
             // re-sort by id here to lock in deterministic UI output
             // independent of any future signature-iteration tweak).
-            let mut ids: Vec<&str> = labels.iter().map(|l| l.id.as_str()).collect();
-            ids.sort_unstable();
-            format!("labels: {}", ids.join(", "))
+            // Named `label_strs` (not `ids`) to avoid shadowing the
+            // outer `IdAllocator` parameter — same allocator is still
+            // used at the `ids.allocate()` call below.
+            let mut label_strs: Vec<&str> = labels.iter().map(|l| l.id.as_str()).collect();
+            label_strs.sort_unstable();
+            format!("labels: {}", label_strs.join(", "))
         };
         format!(
             "{}\nhp {:>3}% · stm {:>3}%\neng {:>3}% · exp {:>3}%\n{}",

--- a/crates/beast-ui/src/screens/encounter.rs
+++ b/crates/beast-ui/src/screens/encounter.rs
@@ -1,9 +1,16 @@
-//! Encounter screen (S10.4).
+//! Encounter screen — combat readout (S10.4 + S11.6).
 //!
 //! Composition (top → bottom):
 //!
-//! 1. Status bar: biome label + active-creature name.
-//! 2. Content row:
+//! 1. Status bar (in the screen frame): biome label + active-creature
+//!    name + leadership-budget bar.
+//! 2. Formation row: five slot cards (vanguard, flank-left,
+//!    flank-right, center, rear) showing per-occupant HP / stamina
+//!    plus a label list pulled from
+//!    [`ChroniclerQuery::labels_for_entity`] — the only surface
+//!    where named-ability strings ("echolocation", "pack_hunting")
+//!    appear (INVARIANTS §2).
+//! 3. Content row:
 //!    - Left column: a [`crate::RenderViewport`] reserved for the
 //!      `beast-render::encounter` 2.5D scene plus a creature `List`.
 //!    - Right column: a horizontal action button bar (Attack /
@@ -12,20 +19,28 @@
 //!      later sprint.
 //!
 //! Per `documentation/INVARIANTS.md` §6 the screen reads from the
-//! [`EncounterSnapshot`] only — no widget in the tree mutates the
-//! snapshot or reaches into sim state.
+//! [`EncounterSnapshot`] and the `ChroniclerQuery` only — no widget
+//! in the tree mutates the snapshot or reaches into sim state.
+
+use beast_chronicler::ChroniclerQuery;
+use beast_core::EntityId;
 
 use crate::layout::{Align, Axis};
 use crate::paint::Color;
-use crate::screens::data::EncounterSnapshot;
+use crate::screens::data::{EncounterSnapshot, FormationSlotView};
 use crate::screens::frame::screen_frame;
 use crate::widget::{Button, Card, IdAllocator, Label, List, ListItem, RenderViewport, Stack};
 use crate::{Size, WidgetTree};
 
 /// Build the encounter screen for a 1280×720 viewport.
-pub fn encounter(snapshot: &EncounterSnapshot) -> WidgetTree {
+///
+/// Takes both a chronicler query (for ability label lookup) and a
+/// read-only `EncounterSnapshot`. Per the S11.6 DoD: never `&mut`,
+/// never reaches into sim state.
+pub fn encounter(query: &dyn ChroniclerQuery, snapshot: &EncounterSnapshot) -> WidgetTree {
     let mut ids = IdAllocator::new();
 
+    let formation_row = build_formation_row(&mut ids, query, snapshot);
     let left = build_left_column(&mut ids, snapshot);
     let right = build_right_column(&mut ids, snapshot);
 
@@ -35,15 +50,105 @@ pub fn encounter(snapshot: &EncounterSnapshot) -> WidgetTree {
     content.push_child(Box::new(left));
     content.push_child(Box::new(right));
 
+    // Outer column: formation row above the content row.
+    let mut outer = Stack::new(ids.allocate(), Axis::Vertical)
+        .with_gap(8.0)
+        .with_align(Align::Start);
+    outer.push_child(Box::new(formation_row));
+    outer.push_child(Box::new(content));
+
     let biome = snapshot.biome_label.clone();
     let active_for_status = active_creature_name(snapshot, "(none)");
+    let leadership_pct = snapshot.keeper.leadership_pct.clamp(0.0, 1.0);
+    let stress_pct = snapshot.keeper.stress_pct.clamp(0.0, 1.0);
+    let keeper_name = snapshot.keeper.name.clone();
     let frame = screen_frame(
         &mut ids,
-        move || format!("encounter | biome: {biome} | active: {active_for_status}"),
-        Box::new(content),
+        move || {
+            // Leadership / stress live in the status string until the
+            // frame gains a dedicated horizontal bar widget. Format is
+            // pinned by `encounter_screen_paints_leadership_in_status`.
+            let keeper_label = if keeper_name.is_empty() {
+                "(none)".to_string()
+            } else {
+                keeper_name.clone()
+            };
+            format!(
+                "encounter | biome: {biome} | active: {active_for_status} | \
+                 keeper: {keeper_label} | leadership: {:>3}% | stress: {:>3}%",
+                (leadership_pct * 100.0).round() as i32,
+                (stress_pct * 100.0).round() as i32,
+            )
+        },
+        Box::new(outer),
     );
 
     WidgetTree::new(Box::new(frame), Size::new(1280.0, 720.0))
+}
+
+/// Five formation slot cards, one per `SLOT_COUNT` position.
+///
+/// Per slot:
+/// - title from `slot_label` ("vanguard" etc.)
+/// - occupant name + HP / stamina percentages
+/// - engagement / exposure percentages
+/// - chronicler-resolved ability labels (the only labelled-ability
+///   surface — INVARIANTS §2 keeps `primitive_id` strings off the UI
+///   path; we read `Label::id` from the chronicler instead)
+fn build_formation_row(
+    ids: &mut IdAllocator,
+    query: &dyn ChroniclerQuery,
+    snapshot: &EncounterSnapshot,
+) -> Stack {
+    let mut row = Stack::new(ids.allocate(), Axis::Horizontal)
+        .with_gap(6.0)
+        .with_align(Align::Start);
+    for slot in &snapshot.formation.slots {
+        row.push_child(Box::new(build_formation_slot_card(ids, query, slot)));
+    }
+    row
+}
+
+fn build_formation_slot_card(
+    ids: &mut IdAllocator,
+    query: &dyn ChroniclerQuery,
+    slot: &FormationSlotView,
+) -> Card {
+    let mut card = Card::new(ids.allocate(), slot.slot_label.clone());
+    let occupant_label = if let Some(occ) = slot.occupant {
+        // Render occupant id in the body text alongside the name —
+        // useful for debugging without forcing the test fixture to
+        // generate display names.
+        let labels = query.labels_for_entity(EntityId::new(occ));
+        let label_text = if labels.is_empty() {
+            "labels: (none)".to_string()
+        } else {
+            // Sort by label id so the rendered string is order-stable
+            // (chronicler returns labels in PatternSignature order;
+            // re-sort by id here to lock in deterministic UI output
+            // independent of any future signature-iteration tweak).
+            let mut ids: Vec<&str> = labels.iter().map(|l| l.id.as_str()).collect();
+            ids.sort_unstable();
+            format!("labels: {}", ids.join(", "))
+        };
+        format!(
+            "{}\nhp {:>3}% · stm {:>3}%\neng {:>3}% · exp {:>3}%\n{}",
+            if slot.occupant_name.is_empty() {
+                format!("(id {occ})")
+            } else {
+                slot.occupant_name.clone()
+            },
+            (slot.hp_pct.clamp(0.0, 1.0) * 100.0).round() as i32,
+            (slot.stamina_pct.clamp(0.0, 1.0) * 100.0).round() as i32,
+            (slot.engagement_pct.clamp(0.0, 1.0) * 100.0).round() as i32,
+            (slot.exposure_pct.clamp(0.0, 1.0) * 100.0).round() as i32,
+            label_text,
+        )
+    } else {
+        "(empty)".to_string()
+    };
+    card.push_child(Box::new(Label::new(ids.allocate(), occupant_label)));
+    card
 }
 
 /// Render-viewport + creature list, packed vertically.
@@ -125,9 +230,38 @@ fn active_creature_name(snapshot: &EncounterSnapshot, fallback: &str) -> String 
 mod tests {
     use super::*;
     use crate::dump_layout;
-    use crate::screens::data::{EncounterCreatureSnapshot, EncounterSnapshot};
+    use crate::screens::data::{
+        EncounterCreatureSnapshot, EncounterSnapshot, FormationSlotView, FormationView, KeeperView,
+    };
+    use beast_chronicler::query::InMemoryChronicler;
+    use beast_chronicler::{Label, PatternSignature};
+    use beast_core::{EntityId, Q3232};
+
+    fn empty_chronicler() -> InMemoryChronicler {
+        InMemoryChronicler::new()
+    }
 
     fn populated_snapshot() -> EncounterSnapshot {
+        let mut formation = FormationView::empty();
+        // Put alpha in vanguard, beta in rear.
+        formation.slots[0] = FormationSlotView {
+            occupant: Some(1),
+            occupant_name: "alpha".into(),
+            slot_label: "vanguard".into(),
+            hp_pct: 1.0,
+            stamina_pct: 0.8,
+            engagement_pct: 0.9,
+            exposure_pct: 0.6,
+        };
+        formation.slots[4] = FormationSlotView {
+            occupant: Some(2),
+            occupant_name: "beta".into(),
+            slot_label: "rear".into(),
+            hp_pct: 0.5,
+            stamina_pct: 0.6,
+            engagement_pct: 0.1,
+            exposure_pct: 0.3,
+        };
         EncounterSnapshot {
             biome_label: "forest".into(),
             creatures: vec![
@@ -143,25 +277,40 @@ mod tests {
                 },
             ],
             selected: Some(0),
+            formation,
+            keeper: KeeperView {
+                name: "Captain".into(),
+                leadership_pct: 0.75,
+                stress_pct: 0.20,
+            },
         }
     }
 
     #[test]
     fn encounter_screen_compiles_and_lays_out() {
+        let chron = empty_chronicler();
         let snapshot = populated_snapshot();
-        let mut tree = encounter(&snapshot);
+        let mut tree = encounter(&chron, &snapshot);
         assert!(tree.layout(), "first layout should be a cache miss");
         let dump = dump_layout(&tree);
         assert!(dump.contains("RenderViewport#"), "dump:\n{dump}");
         assert!(dump.contains("List#"), "dump:\n{dump}");
         let buttons = dump.lines().filter(|l| l.starts_with("Button#")).count();
         assert_eq!(buttons, 3, "expected 3 action buttons, dump:\n{dump}");
+        // Status-bar Card (from screen_frame) + 5 formation slot cards
+        // + the "encounter" info card = 7 total.
+        let cards = dump.lines().filter(|l| l.starts_with("Card#")).count();
+        assert_eq!(
+            cards, 7,
+            "expected 7 cards (1 status + 5 slot + 1 info), dump:\n{dump}",
+        );
     }
 
     #[test]
     fn empty_snapshot_renders_no_selection() {
+        let chron = empty_chronicler();
         let snapshot = EncounterSnapshot::empty("ocean");
-        let mut tree = encounter(&snapshot);
+        let mut tree = encounter(&chron, &snapshot);
         assert!(tree.layout());
         let mut ctx = crate::paint::PaintCtx::new();
         tree.paint(&mut ctx);
@@ -170,5 +319,88 @@ mod tests {
             _ => false,
         });
         assert!(has_no_selection);
+    }
+
+    #[test]
+    fn empty_snapshot_renders_five_empty_slot_cards() {
+        // EncounterSnapshot::empty must produce a panic-safe screen
+        // with the canonical five formation slots present (per the
+        // S11.6 DoD: empty constructor stays panic-safe).
+        let chron = empty_chronicler();
+        let snapshot = EncounterSnapshot::empty("ocean");
+        let mut tree = encounter(&chron, &snapshot);
+        assert!(tree.layout());
+        let dump = dump_layout(&tree);
+        let cards = dump.lines().filter(|l| l.starts_with("Card#")).count();
+        // 1 status bar + 5 slot cards + 1 info card = 7.
+        assert_eq!(cards, 7, "dump:\n{dump}");
+    }
+
+    #[test]
+    fn encounter_screen_paints_leadership_in_status() {
+        // Pin the screen-frame status format so a refactor that drops
+        // the leadership bar fails loudly.
+        let chron = empty_chronicler();
+        let snapshot = populated_snapshot();
+        let mut tree = encounter(&chron, &snapshot);
+        assert!(tree.layout());
+        let mut ctx = crate::paint::PaintCtx::new();
+        tree.paint(&mut ctx);
+        let has_leadership = ctx.commands().iter().any(|cmd| match cmd {
+            crate::paint::DrawCmd::Text { text, .. } => {
+                text.contains("leadership: ") && text.contains("stress: ")
+            }
+            _ => false,
+        });
+        assert!(has_leadership, "leadership/stress missing from status");
+    }
+
+    #[test]
+    fn formation_slot_renders_chronicler_labels() {
+        // Set up an in-memory chronicler with one assigned label for
+        // entity id 1 (alpha in vanguard). The slot card must surface
+        // the label id in its rendered text — this is the chronicler
+        // → UI hand-off the issue specifies.
+        let mut chron = InMemoryChronicler::new();
+        let sig = PatternSignature([7u8; 32]);
+        chron.labels.insert(
+            sig,
+            Label {
+                id: "echolocation".into(),
+                signature: sig,
+                confidence: Q3232::ONE,
+            },
+        );
+        let mut entity_sigs = std::collections::BTreeSet::new();
+        entity_sigs.insert(sig);
+        chron
+            .entity_signatures
+            .insert(EntityId::new(1), entity_sigs);
+
+        let snapshot = populated_snapshot();
+        let mut tree = encounter(&chron, &snapshot);
+        assert!(tree.layout());
+        let mut ctx = crate::paint::PaintCtx::new();
+        tree.paint(&mut ctx);
+        let has_label = ctx.commands().iter().any(|cmd| match cmd {
+            crate::paint::DrawCmd::Text { text, .. } => text.contains("labels: echolocation"),
+            _ => false,
+        });
+        assert!(has_label, "echolocation label missing from slot card");
+    }
+
+    #[test]
+    fn formation_slot_renders_no_labels_marker_when_chronicler_empty() {
+        let chron = empty_chronicler();
+        let snapshot = populated_snapshot();
+        let mut tree = encounter(&chron, &snapshot);
+        assert!(tree.layout());
+        let mut ctx = crate::paint::PaintCtx::new();
+        tree.paint(&mut ctx);
+        let has_none = ctx.commands().iter().any(|cmd| match cmd {
+            crate::paint::DrawCmd::Text { text, .. } => text.contains("labels: (none)"),
+            _ => false,
+        });
+        assert!(has_none, "(none) label marker missing from slot card");
     }
 }

--- a/crates/beast-ui/tests/screen_bindings.rs
+++ b/crates/beast-ui/tests/screen_bindings.rs
@@ -292,13 +292,13 @@ fn screens_accept_only_read_only_references() {
     fn takes_dyn_chronicler_query(q: &dyn ChroniclerQuery) -> WidgetTree {
         bestiary(q)
     }
-    fn takes_encounter_ref(s: &EncounterSnapshot) -> WidgetTree {
-        encounter(s)
+    fn takes_encounter_refs(q: &dyn ChroniclerQuery, s: &EncounterSnapshot) -> WidgetTree {
+        encounter(q, s)
     }
 
     let _ = takes_dyn_world_status(&world, &biomes);
     let _ = takes_dyn_chronicler_query(&chronicler);
-    let _ = takes_encounter_ref(&snapshot);
+    let _ = takes_encounter_refs(&chronicler, &snapshot);
 }
 
 #[test]
@@ -326,5 +326,5 @@ fn all_screens_have_1280x720_viewport() {
     assert_eq!(world_map(&world, &biomes).root_size(), target);
     assert_eq!(bestiary(&chronicler).root_size(), target);
     assert_eq!(settings().root_size(), target);
-    assert_eq!(encounter(&snapshot).root_size(), target);
+    assert_eq!(encounter(&chronicler, &snapshot).root_size(), target);
 }

--- a/crates/beast-ui/tests/screen_snapshots.rs
+++ b/crates/beast-ui/tests/screen_snapshots.rs
@@ -24,7 +24,7 @@ use beast_chronicler::{
 };
 use beast_core::{TickCounter, Q3232};
 use beast_ui::screens::data::{
-    BiomeView, EncounterCreatureSnapshot, EncounterSnapshot, WorldStatus,
+    BiomeView, EncounterCreatureSnapshot, EncounterSnapshot, FormationView, KeeperView, WorldStatus,
 };
 use beast_ui::{bestiary, dump_layout, encounter, settings, world_map};
 
@@ -217,8 +217,11 @@ fn encounter_snapshot_matches_fixture() {
             },
         ],
         selected: Some(0),
+        formation: FormationView::empty(),
+        keeper: KeeperView::empty(),
     };
-    let mut tree = encounter(&snapshot);
+    let chronicler = InMemoryChronicler::new();
+    let mut tree = encounter(&chronicler, &snapshot);
     assert!(tree.layout());
     let dump = dump_layout(&tree);
     assert_kind_sequence(
@@ -227,6 +230,18 @@ fn encounter_snapshot_matches_fixture() {
             "Stack", // root frame
             "Card",  // status bar
             "Label", // status binding label
+            "Stack", // outer column (formation row above content row)
+            "Stack", // formation row
+            "Card",  // slot 0 (vanguard)
+            "Label",
+            "Card", // slot 1 (flank-left)
+            "Label",
+            "Card", // slot 2 (flank-right)
+            "Label",
+            "Card", // slot 3 (center)
+            "Label",
+            "Card", // slot 4 (rear)
+            "Label",
             "Stack", // content row
             "Stack", // left column
             "RenderViewport",


### PR DESCRIPTION
Closes #256. Stacks on S11.1–S11.5 (all merged) + S10.4 (already on master).

## Summary

Wire the encounter screen built in S10.4 to the live combat state from S11.1–S11.5. The readout shows formation slots, per-occupant HP/stamina, displayed ability *labels* (resolved through `ChroniclerQuery::labels_for_entity` — never primitive ids), and the Keeper's leadership budget. Per INVARIANTS §2 the UI is the *only* surface where named abilities appear; the sim path stays primitive-only.

## API changes

- `encounter()` signature changed:
  - Before: `pub fn encounter(snapshot: &EncounterSnapshot) -> WidgetTree`
  - After:  `pub fn encounter(query: &dyn ChroniclerQuery, snapshot: &EncounterSnapshot) -> WidgetTree`
- `EncounterSnapshot` extended with `formation: FormationView` and `keeper: KeeperView`. New types in `screens/data.rs`:
  - `FormationSlotView { occupant, occupant_name, slot_label, hp_pct, stamina_pct, engagement_pct, exposure_pct }`
  - `FormationView { slots: Vec<FormationSlotView> }`  (always 5 entries)
  - `KeeperView { name, leadership_pct, stress_pct }`
- All view types are render-only DTOs — `Serialize`/`Deserialize` intentionally NOT derived to keep them out of bincode save paths (matches the existing `EncounterCreatureSnapshot` discipline).
- `EncounterSnapshot::empty(...)` seeds the five canonical slots from `beast_ecs::components::SLOT_NAMES` and an empty Keeper — stays panic-safe per the DoD.

## Layout

Composition (top → bottom):
1. Status bar in the screen frame: biome + active creature + `keeper: NAME | leadership: NN% | stress: NN%`.
2. **Formation row** (new): 5 cards (vanguard, flank-left, flank-right, center, rear), each rendering occupant + HP/stamina/engagement/exposure + chronicler ability labels.
3. Existing content row (RenderViewport + creature list on left; action buttons + info card on right).

## INVARIANTS compliance

- **§1** — UI floats allowed for layout; sim values flow through Q3232 and are normalised to f32 at the encounter-loop boundary (S13's job).
- **§2** — `crates/beast-sim/` still has no named-ability strings (the existing audit on `beast-chronicler` is untouched). Ability vocabulary ("echolocation", "pack_hunting") only appears in chronicler manifests + the `Label.id` surfaced via `labels_for_entity`. The slot card sorts label ids at the UI layer (independent of chronicler's signature-iteration order) so paint output is deterministic.
- **§6** — UI is read-only; the builder takes `&dyn ChroniclerQuery` + `&EncounterSnapshot`, never `&mut`. Locked in by `screen_bindings.rs::takes_encounter_refs`.

## DoD

- [x] `EncounterSnapshot` extended with `formation` and `keeper` fields; `EncounterSnapshot::empty(...)` stays panic-safe.
- [x] No `unsafe`, no `f32`/`f64` for sim values (UI floats for layout are fine — INVARIANTS §1 carves them out).
- [x] No named-ability strings inside `crates/beast-sim/src/` — confirmed by inspection; existing `no_hardcoded_label_strings.rs` audit on chronicler is unchanged.
- [x] Screen builder takes only `&dyn ChroniclerQuery` and `&EncounterSnapshot` — never `&mut`.
- [x] Snapshot test pins deterministic paint commands (`screen_snapshots.rs::encounter_snapshot_matches_fixture` extended with the new formation row's kind sequence).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test plan (5 new encounter-screen unit tests + existing all green)

- [x] `encounter_screen_compiles_and_lays_out` — 7 cards (status + 5 slot + info), 3 buttons.
- [x] `empty_snapshot_renders_no_selection` — pre-existing.
- [x] `empty_snapshot_renders_five_empty_slot_cards` — panic-safe empty case.
- [x] `encounter_screen_paints_leadership_in_status` — frame format pin.
- [x] `formation_slot_renders_chronicler_labels` — chronicler → UI hand-off.
- [x] `formation_slot_renders_no_labels_marker_when_chronicler_empty` — `(none)` fallback.
- [x] `data.rs::empty_snapshot_has_five_canonical_slots` — DTO seeded correctly.

Local gate runs:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets --locked`
- [x] `cargo test --workspace --doc --locked`
- [x] `cargo deny check`

## Out of scope (future stories)

- Live SDL rendering of these surfaces — beast-render plays the paint commands; this story is `PaintCtx` only.
- Player input → action dispatch → sim mutation (round triggering) — S13's job.
- Animated transitions (damage flash, death animation) — UI polish sprint.
- Dedicated horizontal-bar widget for the leadership/stress readout — kept in the status string for now; future widget refactor.